### PR TITLE
chore(codec): Remove usage of reflect

### DIFF
--- a/mod/consensus-types/pkg/types/block.go
+++ b/mod/consensus-types/pkg/types/block.go
@@ -46,15 +46,8 @@ type BeaconBlock struct {
 }
 
 // Empty creates an empty beacon block.
-func (b *BeaconBlock) Empty(forkVersion uint32) *BeaconBlock {
-	switch forkVersion {
-	case version.Deneb:
-		return &BeaconBlock{}
-	case version.DenebPlus:
-		panic("unsupported fork version")
-	default:
-		panic("fork version not supported")
-	}
+func (*BeaconBlock) Empty() *BeaconBlock {
+	return &BeaconBlock{}
 }
 
 // NewWithVersion assembles a new beacon block from the given.

--- a/mod/consensus-types/pkg/types/block_test.go
+++ b/mod/consensus-types/pkg/types/block_test.go
@@ -76,13 +76,6 @@ func TestBeaconBlockForDeneb(t *testing.T) {
 	require.NotNil(t, block)
 }
 
-// Test the case where the fork version is not supported.
-func TestEmptyBeaconBlockInvalidForkVersion(t *testing.T) {
-	require.Panics(t, func() {
-		(&types.BeaconBlock{}).Empty()
-	})
-}
-
 func TestBeaconBlockFromSSZ(t *testing.T) {
 	originalBlock := generateValidBeaconBlock()
 
@@ -146,7 +139,7 @@ func TestBeaconBlock_HashTreeRoot(t *testing.T) {
 
 func TestBeaconBlockEmpty(t *testing.T) {
 	block := &types.BeaconBlock{}
-	emptyBlock := block.Empty(version.Deneb)
+	emptyBlock := block.Empty()
 	require.NotNil(t, emptyBlock)
 	require.IsType(t, &types.BeaconBlock{}, emptyBlock)
 }

--- a/mod/consensus-types/pkg/types/block_test.go
+++ b/mod/consensus-types/pkg/types/block_test.go
@@ -79,7 +79,7 @@ func TestBeaconBlockForDeneb(t *testing.T) {
 // Test the case where the fork version is not supported.
 func TestEmptyBeaconBlockInvalidForkVersion(t *testing.T) {
 	require.Panics(t, func() {
-		(&types.BeaconBlock{}).Empty(100)
+		(&types.BeaconBlock{}).Empty()
 	})
 }
 

--- a/mod/consensus-types/pkg/types/deposit.go
+++ b/mod/consensus-types/pkg/types/deposit.go
@@ -71,6 +71,11 @@ func NewDeposit(
 	}
 }
 
+// Empty creates an empty Deposit instance.
+func (*Deposit) Empty() *Deposit {
+	return &Deposit{}
+}
+
 // New creates a new Deposit instance.
 func (d *Deposit) New(
 	pubkey crypto.BLSPubkey,

--- a/mod/consensus-types/pkg/types/eth1data.go
+++ b/mod/consensus-types/pkg/types/eth1data.go
@@ -51,6 +51,11 @@ type Eth1Data struct {
 /*                                 Constructor                                */
 /* -------------------------------------------------------------------------- */
 
+// Empty creates an empty Eth1Data.
+func (*Eth1Data) Empty() *Eth1Data {
+	return &Eth1Data{}
+}
+
 // New creates a new Eth1Data.
 func (e *Eth1Data) New(
 	depositRoot common.Root,

--- a/mod/consensus-types/pkg/types/fork.go
+++ b/mod/consensus-types/pkg/types/fork.go
@@ -54,6 +54,11 @@ type Fork struct {
 /*                                 Constructor                                */
 /* -------------------------------------------------------------------------- */
 
+// Empty creates an empty Fork.
+func (f *Fork) Empty() *Fork {
+	return &Fork{}
+}
+
 // New creates a new fork.
 func (f *Fork) New(
 	previousVersion common.Version,

--- a/mod/consensus-types/pkg/types/header.go
+++ b/mod/consensus-types/pkg/types/header.go
@@ -74,6 +74,11 @@ func NewBeaconBlockHeader(
 	}
 }
 
+// Empty creates an empty BeaconBlockHeader instance.
+func (*BeaconBlockHeader) Empty() *BeaconBlockHeader {
+	return &BeaconBlockHeader{}
+}
+
 // New creates a new BeaconBlockHeader.
 func (b *BeaconBlockHeader) New(
 	slot math.Slot,

--- a/mod/consensus-types/pkg/types/validator.go
+++ b/mod/consensus-types/pkg/types/validator.go
@@ -95,6 +95,11 @@ func NewValidatorFromDeposit(
 	}
 }
 
+// Empty creates an empty Validator.
+func (*Validator) Empty() *Validator {
+	return &Validator{}
+}
+
 // New creates a new Validator with the given public key, withdrawal
 // credentials,.
 func (v *Validator) New(

--- a/mod/da/pkg/types/sidecars.go
+++ b/mod/da/pkg/types/sidecars.go
@@ -35,8 +35,7 @@ type BlobSidecars struct {
 
 // NewBlobSidecars creates a new BlobSidecars object.
 func (bs *BlobSidecars) Empty() *BlobSidecars {
-	bs = &BlobSidecars{}
-	return bs
+	return &BlobSidecars{}
 }
 
 // IsNil checks to see if blobs are nil.

--- a/mod/primitives/pkg/constraints/basic.go
+++ b/mod/primitives/pkg/constraints/basic.go
@@ -42,6 +42,11 @@ type EmptyWithVersion[SelfT any] interface {
 	Empty(uint32) SelfT
 }
 
+// Empty is a constraint that requires a type to have an Empty method.
+type Empty[SelfT any] interface {
+	Empty() SelfT
+}
+
 // IsNil is a constraint that requires a type to have an IsNil method.
 type Nillable interface {
 	IsNil() bool

--- a/mod/runtime/pkg/middleware/types.go
+++ b/mod/runtime/pkg/middleware/types.go
@@ -31,11 +31,12 @@ import (
 )
 
 // BeaconBlock is an interface for accessing the beacon block.
-type BeaconBlock[T any] interface {
+type BeaconBlock[SelfT any] interface {
 	constraints.SSZMarshallable
 	constraints.Nillable
+	constraints.Empty[SelfT]
 	GetSlot() math.Slot
-	NewFromSSZ([]byte, uint32) (T, error)
+	NewFromSSZ([]byte, uint32) (SelfT, error)
 }
 
 // TelemetrySink is an interface for sending metrics to a telemetry backend.

--- a/mod/runtime/pkg/p2p/types.go
+++ b/mod/runtime/pkg/p2p/types.go
@@ -24,5 +24,6 @@ import "github.com/berachain/beacon-kit/mod/primitives/pkg/constraints"
 
 type BeaconBlock[SelfT any] interface {
 	constraints.SSZMarshallable
+	constraints.Empty[SelfT]
 	NewFromSSZ([]byte, uint32) (SelfT, error)
 }

--- a/mod/storage/pkg/beacondb/kvstore.go
+++ b/mod/storage/pkg/beacondb/kvstore.go
@@ -35,15 +35,24 @@ import (
 // KVStore is a wrapper around an sdk.Context
 // that provides access to all beacon related data.
 type KVStore[
-	BeaconBlockHeaderT constraints.SSZMarshallable,
-	Eth1DataT constraints.SSZMarshallable,
+	BeaconBlockHeaderT interface {
+		constraints.Empty[BeaconBlockHeaderT]
+		constraints.SSZMarshallable
+	},
+	Eth1DataT interface {
+		constraints.Empty[Eth1DataT]
+		constraints.SSZMarshallable
+	},
 	ExecutionPayloadHeaderT interface {
 		constraints.SSZMarshallable
 		NewFromSSZ([]byte, uint32) (ExecutionPayloadHeaderT, error)
 		Version() uint32
 	},
-	ForkT constraints.SSZMarshallable,
-	ValidatorT Validator,
+	ForkT interface {
+		constraints.Empty[ForkT]
+		constraints.SSZMarshallable
+	},
+	ValidatorT Validator[ValidatorT],
 	ValidatorsT ~[]ValidatorT,
 ] struct {
 	ctx   context.Context
@@ -104,15 +113,24 @@ type KVStore[
 //
 //nolint:funlen // its not overly complex.
 func New[
-	BeaconBlockHeaderT constraints.SSZMarshallable,
-	Eth1DataT constraints.SSZMarshallable,
+	BeaconBlockHeaderT interface {
+		constraints.Empty[BeaconBlockHeaderT]
+		constraints.SSZMarshallable
+	},
+	Eth1DataT interface {
+		constraints.Empty[Eth1DataT]
+		constraints.SSZMarshallable
+	},
 	ExecutionPayloadHeaderT interface {
 		constraints.SSZMarshallable
 		NewFromSSZ([]byte, uint32) (ExecutionPayloadHeaderT, error)
 		Version() uint32
 	},
-	ForkT constraints.SSZMarshallable,
-	ValidatorT Validator,
+	ForkT interface {
+		constraints.Empty[ForkT]
+		constraints.SSZMarshallable
+	},
+	ValidatorT Validator[ValidatorT],
 	ValidatorsT ~[]ValidatorT,
 ](
 	kss store.KVStoreService,

--- a/mod/storage/pkg/beacondb/types.go
+++ b/mod/storage/pkg/beacondb/types.go
@@ -28,6 +28,7 @@ import (
 
 // Validator represents an interface for a validator in the beacon chain.
 type Validator[SelfT any] interface {
+	constraints.Empty[SelfT]
 	constraints.SSZMarshallable
 	// GetPubkey returns the BLS public key of the validator.
 	GetPubkey() crypto.BLSPubkey
@@ -36,5 +37,4 @@ type Validator[SelfT any] interface {
 	GetEffectiveBalance() math.Gwei
 	// IsActive checks if the validator is active at the given epoch.
 	IsActive(epoch math.Epoch) bool
-	Empty() SelfT
 }

--- a/mod/storage/pkg/beacondb/types.go
+++ b/mod/storage/pkg/beacondb/types.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Validator represents an interface for a validator in the beacon chain.
-type Validator interface {
+type Validator[SelfT any] interface {
 	constraints.SSZMarshallable
 	// GetPubkey returns the BLS public key of the validator.
 	GetPubkey() crypto.BLSPubkey
@@ -36,4 +36,5 @@ type Validator interface {
 	GetEffectiveBalance() math.Gwei
 	// IsActive checks if the validator is active at the given epoch.
 	IsActive(epoch math.Epoch) bool
+	Empty() SelfT
 }

--- a/mod/storage/pkg/deposit/store.go
+++ b/mod/storage/pkg/deposit/store.go
@@ -49,7 +49,9 @@ type KVStore[DepositT Deposit[DepositT]] struct {
 }
 
 // NewStore creates a new deposit store.
-func NewStore[DepositT Deposit[DepositT]](kvsp store.KVStoreService) *KVStore[DepositT] {
+func NewStore[DepositT Deposit[DepositT]](
+	kvsp store.KVStoreService,
+) *KVStore[DepositT] {
 	schemaBuilder := sdkcollections.NewSchemaBuilder(kvsp)
 	return &KVStore[DepositT]{
 		store: sdkcollections.NewMap(

--- a/mod/storage/pkg/deposit/store.go
+++ b/mod/storage/pkg/deposit/store.go
@@ -28,11 +28,7 @@ import (
 	sdkcollections "cosmossdk.io/collections"
 	"cosmossdk.io/core/store"
 	"github.com/berachain/beacon-kit/mod/storage/pkg/beacondb/encoding"
-	"github.com/berachain/beacon-kit/mod/storage/pkg/pruner"
 )
-
-// Deposit is a struct that holds the deposit information.
-var _ pruner.Prunable = (*KVStore[Deposit])(nil)
 
 const KeyDepositPrefix = "deposit"
 
@@ -47,13 +43,13 @@ func (p *KVStoreProvider) OpenKVStore(context.Context) store.KVStore {
 
 // KVStore is a simple KV store based implementation that assumes
 // the deposit indexes are tracked outside of the kv store.
-type KVStore[DepositT Deposit] struct {
+type KVStore[DepositT Deposit[DepositT]] struct {
 	store sdkcollections.Map[uint64, DepositT]
 	mu    sync.RWMutex
 }
 
 // NewStore creates a new deposit store.
-func NewStore[DepositT Deposit](kvsp store.KVStoreService) *KVStore[DepositT] {
+func NewStore[DepositT Deposit[DepositT]](kvsp store.KVStoreService) *KVStore[DepositT] {
 	schemaBuilder := sdkcollections.NewSchemaBuilder(kvsp)
 	return &KVStore[DepositT]{
 		store: sdkcollections.NewMap(

--- a/mod/storage/pkg/deposit/types.go
+++ b/mod/storage/pkg/deposit/types.go
@@ -26,7 +26,8 @@ import (
 )
 
 // Deposit is a struct that represents a deposit.
-type Deposit interface {
+type Deposit[DepositT any] interface {
 	constraints.SSZMarshallable
+	constraints.Empty[DepositT]
 	GetIndex() math.U64
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `Empty` methods for multiple types (`Deposit`, `Eth1Data`, `Fork`, `Validator`, `BeaconBlockHeader`, and more) to simplify instantiation of empty instances.
  
- **Improvements**
	- Simplified the `Empty` method in `BeaconBlock`, enhancing usability by removing the need for version parameters.
	- Enhanced type safety across several interfaces by introducing `constraints.Empty` requirements, ensuring type instances can be created in a default state.

- **Bug Fixes**
	- Streamlined test cases related to the `Empty` method, improving clarity and reducing redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->