### PR TITLE
[randao] add configs for number of randao to track

### DIFF
--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -49,10 +49,11 @@ const (
 	DenebForkEpoch = forkRoot + "deneb-fork-epoch"
 
 	// Validator Config.
-	validator             = beaconKitRoot + "validator"
-	SuggestedFeeRecipient = validator + "suggested-fee-recipient"
-	Graffiti              = validator + "graffiti"
-	PrepareAllPayloads    = validator + "prepare-all-payloads"
+	validator               = beaconKitRoot + "validator"
+	SuggestedFeeRecipient   = validator + "suggested-fee-recipient"
+	Graffiti                = validator + "graffiti"
+	PrepareAllPayloads      = validator + "prepare-all-payloads"
+	NumRandaoRevealsToTrack = validator + "num-randao-reveals-to-track"
 
 	// Limits Config.
 	limitsRoot     = beaconConfigRoot + "limits."

--- a/config/validator.go
+++ b/config/validator.go
@@ -54,6 +54,9 @@ type Validator struct {
 
 	// PrepareAllPayloads informs the engine to prepare a block on every slot.
 	PrepareAllPayloads bool
+
+	// Rando reveals to track
+	NumRandaoRevealsToTrack uint64
 }
 
 // Parse parses the configuration.
@@ -70,6 +73,12 @@ func (c Validator) Parse(parser parser.AppOptionsParser) (*Validator, error) {
 
 	if c.PrepareAllPayloads, err = parser.GetBool(
 		flags.PrepareAllPayloads,
+	); err != nil {
+		return nil, err
+	}
+
+	if c.NumRandaoRevealsToTrack, err = parser.GetUint64(
+		flags.NumRandaoRevealsToTrack,
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is needed for tracking historical randao reveals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new constant and field for tracking Randao reveals in the Validator configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->