### PR TITLE
bet(testnet/config): Update app.toml according to the new releases

### DIFF
--- a/testing/networks/80084/app.toml
+++ b/testing/networks/80084/app.toml
@@ -101,111 +101,6 @@ statsd-addr = ""
 datadog-hostname = ""
 
 ###############################################################################
-###                           API Configuration                             ###
-###############################################################################
-
-[api]
-
-# Enable defines if the API server should be enabled.
-enable = false
-
-# Swagger defines if swagger documentation should automatically be registered.
-swagger = false
-
-# Address defines the API server to listen on.
-address = "tcp://localhost:1317"
-
-# MaxOpenConnections defines the number of maximum open connections.
-max-open-connections = 1000
-
-# RPCReadTimeout defines the CometBFT RPC read timeout (in seconds).
-rpc-read-timeout = 10
-
-# RPCWriteTimeout defines the CometBFT RPC write timeout (in seconds).
-rpc-write-timeout = 0
-
-# RPCMaxBodyBytes defines the CometBFT maximum request body (in bytes).
-rpc-max-body-bytes = 1000000
-
-# EnableUnsafeCORS defines if CORS should be enabled (unsafe - use it at your own risk).
-enabled-unsafe-cors = false
-
-###############################################################################
-###                           gRPC Configuration                            ###
-###############################################################################
-
-[grpc]
-
-# Enable defines if the gRPC server should be enabled.
-enable = true
-
-# Address defines the gRPC server address to bind to.
-address = "localhost:9090"
-
-# MaxRecvMsgSize defines the max message size in bytes the server can receive.
-# The default value is 10MB.
-max-recv-msg-size = "10485760"
-
-# MaxSendMsgSize defines the max message size in bytes the server can send.
-# The default value is math.MaxInt32.
-max-send-msg-size = "2147483647"
-
-###############################################################################
-###                        State Sync Configuration                         ###
-###############################################################################
-
-# State sync snapshots allow other nodes to rapidly join the network without replaying historical
-# blocks, instead downloading and applying a snapshot of the application state at a given height.
-[state-sync]
-
-# snapshot-interval specifies the block interval at which local state sync snapshots are
-# taken (0 to disable).
-snapshot-interval = 0
-
-# snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
-snapshot-keep-recent = 2
-
-###############################################################################
-###                              State Streaming                            ###
-###############################################################################
-
-# Streaming allows nodes to stream state to external systems.
-[streaming]
-
-# streaming.abci specifies the configuration for the ABCI Listener streaming service.
-[streaming.abci]
-
-# List of kv store keys to stream out via gRPC.
-# The store key names MUST match the module's StoreKey name.
-#
-# Example:
-# ["acc", "bank", "gov", "staking", "mint"[,...]]
-# ["*"] to expose all keys.
-keys = []
-
-# The plugin name used for streaming via gRPC.
-# Streaming is only enabled if this is set.
-# Supported plugins: abci
-plugin = ""
-
-# stop-node-on-err specifies whether to stop the node on message delivery error.
-stop-node-on-err = true
-
-###############################################################################
-###                         Mempool                                         ###
-###############################################################################
-
-[mempool]
-# Setting max-txs to 0 will allow for a unbounded amount of transactions in the mempool.
-# Setting max_txs to negative 1 (-1) will disable transactions from being inserted into the mempool (no-op mempool).
-# Setting max_txs to a positive number (> 0) will limit the number of transactions in the mempool, by the specified amount.
-#
-# Note, this configuration only applies to SDK built-in app-side mempool
-# implementations.
-max-txs = -1
-
-
-###############################################################################
 ###                                BeaconKit                                ###
 ###############################################################################
 
@@ -223,7 +118,7 @@ rpc-timeout = "900ms"
 rpc-startup-check-interval = "3s"
 
 # Interval for the JWT refresh.
-rpc-jwt-refresh-interval = "30s"
+rpc-jwt-refresh-interval = "20s"
 
 # Path to the execution client JWT-secret
 jwt-secret-path = "./jwt.hex"
@@ -267,3 +162,20 @@ graffiti = ""
 # EnableOptimisticPayloadBuilds enables building the next block's payload optimistically in
 # process-proposal to allow for the execution client to have more time to assemble the block.
 enable-optimistic-payload-builds = "true"
+
+[beacon-kit.block-store-service]
+# Enabled determines if the block store service is enabled.
+enabled = "false"
+
+# AvailabilityWindow is the number of slots to keep in the store.
+availability-window = "8192"
+
+[beacon-kit.node-api]
+# Enabled determines if the node API is enabled.
+enabled = "false"
+
+# Address is the address to bind the node API to.
+address = "0.0.0.0:3500"
+
+# Logging determines if the node API logging is enabled.
+logging = "false"


### PR DESCRIPTION
Since v0.2.0-alpha.5 the app.toml file has a lof of deprecated config. This PR will update the testnet config to avoid any confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration sections for `beacon-kit.block-store-service` and `beacon-kit.node-api`, both disabled by default.
  
- **Changes**
	- Updated `rpc-jwt-refresh-interval` from "30s" to "20s".
  
- **Removed Features**
	- Significant reduction in configuration options, including API, state sync, streaming, and mempool settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->