### PR TITLE
chore(store): Disallow removing from validator registry to return all correctly

### DIFF
--- a/mod/node-core/pkg/components/storage/types.go
+++ b/mod/node-core/pkg/components/storage/types.go
@@ -193,8 +193,6 @@ type KVStore[
 	// GetValidatorsByEffectiveBalance retrieves validators by effective
 	// balance.
 	GetValidatorsByEffectiveBalance() ([]ValidatorT, error)
-	// RemoveValidatorAtIndex removes the validator at the given index.
-	RemoveValidatorAtIndex(idx math.ValidatorIndex) error
 }
 
 // Validator represents an interface for a validator with generic withdrawal

--- a/mod/state-transition/pkg/core/interfaces.go
+++ b/mod/state-transition/pkg/core/interfaces.go
@@ -107,7 +107,6 @@ type WriteOnlyBeaconState[
 	UpdateSlashingAtIndex(uint64, math.Gwei) error
 	SetNextWithdrawalIndex(uint64) error
 	SetNextWithdrawalValidatorIndex(math.ValidatorIndex) error
-	RemoveValidatorAtIndex(math.ValidatorIndex) error
 	SetTotalSlashing(math.Gwei) error
 }
 

--- a/mod/state-transition/pkg/core/state/interfaces.go
+++ b/mod/state-transition/pkg/core/state/interfaces.go
@@ -144,6 +144,4 @@ type KVStore[
 	// GetValidatorsByEffectiveBalance retrieves validators by effective
 	// balance.
 	GetValidatorsByEffectiveBalance() ([]ValidatorT, error)
-	// RemoveValidatorAtIndex removes the validator at the given index.
-	RemoveValidatorAtIndex(idx math.ValidatorIndex) error
 }

--- a/mod/storage/pkg/beacondb/registry.go
+++ b/mod/storage/pkg/beacondb/registry.go
@@ -21,7 +21,6 @@
 package beacondb
 
 import (
-	sdkcollections "cosmossdk.io/collections"
 	"cosmossdk.io/collections/indexes"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/crypto"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
@@ -141,39 +140,22 @@ func (kv *KVStore[
 ]) GetValidators() (
 	[]ValidatorT, error,
 ) {
-	valSize, err := kv.validatorIndex.Peek(kv.ctx)
-	if err != nil {
-		return nil, err
-	}
+	var (
+		vals []ValidatorT
+		val  ValidatorT
+	)
 
 	iter, err := kv.validators.Iterate(kv.ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var (
-		vals     = make([]ValidatorT, valSize)
-		emptyVal ValidatorT
-		keyval   sdkcollections.KeyValue[uint64, ValidatorT]
-		index    uint64
-	)
-
 	for iter.Valid() {
-		keyval, err = iter.KeyValue()
+		val, err = iter.Value()
 		if err != nil {
 			return nil, err
 		}
-
-		// Fill in the empty values to maintain the order of registry.
-		for j := index; j < keyval.Key; j++ {
-			vals[j] = emptyVal
-		}
-
-		// Fill in the validator at index key.
-		vals[keyval.Key] = keyval.Value
-
-		// Move on to the next index.
-		index = keyval.Key + 1
+		vals = append(vals, val)
 		iter.Next()
 	}
 


### PR DESCRIPTION
Enforces the invariant that iterating in order over the validators indexed map for `GetValidators` returns a slice where the index of validator corresponds to validator's `ValidatorIndex`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validator retrieval process, ensuring correct order and gap handling in the list of validators.

- **Bug Fixes**
	- Improved memory allocation efficiency when retrieving validators, preventing potential performance issues.

- **Refactor**
	- Streamlined the validator management interface by removing the `RemoveValidatorAtIndex` method, improving usability and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->