### PR TITLE
refactor: disable gochecknoglobals in test files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -361,3 +361,4 @@ issues:
         - gosec
         - noctx
         - wrapcheck
+        - gochecknoglobals

--- a/mod/cli/pkg/utils/prompt/prompt_test.go
+++ b/mod/cli/pkg/utils/prompt/prompt_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 var (
-	//nolint:gochecknoglobals // this is a test
 	p = &prompt.Prompt{
 		Cmd:  &cobra.Command{},
 		Text: "test",

--- a/mod/consensus-types/pkg/types/payload_header_test.go
+++ b/mod/consensus-types/pkg/types/payload_header_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:gochecknoglobals // allow test constants
 var (
 	extraDataField = "ExecutionPayloadHeaderDeneb.ExtraData"
 	logsBloomField = "ExecutionPayloadHeaderDeneb.LogsBloom"

--- a/mod/da/pkg/kzg/ckzg/helpers_test.go
+++ b/mod/da/pkg/kzg/ckzg/helpers_test.go
@@ -34,10 +34,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:gochecknoglobals // this is a test.
 var globalVerifier *ckzg.Verifier
 
-//nolint:gochecknoglobals // this is a test.
 var baseDir = "../../../../../testing/files/"
 
 func TestMain(m *testing.M) {

--- a/mod/da/pkg/kzg/gokzg/gokzg_test.go
+++ b/mod/da/pkg/kzg/gokzg/gokzg_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:gochecknoglobals // this is a test.
 var baseDir = "../../../../../testing/files/"
 
 func TestVerifyBlobProof(t *testing.T) {

--- a/mod/primitives/pkg/ssz/v2/lib/spec_test.go
+++ b/mod/primitives/pkg/ssz/v2/lib/spec_test.go
@@ -39,10 +39,8 @@ import (
 // Test fixture from fastssz.
 const TestFileName = "fixtures/beacon_state_bellatrix.ssz"
 
-//nolint:gochecknoglobals // test debug print toggle
 var debug = false
 
-//nolint:gochecknoglobals // test debug default err msg
 var defaultErrMsg = "local output & fastssz output doesnt match"
 
 type TestLogger interface {


### PR DESCRIPTION
## Description

Disable the `gochecknoglobals` linter on tests files, since it is not really useful for tests. 

