### PR TITLE
test(consensus-types): add additional test for header

### DIFF
--- a/mod/consensus-types/pkg/types/header_test.go
+++ b/mod/consensus-types/pkg/types/header_test.go
@@ -140,3 +140,205 @@ func TestBeaconBlockHeader_UnmarshalSSZ_ErrSize(t *testing.T) {
 	err := header.UnmarshalSSZ(buf)
 	require.ErrorIs(t, err, ssz.ErrSize)
 }
+
+func TestBeaconBlockHeaderBase_MarshalSSZUnmarshalSSZ(t *testing.T) {
+	tests := []struct {
+		name   string
+		header *types.BeaconBlockHeaderBase
+		valid  bool
+	}{
+		{
+			name: "normal case",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            100,
+				ProposerIndex:   200,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+			valid: true,
+		},
+		{
+			name: "zero values",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            0,
+				ProposerIndex:   0,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid size",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            100,
+				ProposerIndex:   200,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.header.MarshalSSZ()
+			require.NoError(t, err)
+			require.NotNil(t, data)
+
+			var unmarshalled types.BeaconBlockHeaderBase
+			if tt.valid {
+				err = unmarshalled.UnmarshalSSZ(data)
+				require.NoError(t, err)
+				require.Equal(t, tt.header, &unmarshalled)
+			} else {
+				// Modify data to simulate invalid size
+				data = data[:len(data)-1]
+				err = unmarshalled.UnmarshalSSZ(data)
+				require.ErrorIs(t, err, ssz.ErrSize)
+			}
+		})
+	}
+}
+
+func TestBeaconBlockHeaderBase_MarshalSSZToUnmarshalSSZ(t *testing.T) {
+	tests := []struct {
+		name   string
+		header *types.BeaconBlockHeaderBase
+	}{
+		{
+			name: "normal case",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            100,
+				ProposerIndex:   200,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+		},
+		{
+			name: "zero values",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            0,
+				ProposerIndex:   0,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := make([]byte, 0, tt.header.SizeSSZ())
+			data, err := tt.header.MarshalSSZTo(buf)
+			require.NoError(t, err)
+			require.NotNil(t, data)
+
+			var unmarshalled types.BeaconBlockHeaderBase
+			err = unmarshalled.UnmarshalSSZ(data)
+			require.NoError(t, err)
+			require.Equal(t, tt.header, &unmarshalled)
+		})
+	}
+}
+
+func TestBeaconBlockHeaderBase_HashTreeRoot(t *testing.T) {
+	tests := []struct {
+		name   string
+		header *types.BeaconBlockHeaderBase
+	}{
+		{
+			name: "HashTreeRoot normal case",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            100,
+				ProposerIndex:   200,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+		},
+		{
+			name: "HashTreeRoot zero values",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            0,
+				ProposerIndex:   0,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, err := tt.header.HashTreeRoot()
+			require.NoError(t, err)
+			require.NotNil(t, root)
+		})
+	}
+}
+
+func TestBeaconBlockHeaderBase_HashTreeRootWith(t *testing.T) {
+	tests := []struct {
+		name   string
+		header *types.BeaconBlockHeaderBase
+	}{
+		{
+			name: "HashTreeRootWith normal case",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            100,
+				ProposerIndex:   200,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+		},
+		{
+			name: "HashTreeRootWith zero values",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            0,
+				ProposerIndex:   0,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hh := ssz.NewHasher()
+			err := tt.header.HashTreeRootWith(hh)
+			require.NoError(t, err)
+			require.NotNil(t, hh.Hash())
+		})
+	}
+}
+
+func TestBeaconBlockHeaderBase_GetTree(t *testing.T) {
+	tests := []struct {
+		name   string
+		header *types.BeaconBlockHeaderBase
+	}{
+		{
+			name: "GetTree normal case",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            100,
+				ProposerIndex:   200,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+		},
+		{
+			name: "GetTree zero values",
+			header: &types.BeaconBlockHeaderBase{
+				Slot:            0,
+				ProposerIndex:   0,
+				ParentBlockRoot: common.Root{},
+				StateRoot:       common.Root{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree, err := tt.header.GetTree()
+			require.NoError(t, err)
+			require.NotNil(t, tree)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved test coverage for `BeaconBlockHeaderBase` operations, including marshaling, unmarshaling, hashing, and tree generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->