### PR TITLE
[queue/hardening] make sure sizes are non neg

### DIFF
--- a/async/dispatch/gcd.go
+++ b/async/dispatch/gcd.go
@@ -38,10 +38,10 @@ const (
 	GlobalQueueID = "global"
 
 	// DefaultQueueSize is the default size of a queue.
-	DefaultQueueSize = uint64(64) // todo: make this configurable.
+	DefaultQueueSize = uint16(64) // todo: make this configurable.
 
 	// DefaultConcurrentQueueWorkerCount is the default size of a concurrent queue.
-	DefaultConcurrentQueueWorkerCount = uint64(64) // todo: make this configurable.
+	DefaultConcurrentQueueWorkerCount = uint16(64) // todo: make this configurable.
 )
 
 // QueueType represents the type of a queue.

--- a/async/dispatch/queue/queue.go
+++ b/async/dispatch/queue/queue.go
@@ -41,15 +41,15 @@ type DispatchQueue struct {
 
 // NewDispatchQueue creates a new Queue and starts its worker goroutines.
 func NewDispatchQueue(
-	workerCount uint64,
-	maxQueueSize uint64,
+	workerCount uint16,
+	maxQueueSize uint16,
 ) *DispatchQueue {
 	q := &DispatchQueue{
 		queue:    make(chan WorkItem, maxQueueSize),
 		stopChan: make(chan struct{}),
 	}
 
-	for i := uint64(0); i < workerCount; i++ {
+	for i := uint16(0); i < workerCount; i++ {
 		go func() {
 			for {
 				select {


### PR DESCRIPTION
Ensure one cannot accidentally pass non neg sizes to queue init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated data types to `uint16` for better configurability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->