### PR TITLE
Add initial SSZ parity and benchmark tests for uint64

### DIFF
--- a/mod/consensus-types/pkg/types/ssz_test.go
+++ b/mod/consensus-types/pkg/types/ssz_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"testing"
+	"bytes"
+	"encoding/binary"
+	"math"
+	"math/rand"
+	"time"
+)
+
+func TestUint64SSZSerialize(t *testing.T) {
+	testCases := []uint64{
+		0,
+		1,
+		math.MaxUint64,
+		rand.Uint64(),
+	}
+
+	for _, tc := range testCases {
+		serialized, err := SSZSerialize(tc)
+		if err != nil {
+			t.Errorf("Failed to serialize uint64 %d: %v", tc, err)
+			continue
+		}
+
+		expected := make([]byte, 8)
+		binary.LittleEndian.PutUint64(expected, tc)
+
+		if !bytes.Equal(serialized, expected) {
+			t.Errorf("Serialization mismatch for uint64 %d: got %v, want %v", tc, serialized, expected)
+		}
+	}
+}
+
+func TestUint64SSZDeserialize(t *testing.T) {
+	testCases := []uint64{
+		0,
+		1,
+		math.MaxUint64,
+		rand.Uint64(),
+	}
+
+	for _, tc := range testCases {
+		serialized := make([]byte, 8)
+		binary.LittleEndian.PutUint64(serialized, tc)
+
+		var deserialized uint64
+		err := SSZDeserialize(serialized, &deserialized)
+		if err != nil {
+			t.Errorf("Failed to deserialize uint64 %d: %v", tc, err)
+			continue
+		}
+
+		if deserialized != tc {
+			t.Errorf("Deserialization mismatch for uint64: got %d, want %d", deserialized, tc)
+		}
+	}
+}
+
+func BenchmarkUint64SSZSerialize(b *testing.B) {
+	value := rand.Uint64()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := SSZSerialize(value)
+		if err != nil {
+			b.Fatalf("Failed to serialize uint64: %v", err)
+		}
+	}
+}
+
+func BenchmarkUint64SSZDeserialize(b *testing.B) {
+	value := rand.Uint64()
+	serialized, _ := SSZSerialize(value)
+	var deserialized uint64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := SSZDeserialize(serialized, &deserialized)
+		if err != nil {
+			b.Fatalf("Failed to deserialize uint64: %v", err)
+		}
+	}
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}


### PR DESCRIPTION
This PR addresses part of issue #1132 by adding initial parity and benchmark tests for SSZ serialization and deserialization of uint64 values.

Changes made:
1. Created a new file `mod/consensus-types/pkg/types/ssz_test.go`
2. Added tests for uint64 SSZ serialization
3. Added tests for uint64 SSZ deserialization
4. Added benchmarks for uint64 SSZ serialization and deserialization

These tests cover the following tasks from the issue:
- [x] simple type - uint64 (serializer spec parity and benchmark tests)
- [x] simple type - uint64 (deserializer spec parity and benchmark tests)

Next steps:
- Add similar tests for other simple types (bool, uint8)
- Implement tests for fixed types, composite structs, and variable length slices/arrays
- Add tests for full block serialization/deserialization
- Implement bijective property tests

This PR is a starting point and can be expanded upon to cover more types and scenarios.