### PR TITLE
build(ci): Make docker image great again

### DIFF
--- a/examples/beacond/Dockerfile
+++ b/examples/beacond/Dockerfile
@@ -93,8 +93,8 @@ FROM ${RUNNER_IMAGE}
 ARG APP_NAME
 
 # Copy over built executable into a fresh container.
-COPY --from=builder /workdir/build/bin/${APP_NAME} /
+COPY --from=builder /workdir/build/bin/${APP_NAME} /usr/bin
 
 RUN apk add bash jq sed curl
 
-ENTRYPOINT [ "./beacond" ]
+#ENTRYPOINT [ "./beacond" ]


### PR DESCRIPTION
Remove entrypoint as we eill add the start command line within our helm chart and also use this as an init container for other purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - Updated Dockerfile to copy the built executable to a different directory within the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->