### PR TITLE
[queue/chore] use const for default concurr queue worker count

### DIFF
--- a/async/dispatch/gcd.go
+++ b/async/dispatch/gcd.go
@@ -39,6 +39,9 @@ const (
 
 	// DefaultQueueSize is the default size of a queue.
 	DefaultQueueSize = 64 // todo: make this configurable.
+
+	// DefaultConcurrentQueueWorkerCount is the default size of a concurrent queue.
+	DefaultConcurrentQueueWorkerCount = 64 // todo: make this configurable.
 )
 
 // QueueType represents the type of a queue.
@@ -107,7 +110,7 @@ func (gcd *GrandCentralDispatch) CreateQueue(id string, queueType QueueType) Que
 		queue = dqueue.NewDispatchQueue(1, DefaultQueueSize)
 	case QueueTypeConcur:
 		//nolint:gomnd // todo: make this configurable.
-		queue = dqueue.NewDispatchQueue(64, DefaultQueueSize)
+		queue = dqueue.NewDispatchQueue(DefaultConcurrentQueueWorkerCount, DefaultQueueSize)
 	default:
 		panic("unknown queue type")
 	}


### PR DESCRIPTION
Uses const in place of magic number for the concurrent queue worker count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new constant for improved concurrent queue worker count initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->