### PR TITLE
chore(cli): rename comment/description for start cli

### DIFF
--- a/mod/cli/pkg/commands/server/start.go
+++ b/mod/cli/pkg/commands/server/start.go
@@ -89,8 +89,8 @@ func StartCmdWithOptions[
 	//nolint:lll // its okay.
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "Run the full node",
-		Long: `Run the full node application with CometBFT in process. By
+		Short: "Run the node",
+		Long: `Run the node application with CometBFT in process. By
 default, the application will run with CometBFT in process.
 
 Pruning options can be provided via the '--pruning' flag or alternatively with '--pruning-keep-recent', and


### PR DESCRIPTION
A node has multiple modes:
- archive
- fullnode
- validator

This PR will rename the beacond start description/comment to avoid any confusion because full node is onf of the modes mentioned previously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated command descriptions for improved clarity and brevity in the node startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->