### PR TITLE
chore(mnd): Disable magic number detector

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -237,7 +237,7 @@ linters:
     - gocyclo # computes and checks the cyclomatic complexity of functions
     - godot # checks if comments end in a period
     - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
-    - mnd # detects magic numbers
+    # - mnd # detects magic numbers // Disabled by Chibera. This linter is universally hated 
     # - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
     - goprintffuncname # checks that printf-like functions are named with f at the end


### PR DESCRIPTION


>> The obvious solution is to stop using the go-mnd linter.
https://forum.golangbridge.org/t/how-to-solve-the-magic-number-linter-warning/20421

It complains if we ever use a number anywhere. 