### PR TITLE
chore(consensus-types): fixed proposer index type

### DIFF
--- a/mod/consensus-types/pkg/types/block.go
+++ b/mod/consensus-types/pkg/types/block.go
@@ -34,7 +34,7 @@ type BeaconBlock struct {
 	// Slot represents the position of the block in the chain.
 	Slot math.Slot `json:"slot"`
 	// ProposerIndex is the index of the validator who proposed the block.
-	ProposerIndex math.Slot `json:"proposer_index"`
+	ProposerIndex math.ValidatorIndex `json:"proposer_index"`
 	// ParentRoot is the hash of the parent block
 	ParentRoot common.Root `json:"parent_root"`
 	// StateRoot is the hash of the state at the block.


### PR DESCRIPTION
Just picked the right type alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `BeaconBlock` structure to improve the representation of the proposer index, enhancing clarity and accuracy in block proposals.
- **Bug Fixes**
	- Corrected the method signature for `NewWithVersion` to align with the new type for the proposer index, ensuring proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->