### PR TITLE
test: add additional test fo primitives/hex

### DIFF
--- a/mod/primitives/pkg/hex/bytes.go
+++ b/mod/primitives/pkg/hex/bytes.go
@@ -46,11 +46,9 @@ func UnmarshalByteText(input []byte) ([]byte, error) {
 	return dec, nil
 }
 
-// UnmarshalFixedJSON decodes the input as a string with 0x prefix. The length
+// DecodeFixedJSON decodes the input as a string with 0x prefix. The length
 // of out determines the required input length. This function is commonly used
 // to implement the UnmarshalJSON method for fixed-size types.
-
-// UnmarshalFixedJSON decodes the input as a string with 0x prefix.
 func DecodeFixedJSON(typ reflect.Type,
 	bytesT reflect.Type,
 	input,
@@ -63,7 +61,7 @@ func DecodeFixedJSON(typ reflect.Type,
 	)
 }
 
-// UnmarshalFixedText decodes the input as a string with 0x prefix. The length
+// DecodeFixedText decodes the input as a string with 0x prefix. The length
 // of out determines the required input length.
 func DecodeFixedText(typename string, input, out []byte) error {
 	raw, err := formatAndValidateText(input)

--- a/mod/primitives/pkg/hex/bytes_test.go
+++ b/mod/primitives/pkg/hex/bytes_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+//nolint:lll // long strings
+package hex_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/hex"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "typical byte slice",
+			input:    []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f},
+			expected: []byte("0x48656c6c6f"),
+		},
+		{
+			name:     "empty byte slice",
+			input:    []byte{},
+			expected: []byte("0x"),
+		},
+		{
+			name:     "single byte",
+			input:    []byte{0x01},
+			expected: []byte("0x01"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := hex.EncodeBytes(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result, "Test case : %s", tt.name)
+		})
+	}
+}
+
+func TestUnmarshalByteText(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []byte
+		expected  []byte
+		expectErr bool
+	}{
+		{
+			name:      "valid hex string",
+			input:     []byte("0x48656c6c6f"),
+			expected:  []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f},
+			expectErr: false,
+		},
+		{
+			name:      "empty hex string",
+			input:     []byte("0x"),
+			expected:  []byte{},
+			expectErr: false,
+		},
+		{
+			name:      "invalid hex string",
+			input:     []byte("0xZZZZ"),
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "invalid format",
+			input:     []byte("invalid hex string"),
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := hex.UnmarshalByteText(tt.input)
+			if tt.expectErr {
+				require.Error(t, err, "Test case : %s", tt.name)
+			} else {
+				require.NoError(t, err, "Test case : %s", tt.name)
+				require.Equal(t, tt.expected, result, "Test case : %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestDecodeFixedText(t *testing.T) {
+	tests := []struct {
+		name      string
+		typename  string
+		input     []byte
+		expected  []byte
+		expectErr bool
+	}{
+		{
+			name:      "valid hex string",
+			typename:  "testType",
+			input:     []byte("0x48656c6c6f"),
+			expected:  []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f},
+			expectErr: false,
+		},
+		{
+			name:      "invalid hex string length",
+			typename:  "testType",
+			input:     []byte("0x48656c6c"),
+			expected:  make([]byte, 5),
+			expectErr: true,
+		},
+		{
+			name:      "invalid hex characters",
+			typename:  "testType",
+			input:     []byte("0xZZZZZZZZZZ"),
+			expected:  make([]byte, 5),
+			expectErr: true,
+		},
+		{
+			name:      "hex.Decode error",
+			typename:  "testType",
+			input:     []byte("0x123"), // Invalid length for hex.Decode
+			expected:  make([]byte, 2),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := make([]byte, len(tt.expected))
+			err := hex.DecodeFixedText(tt.typename, tt.input, out)
+			if tt.expectErr {
+				require.Error(t, err, "Test case : %s", tt.name)
+			} else {
+				require.NoError(t, err, "Test case : %s", tt.name)
+				require.Equal(t, tt.expected, out, "Test case : %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestDecodeFixedJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		typename  string
+		input     []byte
+		out       []byte
+		expectErr bool
+	}{
+		{
+			name:      "valid hex string",
+			typename:  "testType",
+			input:     []byte(`"0x48656c6c6f"`),
+			out:       make([]byte, 5),
+			expectErr: false,
+		},
+		{
+			name:      "invalid hex string length",
+			typename:  "testType",
+			input:     []byte(`"0x48656c6c"`),
+			out:       make([]byte, 5),
+			expectErr: true,
+		},
+		{
+			name:      "invalid hex characters",
+			typename:  "testType",
+			input:     []byte(`"0xZZZZZZZZZZ"`),
+			out:       make([]byte, 5),
+			expectErr: true,
+		},
+		{
+			name:      "non-quoted string",
+			typename:  "testType",
+			input:     []byte(`0x48656c6c6f`),
+			out:       make([]byte, 5),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := hex.DecodeFixedJSON(reflect.TypeOf(tt.typename), reflect.TypeOf(tt.input), tt.input, tt.out)
+			if tt.expectErr {
+				require.Error(t, err, "Test case : %s", tt.name)
+			} else {
+				require.NoError(t, err, "Test case : %s", tt.name)
+				require.Equal(t, []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f}, tt.out, "Test case : %s", tt.name)
+			}
+		})
+	}
+}

--- a/mod/primitives/pkg/hex/hex_test.go
+++ b/mod/primitives/pkg/hex/hex_test.go
@@ -23,11 +23,14 @@ package hex_test
 
 import (
 	"bytes"
+	"encoding"
 	"math/big"
+	"reflect"
 	"strconv"
 	"testing"
 
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/hex"
+	"github.com/stretchr/testify/require"
 )
 
 // ====================== Constructors ===========================.
@@ -68,13 +71,10 @@ func TestNewStringStrictInvariants(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			str, err := hex.NewStringStrict(test.input)
-			if (err != nil) != test.expectErr {
-				t.Errorf(
-					"NewStringStrict() error = %v, expectErr %v",
-					err,
-					test.expectErr,
-				)
-			} else if err == nil {
+			if test.expectErr {
+				require.Error(t, err, "Test case: %s", test.name)
+			} else {
+				require.NoError(t, err, "Test case: %s", test.name)
 				verifyInvariants(t, "NewStringStrict()", str)
 			}
 		})
@@ -293,5 +293,165 @@ func verifyInvariants(t *testing.T, invoker string, s hex.String) {
 	}
 	if s.IsEmpty() {
 		t.Errorf(invoker+"result is empty: %v", s)
+	}
+}
+
+func TestUnmarshalJSONText(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []byte
+		unmarshaler encoding.TextUnmarshaler
+		expectErr   bool
+	}{
+		{
+			name:        "Valid JSON text",
+			input:       []byte(`"0x48656c6c6f"`),
+			unmarshaler: new(hex.String),
+			expectErr:   false,
+		},
+		{
+			name:        "Invalid JSON text",
+			input:       []byte(`"invalid"`),
+			unmarshaler: new(hex.String),
+			expectErr:   true,
+		},
+		{
+			name:        "Invalid quoted JSON text",
+			input:       []byte(`"0x`),
+			unmarshaler: new(hex.String),
+			expectErr:   true,
+		},
+		{
+			name:        "Empty JSON text",
+			input:       []byte(`""`),
+			unmarshaler: new(hex.String),
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := hex.UnmarshalJSONText(tt.input, tt.unmarshaler, reflect.TypeOf(tt.unmarshaler))
+			if tt.expectErr {
+				require.Error(t, err, "Test case: %s", tt.name)
+			} else {
+				require.NoError(t, err, "Test case: %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestString_MustToBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    hex.String
+		expected []byte
+		panics   bool
+	}{
+		{"Valid hex string", "0x68656c6c6f", []byte("hello"), false},
+		{"Another valid hex string", "0x776f726c64", []byte("world"), false},
+		{"Invalid hex string", "0xinvalid", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.panics {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("MustToBytes did not panic on invalid input")
+					}
+				}()
+				tt.input.MustToBytes()
+			} else {
+				result := tt.input.MustToBytes()
+				require.Equal(t, tt.expected, result, "Test case: %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestString_ToUint64(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     hex.String
+		expected  uint64
+		expectErr bool
+	}{
+		{"Single digit", "0x1", 1, false},
+		{"Two digits", "0x10", 16, false},
+		{"Mixed digits and letters", "0x1a", 26, false},
+		{"Invalid hex string", "0xinvalid", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.input.ToUint64()
+			if tt.expectErr {
+				require.Error(t, err, "Test case: %s", tt.name)
+			} else {
+				require.NoError(t, err, "Test case: %s", tt.name)
+				require.Equal(t, tt.expected, result, "Test case: %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestString_MustToUInt64(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    hex.String
+		expected uint64
+		panics   bool
+	}{
+		{"Single digit", "0x1", 1, false},
+		{"Two digits", "0x10", 16, false},
+		{"Mixed digits and letters", "0x1a", 26, false},
+		{"Invalid hex string", "0xinvalid", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.panics {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("MustToUInt64 did not panic on invalid input")
+					}
+				}()
+				tt.input.MustToUInt64()
+			} else {
+				result := tt.input.MustToUInt64()
+				require.Equal(t, tt.expected, result, "Test case: %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestString_MustToBigInt(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    hex.String
+		expected *big.Int
+		panics   bool
+	}{
+		{"Valid hex string", "0x1", big.NewInt(1), false},
+		{"Another valid hex string", "0x10", big.NewInt(16), false},
+		{"Large valid hex string", "0x1a", big.NewInt(26), false},
+		{"Invalid hex string", "0xinvalid", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.panics {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("MustToBigInt did not panic on invalid input")
+					}
+				}()
+				tt.input.MustToBigInt()
+			} else {
+				result := tt.input.MustToBigInt()
+				require.Equal(t, tt.expected, result, "Test case: %s", tt.name)
+			}
+		})
 	}
 }

--- a/mod/primitives/pkg/hex/json.go
+++ b/mod/primitives/pkg/hex/json.go
@@ -25,8 +25,9 @@ import (
 	"reflect"
 )
 
-// UnmarshalJSONText unmarshals a JSON string with 0x prefix into a
-// TextUnmarshaler.
+// UnmarshalJSONText unmarshals a JSON string with a 0x prefix into a given
+// TextUnmarshaler. It validates the input and then removes the surrounding
+// quotes before passing the inner content to the UnmarshalText method.
 func UnmarshalJSONText(input []byte,
 	u encoding.TextUnmarshaler,
 	t reflect.Type,

--- a/mod/primitives/pkg/hex/string.go
+++ b/mod/primitives/pkg/hex/string.go
@@ -23,6 +23,7 @@ package hex
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"strconv"
 )
@@ -37,6 +38,29 @@ func NewString[T []byte | string](s T) String {
 	str := string(s)
 	str = ensureStringInvariants(str)
 	return String(str)
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// It validates the input text as a hex string and
+// assigns it to the String type.
+// Returns an error if the input is not a valid hex string.
+func (s *String) UnmarshalText(text []byte) error {
+	str := string(text)
+	err := isValidHex(str)
+	if err != nil {
+		return fmt.Errorf("invalid hex string: %s, error: %w", str, err)
+	}
+	*s = String(str)
+	return nil
+}
+
+func isValidHex(str string) error {
+	if len(str) == 0 {
+		return ErrEmptyString
+	} else if !has0xPrefix(str) {
+		return ErrMissingPrefix
+	}
+	return nil
 }
 
 // NewStringStrict creates a hex string with 0x prefix. It errors if any of the

--- a/mod/primitives/pkg/hex/u64_test.go
+++ b/mod/primitives/pkg/hex/u64_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package hex_test
+
+import (
+	"testing"
+
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/hex"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    uint64
+		expected string
+	}{
+		{"Zero", 0, "0x0"},
+		{"MaxByte", 255, "0xff"},
+		{"MaxWord", 65535, "0xffff"},
+		{"MaxDWord", 4294967295, "0xffffffff"},
+		{"MaxQWord", 18446744073709551615, "0xffffffffffffffff"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := hex.MarshalText(test.input)
+			require.NoError(t, err, "Test case %s", test.name)
+			require.Equal(t, test.expected, string(result), "Test case %s", test.name)
+		})
+	}
+}
+
+func TestValidateUnmarshalInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected error
+	}{
+		{"ValidQuotedString", []byte(`"0x0"`), nil},
+		{"ValidQuotedStringFF", []byte(`"0xff"`), nil},
+		{"NonQuotedString", []byte(`0xff`), hex.ErrNonQuotedString},
+		{"InvalidQuotedString", []byte(`"z`), hex.ErrNonQuotedString},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := hex.ValidateUnmarshalInput(test.input)
+			if test.expected != nil {
+				require.Equal(t, test.expected, err, "Test case %s", test.name)
+			} else {
+				require.NoError(t, err, "Test case %s", test.name)
+			}
+		})
+	}
+}
+
+func TestUnmarshalUint64Text(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected uint64
+		err      error
+	}{
+		{"Zero", []byte("0x0"), 0, nil},
+		{"MaxByte", []byte("0xff"), 255, nil},
+		{"MaxWord", []byte("0xffff"), 65535, nil},
+		{"MaxDWord", []byte("0xffffffff"), 4294967295, nil},
+		{"MaxQWord", []byte("0xffffffffffffffff"), 18446744073709551615, nil},
+		{"OutOfRange", []byte("0x10000000000000000"), 0, hex.ErrUint64Range},
+		{"InvalidString", []byte("0xzz"), 0, hex.ErrInvalidString},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := hex.UnmarshalUint64Text(test.input)
+			if test.err != nil {
+				require.Equal(t, test.err, err, "Test case %s", test.name)
+			} else {
+				require.Equal(t, test.expected, result, "Test case %s", test.name)
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added JSON unmarshaling support for hex strings with a `0x` prefix.
  - Introduced validation for hex string inputs when unmarshaling text.

- **Bug Fixes**
  - Enhanced error handling for invalid hex strings.

- **Tests**
  - Expanded test coverage for encoding/decoding byte slices, converting hex strings to various types, and JSON unmarshaling.
  - Improved test assertions using the `testify` package.

- **Refactor**
  - Renamed `UnmarshalFixedJSON` and `UnmarshalFixedText` functions to `DecodeFixedJSON` and `DecodeFixedText` for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->