### PR TITLE
test(consensus-types): additional unit tests for genesis.go

### DIFF
--- a/mod/consensus-types/pkg/genesis/genesis_test.go
+++ b/mod/consensus-types/pkg/genesis/genesis_test.go
@@ -80,7 +80,7 @@ func TestGenesisGetForkVersion(t *testing.T) {
 func TestGenesisGetDeposits(t *testing.T) {
 	g := genesis.DefaultGenesisDeneb()
 	deposits := g.GetDeposits()
-	require.Equal(t, 0, len(deposits))
+	require.Empty(t, deposits)
 }
 
 func TestGenesisGetExecutionPayloadHeader(t *testing.T) {

--- a/mod/consensus-types/pkg/genesis/genesis_test.go
+++ b/mod/consensus-types/pkg/genesis/genesis_test.go
@@ -215,4 +215,3 @@ func TestGenesisUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
-

--- a/mod/consensus-types/pkg/genesis/genesis_test.go
+++ b/mod/consensus-types/pkg/genesis/genesis_test.go
@@ -71,6 +71,30 @@ func TestDefaultGenesisExecutionPayloadHeaderDeneb(t *testing.T) {
 	require.NotNil(t, header)
 }
 
+func TestGenesisGetForkVersion(t *testing.T) {
+	g := genesis.DefaultGenesisDeneb()
+	forkVersion := g.GetForkVersion()
+	require.Equal(t, version.FromUint32[common.Version](version.Deneb), forkVersion)
+}
+
+func TestGenesisGetDeposits(t *testing.T) {
+	g := genesis.DefaultGenesisDeneb()
+	deposits := g.GetDeposits()
+	require.Equal(t, 0, len(deposits))
+}
+
+func TestGenesisGetExecutionPayloadHeader(t *testing.T) {
+	g := genesis.DefaultGenesisDeneb()
+	header := g.GetExecutionPayloadHeader()
+	require.NotNil(t, header)
+}
+
+func TestDefaultGenesisDenebPanics(t *testing.T) {
+	require.NotPanics(t, func() {
+		genesis.DefaultGenesisDeneb()
+	})
+}
+
 func TestGenesisUnmarshalJSON(t *testing.T) {
 	t.Helper()
 	testCases := []struct {
@@ -191,3 +215,4 @@ func TestGenesisUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+


### PR DESCRIPTION
Partially address https://github.com/berachain/beacon-kit/issues/1190

The current status indicates an increase in coverage from 83.9% to 93.5% for genesis.go
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added new test cases to ensure the stability of genesis functions, including fork version retrieval, deposits, and execution payload header.
	- Introduced a test to verify that no panic occurs during the default genesis creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->