### PR TITLE
chore(ssz): Use generic on merkleizer object

### DIFF
--- a/mod/cli/pkg/commands/genesis/root.go
+++ b/mod/cli/pkg/commands/genesis/root.go
@@ -68,7 +68,7 @@ func GetGenesisValidatorRootCmd(cs common.ChainSpec) *cobra.Command {
 
 			depositCount := uint64(len(genesis.AppState.Beacon.Deposits))
 			validators := make(
-				[]ssz.Composite[common.ChainSpec, [32]byte],
+				[]*types.Validator,
 				depositCount,
 			)
 			for i, deposit := range genesis.AppState.Beacon.Deposits {
@@ -83,7 +83,7 @@ func GetGenesisValidatorRootCmd(cs common.ChainSpec) *cobra.Command {
 			}
 
 			merkleizer := ssz.NewMerkleizer[
-				common.ChainSpec, math.U64, math.U256L, [32]byte,
+				common.ChainSpec, math.U64, math.U256L, [32]byte, *types.Validator,
 			]()
 			var validatorsRoot common.Root
 			validatorsRoot, err = merkleizer.MerkleizeListComposite(

--- a/mod/consensus-types/pkg/types/body.go
+++ b/mod/consensus-types/pkg/types/body.go
@@ -227,6 +227,7 @@ func (b *BeaconBlockBodyDeneb) GetTopLevelRoots() ([][32]byte, error) {
 	}
 
 	// KZG commitments is not needed
+	//nosec:G103 // Okay to go from common.Root to [32]byte.
 	return *(*[][32]byte)(unsafe.Pointer(&layer)), nil
 }
 

--- a/mod/consensus-types/pkg/types/body.go
+++ b/mod/consensus-types/pkg/types/body.go
@@ -227,7 +227,7 @@ func (b *BeaconBlockBodyDeneb) GetTopLevelRoots() ([][32]byte, error) {
 	}
 
 	// KZG commitments is not needed
-	//nosec:G103 // Okay to go from common.Root to [32]byte.
+	//#nosec:G103 // Okay to go from common.Root to [32]byte.
 	return *(*[][32]byte)(unsafe.Pointer(&layer)), nil
 }
 

--- a/mod/consensus-types/pkg/types/body.go
+++ b/mod/consensus-types/pkg/types/body.go
@@ -26,6 +26,8 @@
 package types
 
 import (
+	"unsafe"
+
 	"github.com/berachain/beacon-kit/mod/errors"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/crypto"
@@ -197,11 +199,11 @@ func (b *BeaconBlockBodyDeneb) SetBlobKzgCommitments(
 
 // GetTopLevelRoots returns the top-level roots of the BeaconBlockBodyDeneb.
 func (b *BeaconBlockBodyDeneb) GetTopLevelRoots() ([][32]byte, error) {
-	layer := make([][32]byte, BodyLengthDeneb)
+	layer := make([]common.Root, BodyLengthDeneb)
 	var err error
 	randao := b.GetRandaoReveal()
-	merkleizer := ssz.NewMerkleizer[
-		common.ChainSpec, math.U64, math.U256L, common.Root]()
+	merkleizer := ssz.NewMerkleizer[common.ChainSpec, math.U64,
+		math.U256L, [32]byte, common.Root]()
 	layer[0], err = merkleizer.MerkleizeByteSlice(randao[:])
 	if err != nil {
 		return nil, err
@@ -225,7 +227,7 @@ func (b *BeaconBlockBodyDeneb) GetTopLevelRoots() ([][32]byte, error) {
 	}
 
 	// KZG commitments is not needed
-	return layer, nil
+	return *(*[][32]byte)(unsafe.Pointer(&layer)), nil
 }
 
 // Length returns the number of fields in the BeaconBlockBodyDeneb struct.

--- a/mod/consensus-types/pkg/types/deposit.go
+++ b/mod/consensus-types/pkg/types/deposit.go
@@ -84,13 +84,9 @@ type Deposits []*Deposit
 func (d Deposits) HashTreeRoot() (common.Root, error) {
 	// TODO: read max deposits from the chain spec.
 	merkleizer := ssz.NewMerkleizer[
-		common.ChainSpec, math.U64, math.U256L, [32]byte]()
-	deposits := make([]ssz.Composite[common.ChainSpec, [32]byte], len(d))
-	for i, deposit := range d {
-		deposits[i] = deposit
-	}
+		common.ChainSpec, math.U64, math.U256L, [32]byte, *Deposit]()
 	return merkleizer.MerkleizeListComposite(
-		deposits,
+		d,
 		constants.MaxDepositsPerBlock,
 	)
 }

--- a/mod/engine-primitives/pkg/engine-primitives/transactions.go
+++ b/mod/engine-primitives/pkg/engine-primitives/transactions.go
@@ -34,10 +34,10 @@ type Transactions [][]byte
 // HashTreeRoot returns the hash tree root of the Transactions list.
 func (txs Transactions) HashTreeRoot() (common.Root, error) {
 	var err error
-	roots := make([][32]byte, len(txs))
+	roots := make([]common.Root, len(txs))
 
 	merkleizer := ssz.NewMerkleizer[
-		common.ChainSpec, math.U64, math.U256L, [32]byte]()
+		common.ChainSpec, math.U64, math.U256L, [32]byte, common.Root]()
 
 	for i, tx := range txs {
 		roots[i], err = merkleizer.MerkleizeByteSlice(tx)
@@ -46,14 +46,8 @@ func (txs Transactions) HashTreeRoot() (common.Root, error) {
 		}
 	}
 
-	roots2 := make([]ssz.Composite[
-		common.ChainSpec, [32]byte], len(roots))
-	for i, root := range roots {
-		roots2[i] = common.Root(root)
-	}
-
 	return merkleizer.MerkleizeListComposite(
-		roots2,
+		roots,
 		constants.MaxTxsPerPayload,
 	)
 }

--- a/mod/engine-primitives/pkg/engine-primitives/withdrawal.go
+++ b/mod/engine-primitives/pkg/engine-primitives/withdrawal.go
@@ -78,15 +78,11 @@ type Withdrawals []*Withdrawal
 func (w Withdrawals) HashTreeRoot() (common.Root, error) {
 	// TODO: read max withdrawals from the chain spec.
 	merkleizer := ssz.NewMerkleizer[
-		common.ChainSpec, math.U64, math.U256L, [32]byte,
+		common.ChainSpec, math.U64, math.U256L, [32]byte, *Withdrawal,
 	]()
 
-	x := make([]ssz.Composite[common.ChainSpec, [32]byte], len(w))
-	for i, withdrawal := range w {
-		x[i] = withdrawal
-	}
 	return merkleizer.MerkleizeListComposite(
-		x,
+		w,
 		constants.MaxWithdrawalsPerPayload,
 	)
 }

--- a/mod/state-transition/pkg/core/state_processor_genesis.go
+++ b/mod/state-transition/pkg/core/state_processor_genesis.go
@@ -112,18 +112,9 @@ func (sp *StateProcessor[
 
 	var validatorsRoot common.Root
 	merkleizer := ssz.NewMerkleizer[
-		common.ChainSpec, math.U64, math.U256L, [32]byte]()
-	// Convert validators to a slice of Composite
-	compositeValidators := make(
-		[]ssz.Composite[common.ChainSpec, [32]byte],
-		len(validators),
-	)
-	for i, v := range validators {
-		compositeValidators[i] = v
-	}
-
+		common.ChainSpec, math.U64, math.U256L, [32]byte, ValidatorT]()
 	validatorsRoot, err = merkleizer.MerkleizeListComposite(
-		compositeValidators,
+		validators,
 		uint64(len(validators)),
 	)
 	if err != nil {


### PR DESCRIPTION
unhood

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated data types and memory handling in `BeaconBlockBodyDeneb` struct for improved performance and type consistency.
  - Introduced unsafe pointer conversion in the `GetTopLevelRoots` function for optimized data management.

These changes enhance the efficiency of data operations and ensure better alignment with the underlying data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->