### PR TITLE
chore(ci): move off of latest besu image cause broken

### DIFF
--- a/kurtosis/beaconkit-all.yaml
+++ b/kurtosis/beaconkit-all.yaml
@@ -92,7 +92,7 @@ node_settings:
       min_memory: 0
       max_memory: 2048
     images:
-      besu: hyperledger/besu:latest
+      besu: hyperledger/besu:24.5.4
       erigon: thorax/erigon:v2.60.1
       ethereumjs: ethpandaops/ethereumjs:stable
       geth: ethereum/client-go:latest

--- a/testing/e2e/config/config.go
+++ b/testing/e2e/config/config.go
@@ -271,7 +271,7 @@ func defaultExecutionSettings() ExecutionSettings {
 			MaxMemory: 2048, //nolint:mnd // 2 GB
 		},
 		Images: map[string]string{
-			"besu":       "hyperledger/besu:latest",
+			"besu":       "hyperledger/besu:24.5.4",
 			"erigon":     "thorax/erigon:v2.60.1",
 			"ethereumjs": "ethpandaops/ethereumjs:stable",
 			"geth":       "ethereum/client-go:stable",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `besu` image version to `24.5.4` for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->