### PR TITLE
chore(types): set byte as uint8 alias

### DIFF
--- a/mod/primitives/pkg/encoding/ssz/byte.go
+++ b/mod/primitives/pkg/encoding/ssz/byte.go
@@ -21,75 +21,13 @@
 package ssz
 
 import (
-	"fmt"
-
-	"github.com/berachain/beacon-kit/mod/primitives/pkg/encoding/ssz/constants"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/encoding/ssz/types"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
 )
 
-/* -------------------------------------------------------------------------- */
-/*                                Type Definitions                            */
-/* -------------------------------------------------------------------------- */
+// Ensure Byte implements types.SSZType.
+var _ types.SSZType[Byte] = (*Byte)(nil)
 
-// Ensure types implement types.SSZType.
-var (
-	_ types.SSZType[Byte] = (*Byte)(nil)
-)
-
-type (
-	Byte byte
-)
-
-/* -------------------------------------------------------------------------- */
-/*                                    Byte                                    */
-/* -------------------------------------------------------------------------- */
-
-// SizeSSZ returns the size of the byte slice in bytes.
-func (Byte) SizeSSZ() int {
-	return constants.ByteSize
-}
-
-// MarshalSSZ marshals the byte into SSZ format.
-func (b Byte) MarshalSSZ() ([]byte, error) {
-	return []byte{byte(b)}, nil
-}
-
-// NewFromSSZ creates a new Byte from SSZ format.
-func (Byte) NewFromSSZ(buf []byte) (Byte, error) {
-	if len(buf) != constants.ByteSize {
-		return 0, fmt.Errorf(
-			"invalid buffer length: expected %d, got %d",
-			constants.ByteSize,
-			len(buf),
-		)
-	}
-	return Byte(buf[0]), nil
-}
-
-// HashTreeRoot returns the hash tree root of the byte.
-func (b Byte) HashTreeRoot() ([32]byte, error) {
-	buf := make([]byte, constants.BytesPerChunk)
-	buf[0] = byte(b)
-	return [32]byte(buf), nil
-}
-
-// IsFixed returns true if the bool is fixed size.
-func (Byte) IsFixed() bool {
-	return true
-}
-
-// Type returns the type of the Byte.
-func (Byte) Type() types.Type {
-	return types.Basic
-}
-
-// ItemLength returns the required bytes to represent the root
-// element of the Byte.
-func (Byte) ItemLength() uint64 {
-	return constants.ByteSize
-}
-
-// ChunkCount returns the number of chunks required to store the byte.
-func (Byte) ChunkCount() uint64 {
-	return 1
-}
+// Byte is an alias for U8. 8-bit opaque data container, equivalent in
+// serialization and hashing to uint8.
+type Byte = math.U8

--- a/mod/primitives/pkg/encoding/ssz/constants/constants.go
+++ b/mod/primitives/pkg/encoding/ssz/constants/constants.go
@@ -30,9 +30,6 @@ const (
 	// BitsPerByte is the number of bits per byte.
 	BitsPerByte = 8
 
-	// ByteSize is the size of a single byte.
-	ByteSize = 1
-
 	// BoolSize is the size of a boolean in bytes.
 	BoolSize = 1
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated `Byte` type to alias `math.U8` for improved code consistency.
  
- **Chores**
  - Removed `ByteSize` constant to clean up unused code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->