### PR TITLE
chore(node-core): remove module.Environment deps from storage backend initialization

### DIFF
--- a/mod/node-core/pkg/components/defaults.go
+++ b/mod/node-core/pkg/components/defaults.go
@@ -54,6 +54,7 @@ func DefaultComponentsWithStandardTypes() []any {
 		ProvideRuntime,
 		ProvideServiceRegistry,
 		ProvideStateProcessor,
+		ProvideStorageBackend,
 		ProvideTelemetrySink,
 		ProvideTrustedSetup,
 		ProvideValidatorMiddleware,

--- a/mod/node-core/pkg/components/module/depinject.go
+++ b/mod/node-core/pkg/components/module/depinject.go
@@ -34,7 +34,7 @@ import (
 func init() {
 	appconfig.RegisterModule(&modulev1alpha1.Module{},
 		appconfig.Provide(
-			components.ProvideStorageBackend,
+			components.ProvideKVStore,
 			ProvideModule,
 		),
 	)


### PR DESCRIPTION
part of https://github.com/berachain/beacon-kit/pull/1438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced storage capabilities by introducing `ProvideStorageBackend` as a standard component.
  - Added a new `KVStore` field to the storage backend configuration for improved data management.

- **Refactor**
  - Replaced `ProvideStorageBackend` with `ProvideKVStore` during module initialization for better alignment with storage requirements.
  - Refactored storage backend setup to use the new `KVStore` field, streamlining the data handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->