### PR TITLE
Handle node crash when privValKeyFile and privValStateFile is not absolute path

### DIFF
--- a/mod/node-core/pkg/components/signer.go
+++ b/mod/node-core/pkg/components/signer.go
@@ -50,10 +50,15 @@ func ProvideBlsSigner(in BlsSignerInput) (crypto.BLSSigner, error) {
 		privValStateFile := cast.ToString(
 			in.AppOpts.Get("priv_validator_state_file"),
 		)
-		return signer.NewBLSSigner(
-			filepath.Join(homeDir, privValKeyFile),
-			filepath.Join(homeDir, privValStateFile),
-		), nil
+		// If privValKeyFile is not an absolute path, join with homeDir
+		if !filepath.IsAbs(privValKeyFile) {
+			privValKeyFile = filepath.Join(homeDir, privValKeyFile)
+		}
+		// If privValStateFile is not an absolute path, join with homeDir
+		if !filepath.IsAbs(privValStateFile) {
+			privValStateFile = filepath.Join(homeDir, privValStateFile)
+		}
+		return signer.NewBLSSigner(privValKeyFile, privValStateFile), nil
 	}
 	return signer.NewLegacySigner(in.PrivKey)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of file paths in the signing functionality to ensure correct path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->