### PR TITLE
added erigon as EL for local network

### DIFF
--- a/build/scripts/testing.mk
+++ b/build/scripts/testing.mk
@@ -115,6 +115,7 @@ start-erigon: ## start an ephemeral `erigon` node
 	--port 30303 \
 	--http.corsdomain "*" \
 	--http.port 8545 \
+	--authrpc.addr	0.0.0.0 \
 	--authrpc.jwtsecret $(JWT_PATH) \
 	--authrpc.vhosts "*" \
 	--networkid 80087 \


### PR DESCRIPTION
Erigon added as an execution layer for spinning up local dev network using `make start-erigon`. 
Attaching logs from the command.
![image](https://github.com/berachain/beacon-kit/assets/38173192/f2c121f5-7d10-48d4-8dc8-c5d84eef2f94)
