### PR TITLE
Ensure Kurtosis is installed before starting devnet

### DIFF
--- a/kurtosis/Makefile
+++ b/kurtosis/Makefile
@@ -4,8 +4,33 @@
 ###                                Kurtosis                                 ###
 ###############################################################################
 
+# Installs Kurtosis if not already installed
+install-kurtosis:
+	@echo "Checking for Kurtosis installation..."
+	@if ! command -v kurtosis &> /dev/null; then \
+		echo "Kurtosis could not be found, installing..."; \
+		OS=$$(uname -s | tr A-Z a-z); \
+		if [ "$$OS" = "darwin" ]; then \
+			brew install kurtosis-tech/tap/kurtosis-cli; \
+		elif [ "$$OS" = "linux" ]; then \
+			ARCH=$$(uname -m); \
+			if [ "$$ARCH" = "x86_64" ]; then ARCH="amd64"; \
+			elif [ "$$ARCH" = "arm64" ]; then ARCH="arm64"; \
+			else echo "Unsupported architecture $$ARCH for Kurtosis installation" && exit 1; fi; \
+			curl -Lo kurtosis.tar.gz "https://github.com/kurtosis-tech/kurtosis-cli/releases/latest/download/kurtosis-$$OS-$$ARCH.tar.gz"; \
+			tar -xzf kurtosis.tar.gz; \
+			rm kurtosis.tar.gz; \
+			chmod +x kurtosis; \
+			sudo mv kurtosis /usr/local/bin/; \
+		else \
+			echo "Unsupported OS $$OS for Kurtosis installation" && exit 1; \
+		fi; \
+	else \
+		echo "Kurtosis is already installed"; \
+	fi
+
 # Starts a Kurtosis enclave containing a local devnet.
-start-devnet:
+start-devnet: install-kurtosis
 	$(MAKE) build-docker VERSION=kurtosis-local start-devnet-no-build
 
 # Starts a Kurtosis enclave containing a local devnet without building the image
@@ -66,4 +91,4 @@ star-fix:
 # Marks targets as not being associated with files
 .PHONY: start-devnet stop-devnet reset-devnet rm-devnet buildifier-install \
   star-lint star-fix start-gcp-devnet-no-build stop-gcp-devnet \
-  reset-gcp-devnet rm-gcp-devnet
+  reset-gcp-devnet rm-gcp-devnet install-kurtosis


### PR DESCRIPTION
Related to #457

Implements automatic Kurtosis installation and checks before starting the local devnet.

- Adds a new `install-kurtosis` target in the `kurtosis/Makefile` to check for Kurtosis installation and automatically install it if not found. This ensures a smoother setup process for new users.
- Incorporates OS detection logic to handle Kurtosis installation for both Darwin (macOS) and Linux systems, with specific instructions for macOS to use Homebrew for the installation.
- Modifies the `start-devnet` target to depend on the `install-kurtosis` target, ensuring Kurtosis is installed and running before attempting to start the local devnet.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/berachain/beacon-kit/issues/457?shareId=05a58246-79ca-43e2-91c9-5512a6015a8c).