### PR TITLE
chore(build): Rename simd by beacond

### DIFF
--- a/build/scripts/build.mk
+++ b/build/scripts/build.mk
@@ -53,8 +53,8 @@ comma := ,
 build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 
 # process linker flags
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=sim \
-		-X github.com/cosmos/cosmos-sdk/version.AppName=simd \
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=beacon \
+		-X github.com/cosmos/cosmos-sdk/version.AppName=beacond \
 		-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 		-X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"


### PR DESCRIPTION
When doing local build (make build), the help is showing simd. For example:

beacond prune --help
....
Examples:
simd prune custom --pruning-keep-recent 100 --app-db-backend 'goleveldb' ....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated application name and versioning identifiers to reflect the new branding as "beacon" and "beacond." 

- **Chores**
	- Maintained existing version and commit flags, preserving the core versioning structure while updating the application identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->