### PR TITLE
chore(cometBFTService): some more minor cleanups

### DIFF
--- a/mod/consensus/pkg/cometbft/service/options.go
+++ b/mod/consensus/pkg/cometbft/service/options.go
@@ -81,12 +81,3 @@ func SetChainID[
 ](chainID string) func(*Service[LoggerT]) {
 	return func(s *Service[LoggerT]) { s.chainID = chainID }
 }
-
-func (s *Service[_]) SetName(name string) {
-	s.name = name
-}
-
-// SetVersion sets the application's version string.
-func (s *Service[_]) SetVersion(v string) {
-	s.version = v
-}

--- a/mod/consensus/pkg/cometbft/service/service.go
+++ b/mod/consensus/pkg/cometbft/service/service.go
@@ -87,7 +87,6 @@ func NewService[
 	logger LoggerT,
 	db dbm.DB,
 	middleware MiddlewareI,
-	loadLatest bool,
 	cmtCfg *cmtcfg.Config,
 	cs common.ChainSpec,
 	options ...func(*Service[LoggerT]),
@@ -102,9 +101,9 @@ func NewService[
 		Middleware: middleware,
 		cmtCfg:     cmtCfg,
 		paramStore: params.NewConsensusParamsStore(cs),
+		version:    version.Version,
 	}
 
-	s.SetVersion(version.Version)
 	s.MountStore(storeKey, storetypes.StoreTypeIAVL)
 
 	for _, option := range options {
@@ -115,11 +114,9 @@ func NewService[
 		s.sm.CommitMultiStore().SetInterBlockCache(s.interBlockCache)
 	}
 
-	// Load the s.
-	if loadLatest {
-		if err := s.sm.LoadLatestVersion(); err != nil {
-			panic(err)
-		}
+	// Load latest height, once all stores have been set
+	if err := s.sm.LoadLatestVersion(); err != nil {
+		panic(err)
 	}
 
 	return s

--- a/mod/node-core/pkg/components/cometbft_service.go
+++ b/mod/node-core/pkg/components/cometbft_service.go
@@ -36,7 +36,7 @@ func ProvideCometBFTService[
 	LoggerT log.AdvancedLogger[LoggerT],
 ](
 	logger LoggerT,
-	storeKey **storetypes.KVStoreKey,
+	storeKey *storetypes.KVStoreKey,
 	abciMiddleware cometbft.MiddlewareI,
 	db dbm.DB,
 	cmtCfg *cmtcfg.Config,
@@ -44,11 +44,10 @@ func ProvideCometBFTService[
 	chainSpec common.ChainSpec,
 ) *cometbft.Service[LoggerT] {
 	return cometbft.NewService(
-		*storeKey,
+		storeKey,
 		logger,
 		db,
 		abciMiddleware,
-		true,
 		cmtCfg,
 		chainSpec,
 		builder.DefaultServiceOptions[LoggerT](appOpts)...,

--- a/mod/node-core/pkg/components/depinject.go
+++ b/mod/node-core/pkg/components/depinject.go
@@ -31,15 +31,15 @@ import (
 //nolint:gochecknoglobals // storeKey is a singleton.
 var storeKey = storetypes.NewKVStoreKey("beacon")
 
-func ProvideKVStoreKey() **storetypes.KVStoreKey {
-	return &storeKey
+func ProvideKVStoreKey() *storetypes.KVStoreKey {
+	return storeKey
 }
 
 func ProvideKVStoreService(
-	storeKey **storetypes.KVStoreKey,
+	storeKey *storetypes.KVStoreKey,
 ) store.KVStoreService {
 	// skips modules that have no store
-	return kvStoreService{key: *storeKey}
+	return kvStoreService{key: storeKey}
 }
 
 func NewKVStoreService(storeKey *storetypes.KVStoreKey) store.KVStoreService {


### PR DESCRIPTION
I have collected here some minor cleanups around CometBFT service:

1. dropped `loadLatest bool` since I believe we must call `LoadLatestVersion()` in order to initialize the stores. Failing of doing that causes a panic
2. dropped `SetName` since it is not called and name is set in service constructor
3. dropped `SetVersion` since it's simple the assignment of a service attribute that can be done inline
4. modified `StoreKeyServiceProvider` to return a pointer rather than a pointer to a pointer. It's important to avoid copying the key, but passing around the pointer should be enough. All consumers of the key deference the double pointer.

I collected the changes together in the interest of reducing the number of PRs. Happy to further split them if reviewers require it.