### PR TITLE
chore(encoding): dropped go-json direct dependency

### DIFF
--- a/mod/primitives/go.mod
+++ b/mod/primitives/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/berachain/beacon-kit/mod/chain-spec v0.0.0-20240703145037-b5612ab256db
 	github.com/berachain/beacon-kit/mod/errors v0.0.0-20240610210054-bfdc14c4013c
 	github.com/ferranbt/fastssz v0.1.4-0.20240629094022-eac385e6ee79
-	github.com/goccy/go-json v0.10.3
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/holiman/uint256 v1.3.1
 	github.com/karalabe/ssz v0.2.1-0.20240724074312-3d1ff7a6f7c4

--- a/mod/primitives/go.sum
+++ b/mod/primitives/go.sum
@@ -17,8 +17,6 @@ github.com/getsentry/sentry-go v0.28.1 h1:zzaSm/vHmGllRM6Tpx1492r0YDzauArdBfkJRt
 github.com/getsentry/sentry-go v0.28.1/go.mod h1:1fQZ+7l7eeJ3wYi82q5Hg8GqAPgefRq+FP/QhafYVgg=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
-github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
-github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=

--- a/mod/primitives/pkg/encoding/json/json.go
+++ b/mod/primitives/pkg/encoding/json/json.go
@@ -33,16 +33,10 @@ type Marshaler = json.Marshaler
 // that can unmarshal a JSON description of themselves.
 type Unmarshaler = json.Unmarshaler
 
-// Marshal is a wrapper for gojson.Marshal, which provides high-performance JSON
-// encoding.
 var Marshal = json.Marshal
 
-// MarshalIndent is a wrapper for gojson.MarshalIndent, which provides
-// high-performance JSON encoding with indentation.
 var MarshalIndent = json.MarshalIndent
 
-// Unmarshal is a wrapper for gojson.Unmarshal, which provides high-performance
-// JSON decoding.
 var Unmarshal = json.Unmarshal
 
 // RawMessage is an alias for json.RawMessage, represensting a raw encoded JSON

--- a/mod/primitives/pkg/encoding/json/json.go
+++ b/mod/primitives/pkg/encoding/json/json.go
@@ -23,29 +23,27 @@ package json
 
 import (
 	"encoding/json"
-
-	gojson "github.com/goccy/go-json"
 )
 
 // Marshaler is the interface implemented by types that
 // can marshal themselves into valid JSON.
-type Marshaler = gojson.Marshaler
+type Marshaler = json.Marshaler
 
 // Unmarshaler is the interface implemented by types
 // that can unmarshal a JSON description of themselves.
-type Unmarshaler = gojson.Unmarshaler
+type Unmarshaler = json.Unmarshaler
 
 // Marshal is a wrapper for gojson.Marshal, which provides high-performance JSON
 // encoding.
-var Marshal = gojson.Marshal
+var Marshal = json.Marshal
 
 // MarshalIndent is a wrapper for gojson.MarshalIndent, which provides
 // high-performance JSON encoding with indentation.
-var MarshalIndent = gojson.MarshalIndent
+var MarshalIndent = json.MarshalIndent
 
 // Unmarshal is a wrapper for gojson.Unmarshal, which provides high-performance
 // JSON decoding.
-var Unmarshal = gojson.Unmarshal
+var Unmarshal = json.Unmarshal
 
 // RawMessage is an alias for json.RawMessage, represensting a raw encoded JSON
 // value. It implements Marshaler and Unmarshaler and can be used to delay JSON


### PR DESCRIPTION
Replaced `go-json` with `encoding/json` library.
Note that `go-json` is still an indirect dependency, but only an indirect dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Transitioned to using the standard Go JSON encoding and decoding functionalities, enhancing compatibility and performance.

- **Bug Fixes**
	- Removed unnecessary dependency on the `gojson` library, streamlining the module's requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->