### PR TITLE
chore(testing-bartio): Update timeout config

### DIFF
--- a/testing/networks/80084/app.toml
+++ b/testing/networks/80084/app.toml
@@ -271,14 +271,14 @@ implementation = "crate-crypto/go-kzg-4844"
 # Enabled determines if the local payload builder is enabled.
 enabled = true
 
-# Post bellatrix, this address will receive the transaction fees produced by any blocks 
+# Post bellatrix, this address will receive the transaction fees produced by any blocks
 # from this node.
 suggested-fee-recipient = "0x0000000000000000000000000000000000000000"
 
 # The timeout for local build payload. This should match, or be slightly less
 # than the configured timeout on your execution client. It also must be less than
 # timeout_proposal in the CometBFT configuration.
-payload-timeout = "1s"
+payload-timeout = "850ms"
 
 [beacon-kit.validator]
 # Graffiti string that will be included in the graffiti field of the beacon block.

--- a/testing/networks/80084/config.toml
+++ b/testing/networks/80084/config.toml
@@ -453,7 +453,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "1.25s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)


### PR DESCRIPTION
Update the following parameters:
- payload-timeout = "850ms"
- timeout_propose = "1s"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Reduced payload timeout duration for local build operations from 1 second to 850 milliseconds, enhancing performance and responsiveness.
  - Decreased block proposal timeout from 1.25 seconds to 1 second, optimizing the efficiency of block proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->