### PR TITLE
fix(execution): zero max deposits

### DIFF
--- a/mod/execution/pkg/deposit/pruner.go
+++ b/mod/execution/pkg/deposit/pruner.go
@@ -35,7 +35,7 @@ func BuildPruneRangeFn[
 ](cs common.ChainSpec) func(BlockEventT) (uint64, uint64) {
 	return func(event BlockEventT) (uint64, uint64) {
 		deposits := event.Data().GetBody().GetDeposits()
-		if len(deposits) == 0 {
+		if len(deposits) == 0 || cs.MaxDepositsPerBlock() == 0 {
 			return 0, 0
 		}
 		index := deposits[len(deposits)-1].GetIndex()


### PR DESCRIPTION
I discovered a potential bug in the BuildPruneRangeFn function reproduced in the unit test case "Zero max deposits" from PR [1563](https://github.com/berachain/beacon-kit/pull/1563).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deposit pruning logic to handle cases where the maximum deposits per block is zero, ensuring more robust and error-free execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->