### PR TITLE
chore(config): Add Electra fork epoch

### DIFF
--- a/config/beacon.go
+++ b/config/beacon.go
@@ -58,11 +58,10 @@ func DefaultBeaconConfig() Beacon {
 }
 
 // ActiveForkVersion returns the active fork version for a given slot.
-func (c Beacon) ActiveForkVersion(_ primitives.Epoch) int {
-	// Eventually we will need to add more forks here.
-	// if epoch >= c.Forks.ElectraForkEpoch {
-	// 	return version.Electra
-	// }
+func (c Beacon) ActiveForkVersion(epoch primitives.Epoch) int {
+	if epoch >= c.Forks.ElectraForkEpoch {
+		return version.Electra
+	}
 
 	// In BeaconKit we assume the Deneb fork is always active.
 	return version.Deneb

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -50,8 +50,8 @@ const (
 	LocalBuildPayloadTimeout = builderRoot + "local-build-payload-timeout"
 
 	// Fork Config.
-	forkRoot       = beaconConfigRoot + "forks."
-	DenebForkEpoch = forkRoot + "deneb-fork-epoch"
+	forkRoot         = beaconConfigRoot + "forks."
+	ElectraForkEpoch = forkRoot + "electra-fork-epoch"
 
 	// Validator Config.
 	validator               = beaconConfigRoot + "validator."

--- a/config/forks.go
+++ b/config/forks.go
@@ -31,29 +31,32 @@ import (
 	"github.com/itsdevbear/bolaris/types/consensus/primitives"
 )
 
+const defaultElectraForkEpoch = 9999999999999999
+
 // Forks conforms to the BeaconKitConfig interface.
 var _ BeaconKitConfig[Forks] = &Forks{}
 
 // DefaultForksConfig returns the default forks configuration.
 func DefaultForksConfig() Forks {
 	return Forks{
-		DenebForkEpoch: primitives.Epoch(
-			0,
+		ElectraForkEpoch: primitives.Epoch(
+			defaultElectraForkEpoch,
 		),
 	}
 }
 
 // Config represents the configuration struct for the forks.
 type Forks struct {
-	// DenebForkEpoch is used to represent the assigned fork epoch for deneb.
-	DenebForkEpoch primitives.Epoch
+	// ElectraForkEpoch is used to represent the assigned fork epoch for
+	// electra.
+	ElectraForkEpoch primitives.Epoch
 }
 
 // Parse parses the configuration.
 func (c Forks) Parse(parser parser.AppOptionsParser) (*Forks, error) {
 	var err error
-	if c.DenebForkEpoch, err = parser.GetEpoch(
-		flags.DenebForkEpoch,
+	if c.ElectraForkEpoch, err = parser.GetEpoch(
+		flags.ElectraForkEpoch,
 	); err != nil {
 		return nil, err
 	}
@@ -65,7 +68,7 @@ func (c Forks) Parse(parser parser.AppOptionsParser) (*Forks, error) {
 func (c Forks) Template() string {
 	return `
 [beacon-kit.beacon-config.forks]
-# Deneb fork epoch
-deneb-fork-epoch = {{.BeaconKit.Beacon.Forks.DenebForkEpoch}}
+# Electra fork epoch
+electra-fork-epoch = {{.BeaconKit.Beacon.Forks.ElectraForkEpoch}}
 `
 }

--- a/config/version/version.go
+++ b/config/version/version.go
@@ -31,4 +31,5 @@ const (
 	Bellatrix
 	Capella
 	Deneb
+	Electra
 )


### PR DESCRIPTION
Pre-mature, but adding now so that we have an example in the code of the hardfork switch, also removes DenebForkEpoch which we don't use since Deneb is always enabled.