### PR TITLE
chore(cometBFTService): drop redundant context assignemets

### DIFF
--- a/mod/consensus/pkg/cometbft/service/abci.go
+++ b/mod/consensus/pkg/cometbft/service/abci.go
@@ -102,11 +102,6 @@ func (s *Service[LoggerT]) InitChain(
 		return nil, errors.New("finalizeBlockState is nil")
 	}
 
-	// add block gas meter for any genesis transactions (allow infinite gas)
-	s.finalizeBlockState.SetContext(
-		s.finalizeBlockState.Context(),
-	)
-
 	res, err := s.initChainer(s.finalizeBlockState.Context(), req)
 	if err != nil {
 		return nil, err
@@ -233,8 +228,6 @@ func (s *Service[LoggerT]) PrepareProposal(
 		),
 	)
 
-	s.prepareProposalState.SetContext(s.prepareProposalState.Context())
-
 	blkBz, sidecarsBz, err := s.Middleware.PrepareProposal(
 		s.prepareProposalState.Context(), &types.SlotData[
 			*ctypes.AttestationData,
@@ -330,7 +323,6 @@ func (s *Service[LoggerT]) internalFinalizeBlock(
 	if s.finalizeBlockState == nil {
 		return nil, errors.New("finalizeBlockState is nil")
 	}
-	s.finalizeBlockState.SetContext(s.finalizeBlockState.Context())
 
 	// First check for an abort signal after beginBlock, as it's the first place
 	// we spend any significant amount of time.
@@ -340,10 +332,6 @@ func (s *Service[LoggerT]) internalFinalizeBlock(
 	default:
 		// continue
 	}
-
-	s.finalizeBlockState.SetContext(
-		s.finalizeBlockState.Context(),
-	)
 
 	// Iterate over all raw transactions in the proposal and attempt to execute
 	// them, gathering the execution results.


### PR DESCRIPTION
It seems to me all the `s.*State.SetContext(s.*State.Context())` are no-ops.
Dropping them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined context-setting operations in key methods to enhance code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->