### PR TITLE
feat(staking): limit valset by config

### DIFF
--- a/examples/berad/go.mod
+++ b/examples/berad/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/ferranbt/fastssz v0.1.4-0.20240629094022-eac385e6ee79
 	github.com/go-faster/xor v1.0.0
 	github.com/karalabe/ssz v0.2.1-0.20240724074312-3d1ff7a6f7c4
-	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
 	golang.org/x/sync v0.8.0
 )
 

--- a/examples/berad/go.sum
+++ b/examples/berad/go.sum
@@ -198,8 +198,6 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
-github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/examples/berad/pkg/chain-spec/berachain.go
+++ b/examples/berad/pkg/chain-spec/berachain.go
@@ -31,6 +31,8 @@ type BeraChainSpec struct {
 		uint64,
 		any,
 	]
-	// BGTContractAddress
+	// BGTContractAddress is the address of the BGT contract.
 	BGTContractAddress [20]byte `mapstructure:"bgt-contract-address"`
+	// MaxCommitteeSize is the maximum size of the committee.
+	MaxCommitteeSize uint64 `mapstructure:"max-committee-size"`
 }

--- a/examples/berad/pkg/state-transition/state_processor.go
+++ b/examples/berad/pkg/state-transition/state_processor.go
@@ -343,7 +343,14 @@ func (sp *StateProcessor[
 	} else if err = sp.processRandaoMixesReset(st); err != nil {
 		return nil, err
 	}
-	return sp.processSyncCommitteeUpdates(st)
+	valUpdates, err := sp.processSyncCommitteeUpdates(st)
+	if err != nil {
+		return nil, err
+	}
+	if err = sp.processForcedWithdrawals(st, valUpdates); err != nil {
+		return nil, err
+	}
+	return valUpdates, nil
 }
 
 // processBlockHeader processes the header and ensures it matches the local

--- a/examples/berad/pkg/state-transition/state_processor_committee.go
+++ b/examples/berad/pkg/state-transition/state_processor_committee.go
@@ -40,6 +40,7 @@ func (sp *StateProcessor[
 
 	// Process the first sp.cs.MaxCommitteeSize validators.
 	for i, val := range vals {
+		//#nosec G701 // If this overflows, your valset is too big anyways.
 		if i < int(sp.cs.MaxCommitteeSize) {
 			validatorUpdates[i] = &transition.ValidatorUpdate{
 				Pubkey:           val.GetPubkey(),

--- a/examples/berad/pkg/state-transition/state_processor_committee.go
+++ b/examples/berad/pkg/state-transition/state_processor_committee.go
@@ -22,7 +22,6 @@ package transition
 
 import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/transition"
-	"github.com/sourcegraph/conc/iter"
 )
 
 // processSyncCommitteeUpdates processes the sync committee updates.
@@ -36,14 +35,24 @@ func (sp *StateProcessor[
 		return nil, err
 	}
 
-	return iter.MapErr(
-		vals,
-		func(val *ValidatorT) (*transition.ValidatorUpdate, error) {
-			v := (*val)
-			return &transition.ValidatorUpdate{
-				Pubkey:           v.GetPubkey(),
-				EffectiveBalance: v.GetEffectiveBalance(),
-			}, nil
-		},
-	)
+	// Initialize the validator updates slice.
+	validatorUpdates := make(transition.ValidatorUpdates, len(vals))
+
+	// Process the first sp.cs.MaxCommitteeSize validators.
+	for i, val := range vals {
+		if i < int(sp.cs.MaxCommitteeSize) {
+			validatorUpdates[i] = &transition.ValidatorUpdate{
+				Pubkey:           val.GetPubkey(),
+				EffectiveBalance: val.GetEffectiveBalance(),
+			}
+		} else {
+			// For extra validators, set the effective balance to 0.
+			validatorUpdates[i] = &transition.ValidatorUpdate{
+				Pubkey:           val.GetPubkey(),
+				EffectiveBalance: 0,
+			}
+		}
+	}
+
+	return validatorUpdates, nil
 }

--- a/examples/berad/pkg/state-transition/state_processor_staking.go
+++ b/examples/berad/pkg/state-transition/state_processor_staking.go
@@ -25,6 +25,7 @@ import (
 	gethprimitives "github.com/berachain/beacon-kit/mod/geth-primitives"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/transition"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/version"
 	"github.com/davecgh/go-spew/spew"
 )
@@ -264,6 +265,17 @@ func (sp *StateProcessor[
 	}
 
 	return st.SetNextWithdrawalValidatorIndex(nextValidatorIndex)
+}
+
+// processForcedWithdrawals is a helper function to process forced withdrawals.
+func (sp *StateProcessor[
+	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _,
+]) processForcedWithdrawals(
+	_ BeaconStateT,
+	_ transition.ValidatorUpdates,
+) error {
+	// TODO: Implement this function.
+	return nil
 }
 
 // TODO: This is exposed for the PayloadBuilder and probably should be done in a


### PR DESCRIPTION
no longer uses the giga library bc idk if i can iter w index but code cleaner?

will implement forced withdrawals in next PR + will do some statedb updates there as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new field, `MaxCommitteeSize`, in the BeraChainSpec for enhanced configuration options.
	- Added a helper function for handling forced withdrawals in state processing.
  
- **Bug Fixes**
	- Improved error handling and control flow in the state transition processing, ensuring better error management.

- **Documentation**
	- Enhanced clarity of comments in the BeraChainSpec struct for better understanding.
  
- **Refactor**
	- Refined the processSyncCommitteeUpdates function to enhance readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->