### PR TITLE
reth argument correction

### DIFF
--- a/kurtosis/src/nodes/execution/reth/config.star
+++ b/kurtosis/src/nodes/execution/reth/config.star
@@ -98,7 +98,7 @@ CMD = [
     "100000",
     "--txpool.queued-max-size",
     "100",
-    "--txpool.max-account-slots",
+    "--txpool.max_account_slots",
     "1000",
     "--txpool.max-cached-entries",
     "1000",


### PR DESCRIPTION
`make start-devnet` is failing with below error. 
![Screenshot 2024-06-03 at 5 47 04 PM](https://github.com/berachain/beacon-kit/assets/38173192/ce6fdc12-64e3-4912-8c6e-af50cf3da94b)
