### PR TITLE
chore(primitives): `hex.String` basic cleanup

### DIFF
--- a/mod/primitives/pkg/bytes/b.go
+++ b/mod/primitives/pkg/bytes/b.go
@@ -50,6 +50,6 @@ func (b *Bytes) UnmarshalText(input []byte) error {
 }
 
 // String returns the hex encoding of b.
-func (b Bytes) String() hex.String {
-	return hex.FromBytes(b)
+func (b Bytes) String() string {
+	return hex.FromBytes(b).Unwrap()
 }

--- a/mod/primitives/pkg/bytes/b_test.go
+++ b/mod/primitives/pkg/bytes/b_test.go
@@ -89,7 +89,7 @@ func TestMustFromHex(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
-		expected    bytes.Bytes
+		expected    []byte
 		shouldPanic bool
 	}{
 		{
@@ -112,21 +112,19 @@ func TestMustFromHex(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if test.shouldPanic {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf(
-							"MustFromHex did not panic for input: %s",
-							test.input,
-						)
-					}
-				}()
-				_ = hex.MustToBytes(test.input)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				res []byte
+				f   = func() {
+					res = hex.MustToBytes(tt.input)
+				}
+			)
+			if tt.shouldPanic {
+				require.Panics(t, f)
 			} else {
-				result := hex.MustToBytes(test.input)
-				require.True(t, stdbytes.Equal(result, test.expected), "Test case %s", test.name)
+				require.NotPanics(t, f)
+				require.Equal(t, tt.expected, res)
 			}
 		})
 	}
