### PR TITLE
fix(makefile): use beacon kit flag for log level

### DIFF
--- a/testing/files/entrypoint.sh
+++ b/testing/files/entrypoint.sh
@@ -79,7 +79,7 @@ fi
 
 # Start the node (remove the --pruning=nothing flag if historical queries are not needed)
 BEACON_START_CMD="./build/bin/beacond start --pruning=nothing "$TRACE" \
---log_level $LOGLEVEL --api.enabled-unsafe-cors \
+--beacon-kit.logger.log-level $LOGLEVEL --api.enabled-unsafe-cors \
 --api.enable --api.swagger --minimum-gas-prices=0.0001abgt \
 --home $HOMEDIR --beacon-kit.engine.jwt-secret-path ${JWT_SECRET_PATH}"
 


### PR DESCRIPTION
non breaking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Revised logging configuration for node startup to use `--beacon-kit.logger.log-level` for improved control and visibility of log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->