### PR TITLE
test(ssz): conformance tests for merkleizing byte lists/vectors

### DIFF
--- a/mod/engine-primitives/pkg/engine-primitives/transactions_test.go
+++ b/mod/engine-primitives/pkg/engine-primitives/transactions_test.go
@@ -69,7 +69,6 @@ var prysmConsistencyTests = []struct {
 		},
 	},
 	{
-		// TODO: Broken.
 		name: "max bytes per tx",
 		txs: func() [][]byte {
 			var tx []byte
@@ -94,7 +93,6 @@ var prysmConsistencyTests = []struct {
 		},
 	},
 	{
-		// TODO: Broken.
 		name: "max txs",
 		txs: func() [][]byte {
 			var txs [][]byte

--- a/mod/primitives/pkg/bytes/b96_test.go
+++ b/mod/primitives/pkg/bytes/b96_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/bytes"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/merkle/zero"
-	merkleizer "github.com/berachain/beacon-kit/mod/primitives/pkg/ssz/merkleizer"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/ssz"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/ssz/types"
 	"github.com/stretchr/testify/require"
 )
@@ -183,8 +183,7 @@ func TestB96HashTreeRoot(t *testing.T) {
 			root1, err1 := tt.input.HashTreeRoot()
 			require.NoError(t, err1)
 
-			merkleizer := merkleizer.New[[32]byte, bytes.B32]()
-			root2, err := merkleizer.MerkleizeByteSlice(tt.input[:])
+			root2, err := ssz.ByteVectorFromBytes(tt.input[:]).HashTreeRoot()
 			require.NoError(t, err)
 			require.Equal(
 				t,

--- a/mod/primitives/pkg/ssz/merkleizer/merkleizer.go
+++ b/mod/primitives/pkg/ssz/merkleizer/merkleizer.go
@@ -63,6 +63,8 @@ func (m *Merkleizer[RootT, T]) MerkleizeBasic(
 
 // MerkleizeByteSlice hashes a byteslice by chunkifying it and returning the
 // corresponding HTR as if it were a fixed vector of bytes of the given length.
+//
+// TODO: Deprecate in favor of Merkelize(List/Vector)Basic with type T = Byte.
 func (m *Merkleizer[RootT, T]) MerkleizeByteSlice(
 	input []byte,
 ) (RootT, error) {

--- a/mod/primitives/pkg/ssz/merkleizer/merkleizer_basic_test.go
+++ b/mod/primitives/pkg/ssz/merkleizer/merkleizer_basic_test.go
@@ -21,9 +21,12 @@
 package merkleizer_test
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
+	"testing"
 
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/ssz/merkleizer"
+	"github.com/stretchr/testify/require"
 )
 
 // BasicItem represents a basic item in the SSZ Spec.
@@ -48,42 +51,44 @@ func (u BasicItem) HashTreeRoot() ([32]byte, error) {
 	return merkleizer.MerkleizeBasic(u)
 }
 
-// // BasicContainer represents a container of two basic items.
-// type BasicContainer[SpecT any] struct {
-// 	Item1 BasicItem
-// 	Item2 BasicItem
-// }
+// BasicContainer represents a container of two basic items.
+type BasicContainer[SpecT any] struct {
+	Item1 BasicItem
+	Item2 BasicItem
+}
 
-// // SizeSSZ returns the size of the container in bytes.
-// func (c *BasicContainer[SpecT]) SizeSSZ() int {
-// 	return c.Item1.SizeSSZ() + c.Item2.SizeSSZ()
-// }
+// SizeSSZ returns the size of the container in bytes.
+func (c *BasicContainer[SpecT]) SizeSSZ() int {
+	return c.Item1.SizeSSZ() + c.Item2.SizeSSZ()
+}
 
-// // HashTreeRoot computes the Merkle root of the container using SSZ hashing
-// // rules.
-// func (c *BasicContainer[SpecT]) HashTreeRoot() ([32]byte, error) {
-// 	merkleizer := merkleizer.New[[32]byte, common.Root]()
-// 	return merkleizer.MerkleizeContainer(c)
-// }
+// HashTreeRoot computes the Merkle root of the container using SSZ hashing
+// rules.
+func (c *BasicContainer[SpecT]) HashTreeRoot() ([32]byte, error) {
+	merkleizer := merkleizer.New[[32]byte, BasicItem]()
+	return merkleizer.MerkleizeVectorCompositeOrContainer(
+		[]BasicItem{c.Item1, c.Item2},
+	)
+}
 
 // TestBasicItemMerkleization tests the Merkleization of a basic item.
-// func TestBasicContainerMerkleization(t *testing.T) {
-// 	container := BasicContainer[any]{
-// 		Item1: BasicItem(1),
-// 		Item2: BasicItem(2),
-// 	}
+func TestBasicContainerMerkleization(t *testing.T) {
+	container := BasicContainer[any]{
+		Item1: BasicItem(1),
+		Item2: BasicItem(2),
+	}
 
-// 	// Merkleize the container.
-// 	actualRoot, err := container.HashTreeRoot()
-// 	require.NoError(t, err)
+	// Merkleize the container.
+	actualRoot, err := container.HashTreeRoot()
+	require.NoError(t, err)
 
-// 	// Manually compute our own root, using our merkle tree knowledge.
-// 	htr1, err := container.Item1.HashTreeRoot()
-// 	require.NoError(t, err)
-// 	htr2, err := container.Item2.HashTreeRoot()
-// 	require.NoError(t, err)
-// 	expectedRoot := sha256.Sum256(append(htr1[:], htr2[:]...))
+	// Manually compute our own root, using our merkle tree knowledge.
+	htr1, err := container.Item1.HashTreeRoot()
+	require.NoError(t, err)
+	htr2, err := container.Item2.HashTreeRoot()
+	require.NoError(t, err)
+	expectedRoot := sha256.Sum256(append(htr1[:], htr2[:]...))
 
-// 	// Should match
-// 	require.Equal(t, expectedRoot, actualRoot)
-// }
+	// Should match
+	require.Equal(t, expectedRoot, actualRoot)
+}

--- a/mod/primitives/pkg/ssz/merkleizer/merkleizer_bytes_test.go
+++ b/mod/primitives/pkg/ssz/merkleizer/merkleizer_bytes_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package merkleizer_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/constants"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/ssz"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/ssz/merkleizer"
+)
+
+// Tests consistency of our HashTreeRoot implementation with Prysm's.
+// https://github.com/prysmaticlabs/prysm/blob/8070fc8ecef3c2003dea7e1fe6dba179ddf76151/encoding/ssz/htrutils_test.go#L126
+//
+//nolint:lll // link.
+var prysmConsistencyTests = []struct {
+	name      string
+	slice     []byte
+	maxLength uint64
+	want      [32]byte
+	wantErr   bool
+}{
+	{
+		name:  "nil",
+		slice: nil,
+		want: [32]byte{
+			245, 165, 253, 66, 209, 106, 32, 48, 39, 152, 239, 110, 211, 9,
+			151, 155, 67, 0, 61, 35, 32, 217, 240, 232, 234, 152, 49, 169,
+			39, 89, 251, 75,
+		},
+	},
+	{
+		name:  "empty",
+		slice: []byte{},
+		want: [32]byte{
+			245, 165, 253, 66, 209, 106, 32, 48, 39, 152, 239, 110, 211, 9,
+			151, 155, 67, 0, 61, 35, 32, 217, 240, 232, 234, 152, 49, 169,
+			39, 89, 251, 75,
+		},
+	},
+	{
+		name:  "byte slice 3 values",
+		slice: []byte{1, 2, 3},
+		want: [32]byte{
+			20, 159, 26, 252, 247, 204, 44, 159, 161, 135, 211, 195, 106,
+			59, 220, 149, 199, 163, 228, 155, 113, 118, 64, 126, 173, 223,
+			102, 1, 241, 158, 164, 185,
+		},
+	},
+	{
+		name: "byte slice 32 values",
+		slice: []byte{
+			1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+			19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+		},
+		want: [32]byte{
+			7, 30, 46, 77, 237, 240, 59, 126, 232, 232, 232, 6, 145, 210,
+			31, 18, 117, 12, 217, 40, 204, 141, 90, 236, 241, 128, 221, 45,
+			126, 39, 39, 202,
+		},
+	},
+	{
+		name:    "over max length",
+		slice:   make([]byte, constants.RootLength+1),
+		want:    [32]byte{},
+		wantErr: true,
+	},
+}
+
+// NOTE: not testing legacy byte list merkleization
+// (merkleizer.MerkleizeByteSlice) as it will be deprecated soon.
+func TestByteListMerkleization(t *testing.T) {
+	merkleizer := merkleizer.New[[32]byte, ssz.Byte]()
+
+	for _, tt := range prysmConsistencyTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.maxLength == 0 {
+				tt.maxLength = constants.RootLength
+			}
+			byteList := ssz.ByteListFromBytes(tt.slice, tt.maxLength)
+			got, err := byteList.HashTreeRootWith(merkleizer)
+			if (err != nil) != tt.wantErr {
+				t.Errorf(
+					"ByteSliceRoot() error = %v, wantErr %v", err, tt.wantErr,
+				)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ByteSliceRoot() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
revives tests from #1681 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Removed outdated comments on tests for "max bytes per tx" and "max txs".
  - Updated hashing operation in `TestB96HashTreeRoot`.
  - Added new tests for byte slice hashing consistency.

- **Documentation**
  - Deprecated `MerkleizeByteSlice` method in favor of `Merkelize(List/Vector)Basic`.

- **Refactor**
  - Revised `BasicContainer` struct methods for `SizeSSZ` and `HashTreeRoot`.
  - Updated test imports and implementation details for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->