### PR TITLE
chore: update minimum go version info 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ BeaconKit is able to support all 6 major Ethereum execution clients:
 **Prerequisites:**
 
 - [Docker](https://docs.docker.com/engine/install/)
-- [Golang 1.22.0+](https://go.dev/doc/install)
+- [Golang 1.22.5+](https://go.dev/doc/install)
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 
 Start by opening two terminals side-by-side:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the required Golang version to 1.22.5 in the prerequisites section of the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->