### PR TITLE
chore(docs): Add berachain snapshots and fix a41 link

### DIFF
--- a/testing/networks/80084/snapshots.md
+++ b/testing/networks/80084/snapshots.md
@@ -2,12 +2,14 @@
 
 The following are snapshots provided by the community.
 
-| Provider         | URL                                                                                        | Database  |
-| ---------------- | ------------------------------------------------------------------------------------------ | --------- |
-| Imperator        | [https://www.imperator.co/services/chain-services/testnets/bera-v2](https://www.imperator.co/services/chain-services/testnets/bera-v2)                          | goleveldb |
-| Blacknodes       | [https://services.blacknodes.net/Berachain-V2/](https://services.blacknodes.net/Berachain-V2/)                                              | pebbledb  |
-| Contribution DAO | [https://services.contributiondao.com/testnet/berachain-v2/snapshots](https://services.contributiondao.com/testnet/berachain-v2/snapshots)                        | pebbledb  |
-| Staketab         | [https://services.staketab.org/docs/beacon-testnet/snapshot](https://services.staketab.org/docs/beacon-testnet/snapshot)                                 | pebbledb  |
-| A41              | [https://services.staketab.org/docs/beacon-testnet/snapshot](https://services.staketab.org/docs/beacon-testnet/snapshot)                                 | pebbledb  |
-| Synergy Nodes    | [https://synergynodes.com/service/berachain-v2-testnet](https://synergynodes.com/service/berachain-v2-testnet)                                      | pebbledb  |
-| L0vd services    | [https://chain-services.l0vd.com/testnets/berachain_v2/snapshot#sync-from-snapshot-pebbledb](https://chain-services.l0vd.com/testnets/berachain_v2/snapshot#sync-from-snapshot-pebbledb) | pebbledb  |
+| Provider                                             | URL                                                                                                                                                                                      | Database  |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| Berachain Foundation (archive snapshots)             | [https://storage.googleapis.com/bartio-snapshot/](https://storage.googleapis.com/bartio-snapshot/)                                                                                       | pebbledb  |
+| Berachain Foundation - EU Hosted (archive snapshots) | [https://storage.googleapis.com/bartio-snapshot-eu/](https://storage.googleapis.com/bartio-snapshot-eu/)                                                                                 | pebbledb  |
+| Imperator                                            | [https://www.imperator.co/services/chain-services/testnets/bera-v2](https://www.imperator.co/services/chain-services/testnets/bera-v2)                                                   | goleveldb |
+| Blacknodes                                           | [https://services.blacknodes.net/Berachain-V2/](https://services.blacknodes.net/Berachain-V2/)                                                                                           | pebbledb  |
+| Contribution DAO                                     | [https://services.contributiondao.com/testnet/berachain-v2/snapshots](https://services.contributiondao.com/testnet/berachain-v2/snapshots)                                               | pebbledb  |
+| Staketab                                             | [https://services.staketab.org/docs/beacon-testnet/snapshot](https://services.staketab.org/docs/beacon-testnet/snapshot)                                                                 | pebbledb  |
+| A41                                                  | [https://berachain.snapshot.a41.io/](https://berachain.snapshot.a41.io)                                                                                                                  | pebbledb  |
+| Synergy Nodes                                        | [https://synergynodes.com/service/berachain-v2-testnet](https://synergynodes.com/service/berachain-v2-testnet)                                                                           | pebbledb  |
+| L0vd services                                        | [https://chain-services.l0vd.com/testnets/berachain_v2/snapshot#sync-from-snapshot-pebbledb](https://chain-services.l0vd.com/testnets/berachain_v2/snapshot#sync-from-snapshot-pebbledb) | pebbledb  |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new entries for "Berachain Foundation" and "Berachain Foundation - EU Hosted" in the snapshot documentation, providing direct URLs for archive snapshots.
- **Documentation**
	- Enhanced the snapshot table for improved access to snapshot data, benefiting users and developers interacting with the Berachain network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->