### PR TITLE
test(consensus-types): add tests for MarshaSSZTo function

### DIFF
--- a/mod/consensus-types/pkg/types/attestation_data_test.go
+++ b/mod/consensus-types/pkg/types/attestation_data_test.go
@@ -89,6 +89,13 @@ func TestAttestationData_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
 				err = unmarshalled.UnmarshalSSZ(data)
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, &unmarshalled)
+
+				var buf []byte
+				buf, err = tc.data.MarshalSSZTo(buf)
+				require.NoError(t, err)
+
+				// The two byte slices should be equal
+				require.Equal(t, data, buf)
 			}
 		})
 	}

--- a/mod/consensus-types/pkg/types/block_test.go
+++ b/mod/consensus-types/pkg/types/block_test.go
@@ -128,6 +128,13 @@ func TestBeaconBlock_MarshalUnmarshalSSZ(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, block, unmarshalledBlock)
+
+	var buf []byte
+	buf, err = block.MarshalSSZTo(buf)
+	require.NoError(t, err)
+
+	// The two byte slices should be equal
+	require.Equal(t, sszBlock, buf)
 }
 
 func TestBeaconBlock_HashTreeRoot(t *testing.T) {

--- a/mod/consensus-types/pkg/types/body_test.go
+++ b/mod/consensus-types/pkg/types/body_test.go
@@ -129,6 +129,22 @@ func TestBeaconBlockBody_MarshalSSZ(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, data)
 }
+
+func TestBeaconBlockBody_MarshalSSZTo(t *testing.T) {
+	body := generateBeaconBlockBody()
+
+	data, err := body.MarshalSSZ()
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	var buf []byte
+	buf, err = body.MarshalSSZTo(buf)
+	require.NoError(t, err)
+
+	// The two byte slices should be equal
+	require.Equal(t, data, buf)
+}
+
 func TestBeaconBlockBody_GetTopLevelRoots(t *testing.T) {
 	body := generateBeaconBlockBody()
 	roots, err := body.GetTopLevelRoots()

--- a/mod/consensus-types/pkg/types/eth1data_test.go
+++ b/mod/consensus-types/pkg/types/eth1data_test.go
@@ -45,6 +45,13 @@ func TestEth1Data_Serialization(t *testing.T) {
 	err = unmarshalled.UnmarshalSSZ(data)
 	require.NoError(t, err)
 	require.Equal(t, original, &unmarshalled)
+
+	var buf []byte
+	buf, err = original.MarshalSSZTo(buf)
+	require.NoError(t, err)
+
+	// The two byte slices should be equal
+	require.Equal(t, data, buf)
 }
 
 func TestEth1Data_UnmarshalError(t *testing.T) {

--- a/mod/consensus-types/pkg/types/fork_test.go
+++ b/mod/consensus-types/pkg/types/fork_test.go
@@ -45,6 +45,13 @@ func TestFork_Serialization(t *testing.T) {
 	err = unmarshalled.UnmarshalSSZ(data)
 	require.NoError(t, err)
 	require.Equal(t, original, &unmarshalled)
+
+	var buf []byte
+	buf, err = original.MarshalSSZTo(buf)
+	require.NoError(t, err)
+
+	// The two byte slices should be equal
+	require.Equal(t, data, buf)
 }
 
 func TestFork_SizeSSZ(t *testing.T) {

--- a/mod/consensus-types/pkg/types/header_test.go
+++ b/mod/consensus-types/pkg/types/header_test.go
@@ -46,6 +46,13 @@ func TestBeaconBlockHeader_Serialization(t *testing.T) {
 	err = unmarshalled.UnmarshalSSZ(data)
 	require.NoError(t, err)
 	require.Equal(t, original, &unmarshalled)
+
+	var buf []byte
+	buf, err = original.MarshalSSZTo(buf)
+	require.NoError(t, err)
+
+	// The two byte slices should be equal
+	require.Equal(t, data, buf)
 }
 
 func TestBeaconBlockHeader_SizeSSZ(t *testing.T) {

--- a/mod/consensus-types/pkg/types/payload_test.go
+++ b/mod/consensus-types/pkg/types/payload_test.go
@@ -77,6 +77,13 @@ func TestExecutionPayload_Serialization(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, original, &unmarshalled)
+
+	var buf []byte
+	buf, err = original.MarshalSSZTo(buf)
+	require.NoError(t, err)
+
+	// The two byte slices should be equal
+	require.Equal(t, data, buf)
 }
 
 func TestExecutionPayload_SizeSSZ(t *testing.T) {

--- a/mod/consensus-types/pkg/types/slashing_info_test.go
+++ b/mod/consensus-types/pkg/types/slashing_info_test.go
@@ -83,6 +83,13 @@ func TestSlashingInfo_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
 				err = unmarshalled.UnmarshalSSZ(data)
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, &unmarshalled)
+
+				var buf []byte
+				buf, err = tc.data.MarshalSSZTo(buf)
+				require.NoError(t, err)
+
+				// The two byte slices should be equal
+				require.Equal(t, data, buf)
 			}
 		})
 	}

--- a/mod/consensus-types/pkg/types/validator_test.go
+++ b/mod/consensus-types/pkg/types/validator_test.go
@@ -683,6 +683,13 @@ func TestValidator_MarshalUnmarshalSSZ(t *testing.T) {
 					"Test case: %s",
 					tt.name,
 				)
+
+				var buf []byte
+				buf, err = tt.validator.MarshalSSZTo(buf)
+				require.NoError(t, err)
+
+				// The two byte slices should be equal
+				require.Equal(t, marshaled, buf)
 			}
 		})
 	}


### PR DESCRIPTION
Partially address #1190 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced serialization testing for various data structures, including `AttestationData`, `BeaconBlock`, and `Eth1Data`.
  - Added tests to ensure both marshalling and unmarshalling processes produce consistent results across different data types.

- **Bug Fixes**
  - Improved robustness of serialization tests by ensuring output matches expected serialized data.

- **Documentation**
  - Expanded test coverage with new test cases to validate serialization functionality.

- **Refactor**
  - Streamlined the testing process for serialization methods across multiple data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->