@@ -1427,13 +1425,7 @@ func TestBytes_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.input.String()
-			require.Equal(
-				t,
-				tt.expected,
-				result,
-				"Test case: %s",
-				tt.name,
-			)
+			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/mod/primitives/pkg/bytes/b_test.go
+++ b/mod/primitives/pkg/bytes/b_test.go
@@ -1430,7 +1430,7 @@ func TestBytes_String(t *testing.T) {
 			require.Equal(
 				t,
 				tt.expected,
-				string(result),
+				result,
 				"Test case: %s",
 				tt.name,
 			)

--- a/mod/primitives/pkg/common/consensus.go
+++ b/mod/primitives/pkg/common/consensus.go
@@ -84,7 +84,7 @@ func NewRootFromBytes(input []byte) Root {
 }
 
 // Hex converts a root to a hex string.
-func (r Root) Hex() string { return string(hex.EncodeBytes(r[:])) }
+func (r Root) Hex() string { return hex.FromBytes(r[:]).Unwrap() }
 
 // String implements the stringer interface and is used also by the logger when
 // doing full logging into a file.

--- a/mod/primitives/pkg/common/execution.go
+++ b/mod/primitives/pkg/common/execution.go
@@ -55,7 +55,7 @@ func NewExecutionHashFromHex(input string) ExecutionHash {
 }
 
 // Hex converts a hash to a hex string.
-func (h ExecutionHash) Hex() string { return string(hex.EncodeBytes(h[:])) }
+func (h ExecutionHash) Hex() string { return hex.FromBytes(h[:]).Unwrap() }
 
 // String implements the stringer interface and is used also by the logger when
 // doing full logging into a file.

--- a/mod/primitives/pkg/encoding/hex/format.go
+++ b/mod/primitives/pkg/encoding/hex/format.go
@@ -20,9 +20,12 @@
 
 package hex
 
+import "strings"
+
 // has0xPrefix returns true if s has a 0x prefix.
 func has0xPrefix[T []byte | string](s T) bool {
-	return len(s) >= prefixLen && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')
+	return len(s) >= prefixLen &&
+		strings.ToLower(string(s[:prefixLen])) == prefix
 }
 
 // ensure0xPrefix ensures that s has a 0x prefix. If it doesn't, it adds it.

--- a/mod/primitives/pkg/encoding/hex/format.go
+++ b/mod/primitives/pkg/encoding/hex/format.go
@@ -29,9 +29,9 @@ func ensure0xPrefix[T []byte | string](s T) T {
 	}
 	switch v := any(s).(type) {
 	case string:
-		return T("0x" + v)
+		return T(string(prefix) + v)
 	case []byte:
-		return T(append([]byte("0x"), v...))
+		return T(append([]byte(prefix), v...))
 	default:
 		return s
 	}

--- a/mod/primitives/pkg/encoding/hex/format.go
+++ b/mod/primitives/pkg/encoding/hex/format.go
@@ -20,17 +20,11 @@
 
 package hex
 
-import "strings"
-
-// has0xPrefix returns true if s has a 0x prefix.
-func has0xPrefix[T []byte | string](s T) bool {
-	return len(s) >= prefixLen &&
-		strings.ToLower(string(s[:prefixLen])) == prefix
-}
+import "errors"
 
 // ensure0xPrefix ensures that s has a 0x prefix. If it doesn't, it adds it.
 func ensure0xPrefix[T []byte | string](s T) T {
-	if has0xPrefix(s) {
+	if _, err := IsValidHex(s); err == nil {
 		return s
 	}
 	switch v := any(s).(type) {
@@ -59,13 +53,13 @@ func isQuotedString[T []byte | string](input T) bool {
 
 // formatAndValidateText validates the input text for a hex string.
 func formatAndValidateText(input []byte) ([]byte, error) {
-	if len(input) == 0 {
+	input, err := IsValidHex(input)
+	if errors.Is(err, ErrEmptyString) {
 		return nil, nil // empty strings are allowed
+	} else if err != nil {
+		return nil, err
 	}
-	if !has0xPrefix(input) {
-		return nil, ErrMissingPrefix
-	}
-	input = input[prefixLen:]
+
 	if len(input)%2 != 0 {
 		return nil, ErrOddLength
 	}
@@ -74,15 +68,11 @@ func formatAndValidateText(input []byte) ([]byte, error) {
 
 // formatAndValidateNumber checks the input text for a hex number.
 func formatAndValidateNumber[T []byte | string](input T) (T, error) {
-	// realistically, this shouldn't rarely error if called on
-	// unwrapped hex.String
-	if len(input) == 0 {
-		return *new(T), ErrEmptyString
+	input, err := IsValidHex(input)
+	if err != nil {
+		return *new(T), err
 	}
-	if !has0xPrefix(input) {
-		return *new(T), ErrMissingPrefix
-	}
-	input = input[prefixLen:]
+
 	if len(input) == 0 {
 		return *new(T), ErrEmptyNumber
 	}

--- a/mod/primitives/pkg/encoding/hex/format.go
+++ b/mod/primitives/pkg/encoding/hex/format.go
@@ -22,7 +22,7 @@ package hex
 
 // has0xPrefix returns true if s has a 0x prefix.
 func has0xPrefix[T []byte | string](s T) bool {
-	return len(s) >= 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')
+	return len(s) >= prefixLen && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')
 }
 
 // ensure0xPrefix ensures that s has a 0x prefix. If it doesn't, it adds it.
@@ -62,7 +62,7 @@ func formatAndValidateText(input []byte) ([]byte, error) {
 	if !has0xPrefix(input) {
 		return nil, ErrMissingPrefix
 	}
-	input = input[2:]
+	input = input[prefixLen:]
 	if len(input)%2 != 0 {
 		return nil, ErrOddLength
 	}
@@ -79,7 +79,7 @@ func formatAndValidateNumber[T []byte | string](input T) (T, error) {
 	if !has0xPrefix(input) {
 		return *new(T), ErrMissingPrefix
 	}
-	input = input[2:]
+	input = input[prefixLen:]
 	if len(input) == 0 {
 		return *new(T), ErrEmptyNumber
 	}

--- a/mod/primitives/pkg/encoding/hex/hex_test.go
+++ b/mod/primitives/pkg/encoding/hex/hex_test.go
@@ -74,7 +74,8 @@ func TestNewStringStrictInvariants(t *testing.T) {
 				require.Error(t, err, "Test case: %s", test.name)
 			} else {
 				require.NoError(t, err, "Test case: %s", test.name)
-				verifyInvariants(t, "NewStringStrict()", str)
+				_, err = hex.IsValidHex(str)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -112,7 +113,8 @@ func TestNewStringInvariants(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			str := hex.NewString(test.input)
-			verifyInvariants(t, "NewString()", str)
+			_, err := hex.IsValidHex(str)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -155,7 +157,8 @@ func TestFromBytes(t *testing.T) {
 			result := hex.FromBytes(tt.input)
 			require.Equal(t, tt.expected, result.Unwrap())
 
-			verifyInvariants(t, "FromBytes()", result)
+			_, err := hex.IsValidHex(result)
+			require.NoError(t, err)
 
 			decoded, err := result.ToBytes()
 			require.NoError(t, err)
@@ -195,7 +198,8 @@ func TestUint64RoundTrip(t *testing.T) {
 			result := hex.FromUint64(tt.input)
 			require.Equal(t, tt.expected, result.Unwrap())
 
-			verifyInvariants(t, "FromUint64()", result)
+			_, err := hex.IsValidHex(result)
+			require.NoError(t, err)
 
 			decoded, err := strconv.ParseUint(result.Unwrap()[2:], 16, 64)
 			require.NoError(t, err)
@@ -234,12 +238,10 @@ func TestBigIntRoundTrip(t *testing.T) {
 			result := hex.FromBigInt(tt.input)
 			require.Equal(t, tt.expected, result.Unwrap())
 
-			verifyInvariants(t, "FromBigInt()", result)
+			_, err := hex.IsValidHex(result)
+			require.NoError(t, err)
 
-			var (
-				dec *big.Int
-				err error
-			)
+			var dec *big.Int
 
 			if tt.input.Sign() >= 0 {
 				dec, err = hex.NewString(result.Unwrap()).ToBigInt()
@@ -255,12 +257,6 @@ func TestBigIntRoundTrip(t *testing.T) {
 }
 
 // ====================== Helpers ===========================.
-
-func verifyInvariants(t *testing.T, invoker string, s hex.String) {
-	t.Helper()
-	require.True(t, s.Has0xPrefix(), invoker+"result does not have 0x prefix: %v", s)
-	require.False(t, s.IsEmpty(), invoker+"result is empty: %v", s)
-}
 
 func TestUnmarshalJSONText(t *testing.T) {
 	tests := []struct {

--- a/mod/primitives/pkg/encoding/hex/hex_test.go
+++ b/mod/primitives/pkg/encoding/hex/hex_test.go
@@ -384,10 +384,10 @@ func TestString_MustToUInt64(t *testing.T) {
 				}
 			)
 			if tt.panics {
-				require.Panics(t, f, "Test case: %s", tt.name)
+				require.Panics(t, f)
 			} else {
 				require.NotPanics(t, f)
-				require.Equal(t, tt.expected, res, "Test case: %s", tt.name)
+				require.Equal(t, tt.expected, res)
 			}
 		})
 	}
@@ -415,10 +415,10 @@ func TestString_MustToBigInt(t *testing.T) {
 				}
 			)
 			if tt.panics {
-				require.Panics(t, f, "Test case: %s", tt.name)
+				require.Panics(t, f)
 			} else {
 				require.NotPanics(t, f)
-				require.Equal(t, tt.expected, res, "Test case: %s", tt.name)
+				require.Equal(t, tt.expected, res)
 			}
 		})
 	}

--- a/mod/primitives/pkg/encoding/hex/string.go
+++ b/mod/primitives/pkg/encoding/hex/string.go
@@ -97,12 +97,12 @@ func FromUint64[U ~uint64](i U) String {
 // Precondition: bigint is non-negative.
 func FromBigInt(bigint *big.Int) String {
 	if sign := bigint.Sign(); sign == 0 {
-		return NewString("0x0")
+		return NewString(prefix + "0")
 	} else if sign > 0 {
-		return NewString("0x" + bigint.Text(hexBase))
+		return NewString(prefix + bigint.Text(hexBase))
 	}
 	// this return should never reach if precondition is met
-	return NewString("0x" + bigint.Text(hexBase)[1:])
+	return NewString(prefix + bigint.Text(hexBase)[1:])
 }
 
 func FromJSONString[B ~[]byte](b B) String {

--- a/mod/primitives/pkg/encoding/hex/string.go
+++ b/mod/primitives/pkg/encoding/hex/string.go
@@ -77,11 +77,9 @@ func NewStringStrict[T []byte | string](s T) (String, error) {
 }
 
 // FromBytes creates a hex string with 0x prefix.
-func FromBytes[B ~[]byte](b B) String {
-	enc := make([]byte, len(b)*2+prefixLen)
-	copy(enc, prefix)
-	hex.Encode(enc[2:], b)
-	return NewString(enc)
+func FromBytes[B ~[]byte](input B) String {
+	b := EncodeBytes(input)
+	return NewString(b)
 }
 
 // FromUint64 encodes i as a hex string with 0x prefix.
@@ -120,7 +118,7 @@ func (s String) IsEmpty() bool {
 
 // ToBytes decodes a hex string with 0x prefix.
 func (s String) ToBytes() ([]byte, error) {
-	return hex.DecodeString(string(s[2:]))
+	return hex.DecodeString(string(s[prefixLen:]))
 }
 
 // MustToBytes decodes a hex string with 0x prefix.


### PR DESCRIPTION
MInor cleanups, useful for future larger ones:

- Replaced magic numbers and strings with constants already defined
- Reduced code duplication across some functions
- Simplified UTs using `require`
- Consolidated multiple validations into `IsValidHex`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced hex string validation and conversion methods for byte manipulation.
	- Improved JSON unmarshalling for execution types.

- **Bug Fixes**
	- Updated tests to cover additional edge cases and ensure robust error handling for hex conversions.

- **Refactor**
	- Streamlined hex validation logic and removed redundant functions for clarity and maintainability.

- **Tests**
	- Expanded test coverage for various byte manipulation methods and hex string handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->