### PR TITLE
feat(builder): Move ValidatorService to BuilderService

### DIFF
--- a/beacon/execution/notify.go
+++ b/beacon/execution/notify.go
@@ -85,6 +85,8 @@ func (s *Service) notifyForkchoiceUpdate(
 ) (*enginev1.PayloadIDBytes, error) {
 	beaconState := s.BeaconState(ctx)
 
+	// TODO: intercept here and ask builder service for payload attributes.
+	// if isValidator && PrepareAllPayloads {
 	// Ensure we don't pass a nil attribute to the execution engine.
 	if fcuConfig.Attributes == nil {
 		fcuConfig.Attributes = engine.EmptyPayloadAttributesWithVersion(beaconState.Version())

--- a/execution/builder/doc.go
+++ b/execution/builder/doc.go
@@ -25,4 +25,4 @@
 
 // validator contains the core block proposal logic for the beacon chain. It's goal
 // is to decouple running a validator from processing beacon block.
-package validator
+package builder

--- a/execution/builder/metrics.go
+++ b/execution/builder/metrics.go
@@ -23,7 +23,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-package validator
+package builder
 
 const (
 	// MetricGetBuiltPayloadHit is used to count the number of times a built

--- a/execution/builder/options.go
+++ b/execution/builder/options.go
@@ -23,7 +23,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-package validator
+package builder
 
 import (
 	"github.com/itsdevbear/bolaris/cache"

--- a/execution/builder/propose.go
+++ b/execution/builder/propose.go
@@ -23,7 +23,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-package validator
+package builder
 
 import (
 	"context"
@@ -48,12 +48,12 @@ func (s *Service) BuildBeaconBlock(
 		slot          = beaconState.Slot()
 	)
 
-	// // TODO: SIGN UR RANDAO THINGY HERE OR SOMETHING.
-	_ = s.beaconKitValKey
-	// _, err := s.beaconKitValKey.Key.PrivKey.Sign([]byte("hello world"))
-	// if err != nil {
-	// 	return nil, err
-	// }
+	// // // TODO: SIGN UR RANDAO THINGY HERE OR SOMETHING.
+	// _ = s.beaconKitValKey
+	// // _, err := s.beaconKitValKey.Key.PrivKey.Sign([]byte("hello world"))
+	// // if err != nil {
+	// // 	return nil, err
+	// // }
 
 	// Create a new empty block from the current state.
 	beaconBlock, err := consensus.EmptyBeaconKitBlock(
@@ -63,10 +63,15 @@ func (s *Service) BuildBeaconBlock(
 		return nil, err
 	}
 
-	executionData, overrideBuilder, err := s.getLocalPayload(ctx, beaconBlock, beaconState)
+	executionData, blobsBundle, overrideBuilder, err := s.getLocalPayload(
+		ctx, beaconBlock, beaconState,
+	)
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO: Dencun
+	_ = blobsBundle
 
 	// TODO: allow external block builders to override the payload.
 	_ = overrideBuilder

--- a/execution/builder/service.go
+++ b/execution/builder/service.go
@@ -23,7 +23,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-package validator
+package builder
 
 import (
 	"context"
@@ -31,7 +31,6 @@ import (
 	"github.com/itsdevbear/bolaris/cache"
 	"github.com/itsdevbear/bolaris/execution/engine"
 	"github.com/itsdevbear/bolaris/runtime/service"
-	"github.com/itsdevbear/bolaris/validator/key"
 )
 
 type BlockBuilder interface {
@@ -41,9 +40,8 @@ type BlockBuilder interface {
 // have it configured itself and not be a service persay.
 type Service struct {
 	service.BaseService
-	beaconKitValKey key.BeaconKitValKey
-	en              engine.Caller
-	payloadCache    *cache.PayloadIDCache
+	en           engine.Caller
+	payloadCache *cache.PayloadIDCache
 }
 
 func NewService(

--- a/runtime/abci.go
+++ b/runtime/abci.go
@@ -31,9 +31,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/mempool"
 	"github.com/itsdevbear/bolaris/beacon/blockchain"
 	"github.com/itsdevbear/bolaris/beacon/sync"
+	"github.com/itsdevbear/bolaris/execution/builder"
 	"github.com/itsdevbear/bolaris/runtime/abci/preblock"
 	"github.com/itsdevbear/bolaris/runtime/abci/proposal"
-	"github.com/itsdevbear/bolaris/validator"
 )
 
 // CosmosApp is an interface that defines the methods needed for the Cosmos setup.
@@ -49,9 +49,9 @@ type CosmosApp interface {
 
 func (r *BeaconKitRuntime) RegisterApp(app CosmosApp) error {
 	var (
-		chainService     *blockchain.Service
-		validatorService *validator.Service
-		syncService      *sync.Service
+		chainService   *blockchain.Service
+		builderService *builder.Service
+		syncService    *sync.Service
 	)
 	if err := r.services.FetchService(&chainService); err != nil {
 		return err
@@ -61,7 +61,7 @@ func (r *BeaconKitRuntime) RegisterApp(app CosmosApp) error {
 		panic(err)
 	}
 
-	if err := r.services.FetchService(&validatorService); err != nil {
+	if err := r.services.FetchService(&builderService); err != nil {
 		panic(err)
 	}
 
@@ -69,7 +69,7 @@ func (r *BeaconKitRuntime) RegisterApp(app CosmosApp) error {
 	defaultProposalHandler := baseapp.NewDefaultProposalHandler(app.Mempool(), app)
 	proposalHandler := proposal.NewHandler(
 		&r.cfg.ABCI,
-		validatorService,
+		builderService,
 		syncService,
 		chainService,
 		defaultProposalHandler.PrepareProposalHandler(),

--- a/runtime/abci/proposal/proposal.go
+++ b/runtime/abci/proposal/proposal.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/itsdevbear/bolaris/execution/builder"
 	"github.com/itsdevbear/bolaris/types/consensus/primitives"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -39,14 +40,13 @@ import (
 	sync "github.com/itsdevbear/bolaris/beacon/sync"
 	"github.com/itsdevbear/bolaris/config"
 	abcitypes "github.com/itsdevbear/bolaris/runtime/abci/types"
-	"github.com/itsdevbear/bolaris/validator"
 )
 
 // Handler is a struct that encapsulates the necessary components to handle
 // the proposal processes.
 type Handler struct {
 	cfg             *config.ABCI
-	validator       *validator.Service
+	builderService  *builder.Service
 	beaconChain     *blockchain.Service
 	syncService     *sync.Service
 	prepareProposal sdk.PrepareProposalHandler
@@ -56,7 +56,7 @@ type Handler struct {
 // NewHandler creates a new instance of the Handler struct.
 func NewHandler(
 	cfg *config.ABCI,
-	validator *validator.Service,
+	builderService *builder.Service,
 	syncService *sync.Service,
 	beaconChain *blockchain.Service,
 	prepareProposal sdk.PrepareProposalHandler,
@@ -64,7 +64,7 @@ func NewHandler(
 ) *Handler {
 	return &Handler{
 		cfg:             cfg,
-		validator:       validator,
+		builderService:  builderService,
 		syncService:     syncService,
 		beaconChain:     beaconChain,
 		prepareProposal: prepareProposal,
@@ -88,7 +88,7 @@ func (h *Handler) PrepareProposalHandler(
 	// We start by requesting the validator service to build us a block. This may
 	// be from pulling a previously built payload from the local cache or it may be
 	// by asking for a forkchoice from the execution client, depending on timing.
-	block, err := h.validator.BuildBeaconBlock(
+	block, err := h.builderService.BuildBeaconBlock(
 		ctx, primitives.Slot(req.Height),
 	)
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -38,11 +38,11 @@ import (
 	"github.com/itsdevbear/bolaris/beacon/sync"
 	"github.com/itsdevbear/bolaris/cache"
 	"github.com/itsdevbear/bolaris/config"
+	"github.com/itsdevbear/bolaris/execution/builder"
 	"github.com/itsdevbear/bolaris/execution/engine"
 	eth "github.com/itsdevbear/bolaris/execution/engine/ethclient"
 	"github.com/itsdevbear/bolaris/io/jwt"
 	"github.com/itsdevbear/bolaris/runtime/service"
-	"github.com/itsdevbear/bolaris/validator"
 )
 
 // BeaconKitRuntime is a struct that holds the
@@ -153,10 +153,10 @@ func NewDefaultBeaconKitRuntime(
 	)
 
 	// Build the validator service.
-	validatorService := validator.NewService(
+	builderService := builder.NewService(
 		baseService.WithName("validator"),
-		validator.WithEngineCaller(engineClient),
-		validator.WithPayloadCache(payloadCache),
+		builder.WithEngineCaller(engineClient),
+		builder.WithPayloadCache(payloadCache),
 	)
 
 	// Create the service registry.
@@ -166,7 +166,7 @@ func NewDefaultBeaconKitRuntime(
 		service.WithService(executionService),
 		service.WithService(chainService),
 		service.WithService(notificationService),
-		service.WithService(validatorService),
+		service.WithService(builderService),
 	)
 
 	// Pass all the services and options into the BeaconKitRuntime.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed package from `validator` to `builder` in multiple files to align with core block proposal logic for the beacon chain.
	- Updated package declarations, import statements, and references to reflect the package name change.
	- Modified functions and methods to utilize `builder` package instead of `validator` package for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->