### PR TITLE
ci: remove `prompt` package from ci

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -43,11 +43,6 @@ packages:
       recursive: True
       with-expecter: true
       all: True
-  github.com/berachain/beacon-kit/mod/cli/pkg/utils/prompt:
-    config:
-      recursive: True
-      with-expecter: true
-      all: True
   github.com/berachain/beacon-kit/mod/storage/pkg/interfaces:
     config:
       recursive: False


### PR DESCRIPTION
## Description

Remove the package that was previously removed(9ff4430) from CI pipeline .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package configurations for internal tools to improve maintainability and performance. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->