### PR TITLE
Use 'require' instead of 'if' and 'revert'

### DIFF
--- a/contracts/src/staking/BeaconDepositContract.sol
+++ b/contracts/src/staking/BeaconDepositContract.sol
@@ -76,7 +76,7 @@ contract BeaconDepositContract is IBeaconDepositContract, Ownable {
             revert InvalidCredentialsLength();
         }
 
-        require(signature.length != SIGNATURE_LENGTH, InvalidSignatureLength());
+        require(signature.length == SIGNATURE_LENGTH, InvalidSignatureLength());
 
         uint64 amountInGwei = _deposit(amount);
 

--- a/contracts/src/staking/BeaconDepositContract.sol
+++ b/contracts/src/staking/BeaconDepositContract.sol
@@ -76,15 +76,11 @@ contract BeaconDepositContract is IBeaconDepositContract, Ownable {
             revert InvalidCredentialsLength();
         }
 
-        if (signature.length != SIGNATURE_LENGTH) {
-            revert InvalidSignatureLength();
-        }
+        require(signature.length != SIGNATURE_LENGTH, InvalidSignatureLength());
 
         uint64 amountInGwei = _deposit(amount);
 
-        if (amountInGwei < MIN_DEPOSIT_AMOUNT_IN_GWEI) {
-            revert InsufficientDeposit();
-        }
+        require(amountInGwei >= MIN_DEPOSIT_AMOUNT_IN_GWEI, InsufficientDeposit());
 
         --depositAuth[msg.sender];
 


### PR DESCRIPTION
**Use require instead of if and revert:** require is a built-in function in Solidity that throws an exception if the condition is not met and reverts the changes. It's more readable and concise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved input validation in the staking contract by replacing `revert` statements with `require` statements, enhancing control flow and error messaging for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->