### PR TITLE
perf(serializer): use direct indexing to avoid append overhead

### DIFF
--- a/mod/primitives/pkg/ssz/serializer/vector.go
+++ b/mod/primitives/pkg/ssz/serializer/vector.go
@@ -58,20 +58,21 @@ func UnmarshalVectorFixed[
 		t   T
 	)
 	elementSize := t.SizeSSZ()
-	if len(buf)%elementSize != 0 {
+	bufLen := len(buf)
+	if bufLen%elementSize != 0 {
 		return nil, fmt.Errorf(
 			"invalid buffer length %d for element size %d",
-			len(buf),
+			bufLen,
 			elementSize,
 		)
 	}
 
-	result := make([]T, 0, len(buf)/elementSize)
-	for i := 0; i < len(buf); i += elementSize {
-		if t, err = t.NewFromSSZ(buf[i : i+elementSize]); err != nil {
+	result := make([]T, bufLen/elementSize)
+	for i := 0; i < bufLen; i += elementSize {
+		if result[i/elementSize],
+			err = t.NewFromSSZ(buf[i : i+elementSize]); err != nil {
 			return nil, err
 		}
-		result = append(result, t)
 	}
 
 	return result, nil

--- a/mod/primitives/pkg/ssz/serializer/vector_test.go
+++ b/mod/primitives/pkg/ssz/serializer/vector_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package serializer_test
+
+import (
+	"testing"
+
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/ssz/serializer"
+)
+
+// Mock type implementing the required interface for testing
+type MockType struct {
+	data []byte
+}
+
+func (m MockType) NewFromSSZ(data []byte) (MockType, error) {
+	return MockType{data: data}, nil
+}
+
+func (m MockType) SizeSSZ() int {
+	return 10
+}
+
+func BenchmarkUnmarshalVectorFixed(b *testing.B) {
+	// Prepare a buffer with mock data
+	elementSize := 10
+	numElements := 1000
+	buf := make([]byte, elementSize*numElements)
+	for i := 0; i < len(buf); i++ {
+		buf[i] = byte(i % 256)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := serializer.UnmarshalVectorFixed[MockType](buf)
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}

--- a/mod/primitives/pkg/ssz/serializer/vector_test.go
+++ b/mod/primitives/pkg/ssz/serializer/vector_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/ssz/serializer"
 )
 
-// Mock type implementing the required interface for testing
 type MockType struct {
 	data []byte
 }


### PR DESCRIPTION
Before
```
pkg: github.com/berachain/beacon-kit/mod/primitives/pkg/ssz/serializer
BenchmarkUnmarshalVectorFixed
BenchmarkUnmarshalVectorFixed-11    	  327990	      3292 ns/op

```
After
```
pkg: github.com/berachain/beacon-kit/mod/primitives/pkg/ssz/serializer
BenchmarkUnmarshalVectorFixed
BenchmarkUnmarshalVectorFixed-11    	  402188	      2825 ns/op

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved memory allocation and error handling in the vector unmarshalling process.

- **Tests**
	- Added benchmarking tests for vector unmarshalling to ensure performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->