### PR TITLE
test(net/jwt): refactor test to use `require` pkg

### DIFF
--- a/mod/primitives/pkg/net/jwt/jwt_test.go
+++ b/mod/primitives/pkg/net/jwt/jwt_test.go
@@ -22,13 +22,13 @@
 package jwt_test
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/hex"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/net/jwt"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewFromHex(t *testing.T) {
@@ -74,14 +74,11 @@ func TestNewFromHex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := jwt.NewFromHex(tt.hexStr)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewFromHex() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewFromHex() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -105,95 +102,54 @@ func TestSecretString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.secret.String(); got != tt.want {
-				t.Errorf("Secret.String() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, tt.secret.String(), "Secret.String() mismatch")
 		})
 	}
 }
 
 func TestNewRandom(t *testing.T) {
 	secret, err := jwt.NewRandom()
-	if err != nil {
-		t.Errorf("NewRandom() error = %v, wantErr %v", err, false)
-	}
-	if len(secret) == 0 {
-		t.Errorf("NewRandom() generated an empty secret")
-	}
-
-	if len(secret.Bytes()) != 32 {
-		t.Errorf(
-			"NewRandom() generated a secret of incorrect length: got %d, want %d",
-			len(secret.Bytes()),
-			32,
-		)
-	}
+	require.NoError(t, err, "NewRandom() error")
+	require.Len(t, secret.Bytes(), 32, "NewRandom() length mismatch")
 }
 
 func TestSecretBytes(t *testing.T) {
 	expectedLength := 32 // Assuming the secret is expected to be 32 bytes long
 	secret, _ := jwt.NewRandom()
 	bytes := secret.Bytes()
-	if len(bytes) != expectedLength {
-		t.Errorf("Bytes() length = %d, want %d", len(bytes), expectedLength)
-	}
+	require.Len(t, bytes, expectedLength, "Bytes() length mismatch")
 }
 
 func TestSecretHexWithFixedInput(t *testing.T) {
 	expectedHex := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-	// Since the secret is 32 bytes, its hex representation should be 64
-	// characters
-	// long
 	expectedHexLength := 64
+
 	secret, err := jwt.NewFromHex(expectedHex)
-	if err != nil {
-		t.Fatalf("NewFromHex() error = %v", err)
-	}
+	require.NoError(t, err, "NewFromHex() error")
+
 	hexStr := secret.Hex()
-	if hexStr != expectedHex {
-		t.Errorf("Hex() = %s, want %s", hexStr, expectedHex)
-	}
+	require.Equal(t, expectedHex, hexStr, "Hex() output mismatch")
 
 	// Check if the hex string is of the expected length and format.
-	if len(hexStr) != expectedHexLength+2 {
-		t.Errorf("Hex() length = %d, want %d", len(hexStr), expectedHexLength)
-	}
+	require.Len(t, hexStr, expectedHexLength+2, "Hex() length mismatch")
 
 	// Strip the '0x' prefix and check if the remaining string is valid hex.
 	hexStr = strings.TrimPrefix(hexStr, "0x")
-	if len(hexStr) != expectedHexLength {
-		t.Errorf(
-			"Hex() length after stripping '0x' = %d, want %d",
-			len(hexStr), expectedHexLength)
-	}
-
-	if !jwt.HexRegexp.MatchString(hexStr) {
-		t.Errorf(
-			"Hex() output does not match hexadecimal format, got: %s", hexStr,
-		)
-	}
+	require.Len(t, hexStr, expectedHexLength, "Hex() length after stripping '0x' mismatch")
+	require.True(t, jwt.HexRegexp.MatchString(hexStr), "Hex() output does not match hexadecimal format")
 }
 
 func TestSecretRoundTripEncoding(t *testing.T) {
 	originalSecret, err := jwt.NewRandom()
-	if err != nil {
-		t.Fatalf("NewRandom() error = %v, wantErr %v", err, false)
-	}
+	require.NoError(t, err, "NewRandom() error")
 
 	// Encode the original secret to hex string
 	encodedSecret := hex.FromBytes(originalSecret.Bytes())
 
 	// Decode the hex string back to secret
 	decodedSecret, err := jwt.NewFromHex(encodedSecret.Unwrap())
-	if err != nil {
-		t.Fatalf("NewFromHex() error = %v", err)
-	}
+	require.NoError(t, err, "NewFromHex() error")
 
 	// Compare the original and decoded secrets
-	if !reflect.DeepEqual(originalSecret, decodedSecret) {
-		t.Errorf(
-			"Round trip encoding failed. Original: %v, Decoded: %v",
-			originalSecret, decodedSecret,
-		)
-	}
+	require.Equal(t, originalSecret, decodedSecret, "Round trip encoding failed")
 }


### PR DESCRIPTION
### Description

Use `require` pkg for better test results' readability. 