### PR TITLE
fix(node-api): change default port addr

### DIFF
--- a/mod/node-api/server/config.go
+++ b/mod/node-api/server/config.go
@@ -20,6 +20,10 @@
 
 package server
 
+const (
+	defaultAddress = "0.0.0.0:3500"
+)
+
 // Config is the configuration for the node API server.
 type Config struct {
 	// Enabled is the flag to enable the node API server.
@@ -34,7 +38,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		Enabled: false,
-		Address: "0.0.0.0:8080",
+		Address: defaultAddress,
 		Logging: false,
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Centralized default server address configuration for improved maintainability.
	- Updated server to listen on port 3500 instead of the previous port 8080.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->