### PR TITLE
test(primitives): add more test for tree

### DIFF
--- a/mod/primitives/pkg/ssz/tree/index.go
+++ b/mod/primitives/pkg/ssz/tree/index.go
@@ -136,7 +136,7 @@ func (g GeneralizedIndex[RootT]) VerifyMerkleProof(
 	return calculated == root, err
 }
 
-// Concatenates multiple generalized indices into a single generalized index
+// Concat multiple generalized indices into a single generalized index
 // representing the path from the first to the last node.
 func (gs GeneralizedIndicies[RootT]) Concat() GeneralizedIndex[RootT] {
 	o := GeneralizedIndex[RootT](1)

--- a/mod/primitives/pkg/ssz/tree/index_test.go
+++ b/mod/primitives/pkg/ssz/tree/index_test.go
@@ -117,3 +117,305 @@ func TestGeneralizedIndexMethods(t *testing.T) {
 		"Incorrect parent index",
 	)
 }
+
+func TestGetBranchIndices(t *testing.T) {
+	tests := []struct {
+		name   string
+		index  tree.GeneralizedIndex[[32]byte]
+		expect tree.GeneralizedIndicies[[32]byte]
+	}{
+		{name: "Single Branch", index: 1,
+			expect: []tree.GeneralizedIndex[[32]byte]{}},
+		{name: "Two Branches", index: 3,
+			expect: []tree.GeneralizedIndex[[32]byte]{2}},
+		{name: "Multiple Branches", index: 5,
+			expect: []tree.GeneralizedIndex[[32]byte]{4, 3}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.index.GetBranchIndices()
+			require.Equal(
+				t,
+				tt.expect,
+				result,
+				"Failed for index %d",
+				tt.index,
+			)
+		})
+	}
+}
+
+func TestGetPathIndices(t *testing.T) {
+	tests := []struct {
+		name   string
+		index  tree.GeneralizedIndex[[32]byte]
+		expect tree.GeneralizedIndicies[[32]byte]
+	}{
+		{name: "No Path", index: 1, expect: []tree.GeneralizedIndex[[32]byte]{}},
+		{name: "Single Path", index: 3,
+			expect: []tree.GeneralizedIndex[[32]byte]{3}},
+		{name: "Multiple Paths", index: 5,
+			expect: []tree.GeneralizedIndex[[32]byte]{5, 2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.index.GetPathIndices()
+			require.Equal(
+				t,
+				tt.expect,
+				result,
+				"Failed for index %d",
+				tt.index,
+			)
+		})
+	}
+}
+
+func TestCalculateMerkleRoot(t *testing.T) {
+	tests := []struct {
+		name      string
+		index     tree.GeneralizedIndex[[32]byte]
+		leaf      [32]byte
+		proof     [][32]byte
+		expect    [32]byte
+		expectErr bool
+	}{
+		{
+			name:  "Valid Proof",
+			index: tree.GeneralizedIndex[[32]byte](3),
+			leaf:  [32]byte{0x01},
+			proof: [][32]byte{{0x02}},
+			expect: [32]byte{
+				0x95, 0xe7, 0x3e, 0x86, 0x16, 0xbb, 0x92, 0x7b, 0xb0, 0x74, 0xee,
+				0x5, 0x5b, 0x12, 0x23, 0xf3, 0xa0, 0x85, 0xf7, 0x10, 0xc, 0x97,
+				0x46, 0x8d, 0x92, 0xe6, 0x3a, 0x1c, 0x87, 0xaf, 0x1c, 0x1a},
+			expectErr: false,
+		},
+		{
+			name:      "Invalid Proof Length",
+			index:     tree.GeneralizedIndex[[32]byte](3),
+			leaf:      [32]byte{0x01},
+			proof:     [][32]byte{{0x02}, {0x03}},
+			expect:    [32]byte{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.index.CalculateMerkleRoot(tt.leaf, tt.proof)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expect, result)
+			}
+		})
+	}
+}
+
+func TestVerifyMerkleProof(t *testing.T) {
+	tests := []struct {
+		name        string
+		index       tree.GeneralizedIndex[[32]byte]
+		leaf        [32]byte
+		proof       [][32]byte
+		root        [32]byte
+		expectValid bool
+		expectErr   bool
+	}{
+		{
+			name:  "Valid Proof",
+			index: tree.GeneralizedIndex[[32]byte](3),
+			leaf:  [32]byte{0x01},
+			proof: [][32]byte{{0x02}},
+			root: [32]byte{
+				0x95, 0xe7, 0x3e, 0x86, 0x16, 0xbb, 0x92, 0x7b, 0xb0, 0x74, 0xee,
+				0x5, 0x5b, 0x12, 0x23, 0xf3, 0xa0, 0x85, 0xf7, 0x10, 0xc, 0x97,
+				0x46, 0x8d, 0x92, 0xe6, 0x3a, 0x1c, 0x87, 0xaf, 0x1c, 0x1a},
+			expectErr:   false,
+			expectValid: true,
+		},
+		{
+			name:        "Invalid Proof",
+			index:       tree.GeneralizedIndex[[32]byte](3),
+			leaf:        [32]byte{0x01},
+			proof:       [][32]byte{{0x02}, {0x04}},
+			root:        [32]byte{0x01},
+			expectErr:   true,
+			expectValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.index.VerifyMerkleProof(tt.leaf, tt.proof, tt.root)
+			require.Equal(t, tt.expectValid, result)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetHelperIndices(t *testing.T) {
+	tests := []struct {
+		name    string
+		indices tree.GeneralizedIndicies[[32]byte]
+		expect  tree.GeneralizedIndicies[[32]byte]
+	}{
+		{
+			name:    "No Indices",
+			indices: []tree.GeneralizedIndex[[32]byte]{},
+			expect:  []tree.GeneralizedIndex[[32]byte]{},
+		},
+		{
+			name:    "Single Index",
+			indices: []tree.GeneralizedIndex[[32]byte]{1},
+			expect:  []tree.GeneralizedIndex[[32]byte]{},
+		},
+		{
+			name:    "Multiple Indices",
+			indices: []tree.GeneralizedIndex[[32]byte]{3, 5},
+			expect:  []tree.GeneralizedIndex[[32]byte]{4},
+		},
+		{
+			name:    "Overlapping Indices",
+			indices: []tree.GeneralizedIndex[[32]byte]{3, 7},
+			expect:  []tree.GeneralizedIndex[[32]byte]{6, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.indices.GetHelperIndices()
+			require.Equal(t, tt.expect, result,
+				"Failed for indices %v", tt.indices)
+		})
+	}
+}
+
+func TestCalculateMultiMerkleRoot(t *testing.T) {
+	tests := []struct {
+		name      string
+		indices   tree.GeneralizedIndicies[[32]byte]
+		leaves    [][32]byte
+		proof     [][32]byte
+		expect    [32]byte
+		expectErr bool
+	}{
+		{
+			name:    "Valid Multi Merkle Root",
+			indices: []tree.GeneralizedIndex[[32]byte]{3, 5},
+			leaves:  [][32]byte{{0x01}, {0x02}},
+			proof:   [][32]byte{{0x03}},
+			expect: [32]byte{
+				0xaf, 0xc4, 0xd0, 0x61, 0xb2, 0x2e, 0x1b, 0xd2, 0xad, 0x7c, 0xb8,
+				0x3c, 0xa7, 0xc8, 0x41, 0xca, 0xd, 0x8d, 0x51, 0x76, 0x2a, 0xe9,
+				0x7e, 0x74, 0xa3, 0xc2, 0x97, 0x70, 0x55, 0xdf, 0x62, 0x7c},
+			expectErr: false,
+		},
+		{
+			name:      "Mismatched Leaves and Indices Length",
+			indices:   []tree.GeneralizedIndex[[32]byte]{3, 5},
+			leaves:    [][32]byte{{0x01}},
+			proof:     [][32]byte{{0x03}},
+			expect:    [32]byte{},
+			expectErr: true,
+		},
+		{
+			name:      "Mismatched Proof and Helper Indices Length",
+			indices:   []tree.GeneralizedIndex[[32]byte]{3, 5},
+			leaves:    [][32]byte{{0x01}, {0x02}},
+			proof:     [][32]byte{},
+			expect:    [32]byte{},
+			expectErr: true,
+		},
+		{
+			name:      "Empty Indices and Leaves",
+			indices:   []tree.GeneralizedIndex[[32]byte]{},
+			leaves:    [][32]byte{},
+			proof:     [][32]byte{},
+			expect:    [32]byte{},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.indices.CalculateMultiMerkleRoot(tt.leaves, tt.proof)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expect, result)
+			}
+		})
+	}
+}
+
+func TestVerifyMerkleMultiproof(t *testing.T) {
+	tests := []struct {
+		name    string
+		indices tree.GeneralizedIndicies[[32]byte]
+		leaves  [][32]byte
+		proof   [][32]byte
+		root    [32]byte
+		expect  bool
+	}{
+		{
+			name:    "Valid Merkle Multiproof",
+			indices: []tree.GeneralizedIndex[[32]byte]{3, 5},
+			leaves:  [][32]byte{{0x01}, {0x02}},
+			proof:   [][32]byte{{0x03}},
+			root: [32]byte{
+				0xaf, 0xc4, 0xd0, 0x61, 0xb2, 0x2e, 0x1b, 0xd2, 0xad, 0x7c, 0xb8,
+				0x3c, 0xa7, 0xc8, 0x41, 0xca, 0xd, 0x8d, 0x51, 0x76, 0x2a, 0xe9,
+				0x7e, 0x74, 0xa3, 0xc2, 0x97, 0x70, 0x55, 0xdf, 0x62, 0x7c},
+			expect: true,
+		},
+		{
+			name:    "Invalid Merkle Multiproof",
+			indices: []tree.GeneralizedIndex[[32]byte]{3, 5},
+			leaves:  [][32]byte{{0x01}, {0x02}},
+			proof:   [][32]byte{{0x03}},
+			root:    [32]byte{},
+			expect:  false,
+		},
+		{
+			name:    "Mismatched Leaves and Indices Length",
+			indices: []tree.GeneralizedIndex[[32]byte]{3, 5},
+			leaves:  [][32]byte{{0x01}},
+			proof:   [][32]byte{{0x03}},
+			root:    [32]byte{},
+			expect:  false,
+		},
+		{
+			name:    "Mismatched Proof and Helper Indices Length",
+			indices: []tree.GeneralizedIndex[[32]byte]{3, 5},
+			leaves:  [][32]byte{{0x01}, {0x02}},
+			proof:   [][32]byte{},
+			root:    [32]byte{},
+			expect:  false,
+		},
+		{
+			name:    "Empty Indices and Leaves",
+			indices: []tree.GeneralizedIndex[[32]byte]{},
+			leaves:  [][32]byte{},
+			proof:   [][32]byte{},
+			root:    [32]byte{},
+			expect:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.indices.VerifyMerkleMultiproof(tt.leaves, tt.proof, tt.root)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed method `Concatenates` to `Concat` for improved clarity.

- **Tests**
  - Added comprehensive test functions for tree index operations including `GetBranchIndices`, `GetPathIndices`, `CalculateMerkleRoot`, `VerifyMerkleProof`, `GetHelperIndices`, `CalculateMultiMerkleRoot`, and `VerifyMerkleMultiproof`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->