### PR TITLE
clearing cache for blutgang

### DIFF
--- a/kurtosis/src/services/blutgang/config.toml.tmpl
+++ b/kurtosis/src/services/blutgang/config.toml.tmpl
@@ -3,7 +3,7 @@
 # Config for blutgang goes here
 [blutgang]
 # Clear the cache DB on startup
-do_clear = false
+do_clear = true
 # Where to bind blutgang to
 address = "0.0.0.0:3000"
 # Moving average length for the latency


### PR DESCRIPTION
Trying this out to see if it fixes e2e flakiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated configuration to clear the cache DB on startup, ensuring that users always work with fresh data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->