### PR TITLE
chore(primitives): Consolidating hex.NewString

### DIFF
--- a/mod/primitives/pkg/bytes/b.go
+++ b/mod/primitives/pkg/bytes/b.go
@@ -31,7 +31,7 @@ type Bytes []byte
 
 // MarshalText implements encoding.TextMarshaler.
 func (b Bytes) MarshalText() ([]byte, error) {
-	return hex.EncodeBytes(b), nil
+	return []byte(hex.EncodeBytes(b)), nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -51,5 +51,5 @@ func (b *Bytes) UnmarshalText(input []byte) error {
 
 // String returns the hex encoding of b.
 func (b Bytes) String() string {
-	return string(hex.EncodeBytes(b))
+	return hex.EncodeBytes(b)
 }

--- a/mod/primitives/pkg/bytes/b.go
+++ b/mod/primitives/pkg/bytes/b.go
@@ -51,5 +51,5 @@ func (b *Bytes) UnmarshalText(input []byte) error {
 
 // String returns the hex encoding of b.
 func (b Bytes) String() string {
-	return hex.FromBytes(b).Unwrap()
+	return string(hex.EncodeBytes(b))
 }

--- a/mod/primitives/pkg/bytes/b20.go
+++ b/mod/primitives/pkg/bytes/b20.go
@@ -56,7 +56,7 @@ func (h *B20) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B20.
 func (h *B20) String() string {
-	return hex.FromBytes(h[:]).Unwrap()
+	return string(hex.EncodeBytes(h[:]))
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b20.go
+++ b/mod/primitives/pkg/bytes/b20.go
@@ -56,7 +56,7 @@ func (h *B20) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B20.
 func (h *B20) String() string {
-	return string(hex.EncodeBytes(h[:]))
+	return hex.EncodeBytes(h[:])
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b256.go
+++ b/mod/primitives/pkg/bytes/b256.go
@@ -57,7 +57,7 @@ func (h *B256) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B256.
 func (h *B256) String() string {
-	return hex.FromBytes(h[:]).Unwrap()
+	return string(hex.EncodeBytes(h[:]))
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b256.go
+++ b/mod/primitives/pkg/bytes/b256.go
@@ -57,7 +57,7 @@ func (h *B256) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B256.
 func (h *B256) String() string {
-	return string(hex.EncodeBytes(h[:]))
+	return hex.EncodeBytes(h[:])
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b32.go
+++ b/mod/primitives/pkg/bytes/b32.go
@@ -58,7 +58,7 @@ func (h *B32) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B32.
 func (h B32) String() string {
-	return hex.FromBytes(h[:]).Unwrap()
+	return string(hex.EncodeBytes(h[:]))
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b32.go
+++ b/mod/primitives/pkg/bytes/b32.go
@@ -58,7 +58,7 @@ func (h *B32) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B32.
 func (h B32) String() string {
-	return string(hex.EncodeBytes(h[:]))
+	return hex.EncodeBytes(h[:])
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b4.go
+++ b/mod/primitives/pkg/bytes/b4.go
@@ -56,7 +56,7 @@ func (h *B4) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B4.
 func (h B4) String() string {
-	return string(hex.EncodeBytes(h[:]))
+	return hex.EncodeBytes(h[:])
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b4.go
+++ b/mod/primitives/pkg/bytes/b4.go
@@ -56,7 +56,7 @@ func (h *B4) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B4.
 func (h B4) String() string {
-	return hex.FromBytes(h[:]).Unwrap()
+	return string(hex.EncodeBytes(h[:]))
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b48.go
+++ b/mod/primitives/pkg/bytes/b48.go
@@ -57,7 +57,7 @@ func (h *B48) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B48.
 func (h B48) String() string {
-	return hex.FromBytes(h[:]).Unwrap()
+	return string(hex.EncodeBytes(h[:]))
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b48.go
+++ b/mod/primitives/pkg/bytes/b48.go
@@ -57,7 +57,7 @@ func (h *B48) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B48.
 func (h B48) String() string {
-	return string(hex.EncodeBytes(h[:]))
+	return hex.EncodeBytes(h[:])
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b8.go
+++ b/mod/primitives/pkg/bytes/b8.go
@@ -56,7 +56,7 @@ func (h *B8) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B8.
 func (h B8) String() string {
-	return hex.FromBytes(h[:]).Unwrap()
+	return string(hex.EncodeBytes(h[:]))
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b8.go
+++ b/mod/primitives/pkg/bytes/b8.go
@@ -56,7 +56,7 @@ func (h *B8) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B8.
 func (h B8) String() string {
-	return string(hex.EncodeBytes(h[:]))
+	return hex.EncodeBytes(h[:])
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b96.go
+++ b/mod/primitives/pkg/bytes/b96.go
@@ -57,7 +57,7 @@ func (h *B96) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B96.
 func (h *B96) String() string {
-	return string(hex.EncodeBytes(h[:]))
+	return hex.EncodeBytes(h[:])
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b96.go
+++ b/mod/primitives/pkg/bytes/b96.go
@@ -57,7 +57,7 @@ func (h *B96) UnmarshalText(text []byte) error {
 
 // String returns the hex string representation of B96.
 func (h *B96) String() string {
-	return hex.FromBytes(h[:]).Unwrap()
+	return string(hex.EncodeBytes(h[:]))
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mod/primitives/pkg/bytes/b_test.go
+++ b/mod/primitives/pkg/bytes/b_test.go
@@ -22,7 +22,7 @@
 package bytes_test
 
 import (
-	stdbytes "bytes"
+	stdhex "encoding/hex"
 	"fmt"
 	"reflect"
 	"strings"
@@ -35,51 +35,51 @@ import (
 
 func TestFromHex(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    bytes.Bytes
-		wantErr bool
+		name       string
+		input      string
+		wantOutput bytes.Bytes
+		wantErr    error
 	}{
 		{
-			name:    "Valid hex string",
-			input:   "0x48656c6c6f",
-			want:    bytes.Bytes{0x48, 0x65, 0x6c, 0x6c, 0x6f},
-			wantErr: false,
+			name:       "Valid hex string",
+			input:      "0x48656c6c6f",
+			wantOutput: bytes.Bytes{0x48, 0x65, 0x6c, 0x6c, 0x6f},
+			wantErr:    nil,
 		},
 		{
-			name:    "Empty hex string",
-			input:   "0x",
-			want:    bytes.Bytes{},
-			wantErr: false,
+			name:       "Empty hex string",
+			input:      "0x",
+			wantOutput: bytes.Bytes{},
+			wantErr:    nil,
 		},
 		{
-			name:    "Invalid hex string - odd length",
-			input:   "0x12345",
-			want:    nil,
-			wantErr: true,
+			name:       "Invalid hex string - odd length",
+			input:      "0x12345",
+			wantOutput: nil,
+			wantErr:    stdhex.ErrLength,
 		},
 		{
-			name:    "Invalid hex string - no 0x prefix",
-			input:   "12345",
-			want:    nil,
-			wantErr: true,
+			name:       "Invalid hex string - no 0x prefix",
+			input:      "12345",
+			wantOutput: nil,
+			wantErr:    hex.ErrMissingPrefix,
 		},
 		{
-			name:    "Empty input string",
-			input:   "",
-			want:    nil,
-			wantErr: true,
+			name:       "Empty input string",
+			input:      "",
+			wantOutput: nil,
+			wantErr:    hex.ErrEmptyString,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := hex.ToBytes(tt.input)
-			if tt.wantErr {
-				require.Error(t, err, "Test case: %s", tt.name)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
 			} else {
-				require.NoError(t, err, "Test case: %s", tt.name)
-				require.True(t, stdbytes.Equal(got, tt.want), "Test case: %s", tt.name)
+				require.NoError(t, err)
+				require.Equal(t, tt.wantOutput, bytes.Bytes(got))
 			}
 		})
 	}

--- a/mod/primitives/pkg/bytes/b_test.go
+++ b/mod/primitives/pkg/bytes/b_test.go
@@ -94,8 +94,14 @@ func TestMustFromHex(t *testing.T) {
 	}{
 		{
 			name:        "Valid hex string",
-			input:       "0x48656c6c6f",
-			expected:    bytes.Bytes{0x48, 0x65, 0x6c, 0x6c, 0x6f},
+			input:       "0x68656c6c6f",
+			expected:    bytes.Bytes("hello"),
+			shouldPanic: false,
+		},
+		{
+			name:        "Another valid hex string",
+			input:       "0x776f726c64",
+			expected:    bytes.Bytes("world"),
 			shouldPanic: false,
 		},
 		{

--- a/mod/primitives/pkg/common/consensus.go
+++ b/mod/primitives/pkg/common/consensus.go
@@ -84,7 +84,7 @@ func NewRootFromBytes(input []byte) Root {
 }
 
 // Hex converts a root to a hex string.
-func (r Root) Hex() string { return string(hex.EncodeBytes(r[:])) }
+func (r Root) Hex() string { return hex.EncodeBytes(r[:]) }
 
 // String implements the stringer interface and is used also by the logger when
 // doing full logging into a file.

--- a/mod/primitives/pkg/common/consensus.go
+++ b/mod/primitives/pkg/common/consensus.go
@@ -84,7 +84,7 @@ func NewRootFromBytes(input []byte) Root {
 }
 
 // Hex converts a root to a hex string.
-func (r Root) Hex() string { return hex.FromBytes(r[:]).Unwrap() }
+func (r Root) Hex() string { return string(hex.EncodeBytes(r[:])) }
 
 // String implements the stringer interface and is used also by the logger when
 // doing full logging into a file.

--- a/mod/primitives/pkg/common/execution.go
+++ b/mod/primitives/pkg/common/execution.go
@@ -55,7 +55,7 @@ func NewExecutionHashFromHex(input string) ExecutionHash {
 }
 
 // Hex converts a hash to a hex string.
-func (h ExecutionHash) Hex() string { return string(hex.EncodeBytes(h[:])) }
+func (h ExecutionHash) Hex() string { return hex.EncodeBytes(h[:]) }
 
 // String implements the stringer interface and is used also by the logger when
 // doing full logging into a file.
@@ -65,7 +65,7 @@ func (h ExecutionHash) String() string {
 
 // MarshalText returns the hex representation of h.
 func (h ExecutionHash) MarshalText() ([]byte, error) {
-	return hex.EncodeBytes(h[:]), nil
+	return []byte(hex.EncodeBytes(h[:])), nil
 }
 
 // UnmarshalText parses a hash in hex syntax.
@@ -128,7 +128,7 @@ func (a *ExecutionAddress) UnmarshalJSON(input []byte) error {
 
 // checksumHex returns the checksummed hex representation of a.
 func (a *ExecutionAddress) checksumHex() []byte {
-	buf := hex.EncodeBytes(a[:])
+	buf := []byte(hex.EncodeBytes(a[:]))
 
 	// compute checksum
 	sha := sha3.NewLegacyKeccak256()

--- a/mod/primitives/pkg/common/execution.go
+++ b/mod/primitives/pkg/common/execution.go
@@ -55,7 +55,7 @@ func NewExecutionHashFromHex(input string) ExecutionHash {
 }
 
 // Hex converts a hash to a hex string.
-func (h ExecutionHash) Hex() string { return hex.FromBytes(h[:]).Unwrap() }
+func (h ExecutionHash) Hex() string { return string(hex.EncodeBytes(h[:])) }
 
 // String implements the stringer interface and is used also by the logger when
 // doing full logging into a file.

--- a/mod/primitives/pkg/encoding/hex/bytes.go
+++ b/mod/primitives/pkg/encoding/hex/bytes.go
@@ -97,13 +97,10 @@ func MustToBytes(input string) []byte {
 // ToBytes returns the bytes represented by the given hex string.
 // An error is returned if the input is not a valid hex string.
 func ToBytes(input string) ([]byte, error) {
-	s, err := NewStringStrict(input)
+	strippedInput, err := IsValidHex(input)
 	if err != nil {
 		return nil, err
 	}
-	h, err := s.ToBytes()
-	if err != nil {
-		return nil, err
-	}
-	return h, nil
+
+	return hex.DecodeString(strippedInput)
 }

--- a/mod/primitives/pkg/encoding/hex/bytes.go
+++ b/mod/primitives/pkg/encoding/hex/bytes.go
@@ -28,11 +28,34 @@ import (
 
 var ErrInvalidHexStringLength = errors.New("invalid hex string length")
 
-func EncodeBytes[B ~[]byte](b B) []byte {
-	result := make([]byte, len(b)*2+prefixLen)
-	copy(result, prefix)
-	hex.Encode(result[prefixLen:], b)
-	return result
+// EncodeBytes creates a hex string with 0x prefix.
+// Inverse operation is ToBytes or MustToBytes.
+func EncodeBytes(b []byte) string {
+	hexStr := make([]byte, len(b)*2+prefixLen)
+	copy(hexStr, prefix)
+	hex.Encode(hexStr[prefixLen:], b)
+	return string(hexStr)
+}
+
+// MustToBytes returns the bytes represented by the given hex string.
+// It panics if the input is not a valid hex string.
+func MustToBytes(input string) []byte {
+	bz, err := ToBytes(input)
+	if err != nil {
+		panic(err)
+	}
+	return bz
+}
+
+// ToBytes returns the bytes represented by the given hex string.
+// An error is returned if the input is not a valid hex string.
+func ToBytes(input string) ([]byte, error) {
+	strippedInput, err := IsValidHex(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return hex.DecodeString(strippedInput)
 }
 
 func UnmarshalByteText(input []byte) ([]byte, error) {
@@ -82,25 +105,4 @@ func DecodeFixedText(input, out []byte) error {
 	}
 
 	return nil
-}
-
-// MustToBytes returns the bytes represented by the given hex string.
-// It panics if the input is not a valid hex string.
-func MustToBytes(input string) []byte {
-	bz, err := ToBytes(input)
-	if err != nil {
-		panic(err)
-	}
-	return bz
-}
-
-// ToBytes returns the bytes represented by the given hex string.
-// An error is returned if the input is not a valid hex string.
-func ToBytes(input string) ([]byte, error) {
-	strippedInput, err := IsValidHex(input)
-	if err != nil {
-		return nil, err
-	}
-
-	return hex.DecodeString(strippedInput)
 }

--- a/mod/primitives/pkg/encoding/hex/bytes_test.go
+++ b/mod/primitives/pkg/encoding/hex/bytes_test.go
@@ -29,33 +29,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeBytes(t *testing.T) {
+func TestEncodeAndDecodeBytes(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    []byte
-		expected []byte
+		expected string
 	}{
 		{
 			name:     "typical byte slice",
 			input:    []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f},
-			expected: []byte("0x48656c6c6f"),
+			expected: "0x48656c6c6f",
 		},
 		{
 			name:     "empty byte slice",
 			input:    []byte{},
-			expected: []byte("0x"),
+			expected: "0x",
 		},
 		{
 			name:     "single byte",
 			input:    []byte{0x01},
-			expected: []byte("0x01"),
+			expected: "0x01",
+		},
+		{
+			name: "long byte slice",
+			input: []byte{
+				0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad,
+				0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef,
+				0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe,
+				0xba, 0xbe},
+			expected: "0xdeadbeefcafebabe" + "deadbeefcafebabe" + "deadbeefcafebabe" + "deadbeefcafebabe",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := hex.EncodeBytes(tt.input)
-			require.Equal(t, tt.expected, result, "Test case : %s", tt.name)
+			require.Equal(t, tt.expected, result)
+
+			_, err := hex.IsValidHex(result)
+			require.NoError(t, err)
+
+			decoded, err := hex.ToBytes(result)
+			require.NoError(t, err)
+			require.Equal(t, tt.input, decoded)
 		})
 	}
 }
@@ -97,10 +113,10 @@ func TestUnmarshalByteText(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := hex.UnmarshalByteText(tt.input)
 			if tt.expectErr {
-				require.Error(t, err, "Test case : %s", tt.name)
+				require.Error(t, err)
 			} else {
-				require.NoError(t, err, "Test case : %s", tt.name)
-				require.Equal(t, tt.expected, result, "Test case : %s", tt.name)
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
 			}
 		})
 	}
@@ -149,10 +165,10 @@ func TestDecodeFixedText(t *testing.T) {
 			out := make([]byte, len(tt.expected))
 			err := hex.DecodeFixedText(tt.input, out)
 			if tt.expectErr {
-				require.Error(t, err, "Test case : %s", tt.name)
+				require.Error(t, err)
 			} else {
-				require.NoError(t, err, "Test case : %s", tt.name)
-				require.Equal(t, tt.expected, out, "Test case : %s", tt.name)
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, out)
 			}
 		})
 	}
@@ -203,10 +219,10 @@ func TestDecodeFixedJSON(t *testing.T) {
 				tt.out,
 			)
 			if tt.expectErr {
-				require.Error(t, err, "Test case : %s", tt.name)
+				require.Error(t, err)
 			} else {
-				require.NoError(t, err, "Test case : %s", tt.name)
-				require.Equal(t, []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f}, tt.out, "Test case : %s", tt.name)
+				require.NoError(t, err)
+				require.Equal(t, []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f}, tt.out)
 			}
 		})
 	}

--- a/mod/primitives/pkg/encoding/hex/format.go
+++ b/mod/primitives/pkg/encoding/hex/format.go
@@ -22,30 +22,6 @@ package hex
 
 import "errors"
 
-// ensure0xPrefix ensures that s has a 0x prefix. If it doesn't, it adds it.
-func ensure0xPrefix[T []byte | string](s T) T {
-	if _, err := IsValidHex(s); err == nil {
-		return s
-	}
-	switch v := any(s).(type) {
-	case string:
-		return T(string(prefix) + v)
-	case []byte:
-		return T(append([]byte(prefix), v...))
-	default:
-		return s
-	}
-}
-
-// ensureStringInvariants ensures that String invariants are met by appending
-// 0x prefix if missing, and converting empty string to "0x0".
-func ensureStringInvariants(s string) string {
-	if len(s) == 0 {
-		s = "0"
-	}
-	return ensure0xPrefix(s)
-}
-
 // isQuotedString returns true if input has quotes.
 func isQuotedString[T []byte | string](input T) bool {
 	return len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"'

--- a/mod/primitives/pkg/encoding/hex/hex_test.go
+++ b/mod/primitives/pkg/encoding/hex/hex_test.go
@@ -71,54 +71,6 @@ func TestNewStringInvariants(t *testing.T) {
 	}
 }
 
-// ====================== Bytes ===========================.
-func TestFromBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []byte
-		expected string
-	}{
-		{
-			name:     "typical byte slice",
-			input:    []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f},
-			expected: "0x48656c6c6f",
-		},
-		{
-			name:     "empty byte slice",
-			input:    []byte{},
-			expected: "0x",
-		},
-		{
-			name:     "single byte",
-			input:    []byte{0x01},
-			expected: "0x01",
-		},
-		{
-			name: "long byte slice",
-			input: []byte{
-				0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad,
-				0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef,
-				0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe,
-				0xba, 0xbe},
-			expected: "0xdeadbeefcafebabe" + "deadbeefcafebabe" + "deadbeefcafebabe" + "deadbeefcafebabe",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hex.EncodeBytes(tt.input)
-			require.Equal(t, tt.expected, string(result))
-
-			_, err := hex.IsValidHex(result)
-			require.NoError(t, err)
-
-			decoded, err := hex.ToBytes(string(result))
-			require.NoError(t, err)
-			require.Equal(t, tt.input, decoded)
-		})
-	}
-}
-
 // ====================== Numeric ===========================.
 
 // FromUint64, then ToUint64.

--- a/mod/primitives/pkg/encoding/hex/hex_test.go
+++ b/mod/primitives/pkg/encoding/hex/hex_test.go
@@ -106,13 +106,13 @@ func TestFromBytes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := hex.FromBytes(tt.input)
-			require.Equal(t, tt.expected, result.Unwrap())
+			result := hex.EncodeBytes(tt.input)
+			require.Equal(t, tt.expected, string(result))
 
 			_, err := hex.IsValidHex(result)
 			require.NoError(t, err)
 
-			decoded, err := result.ToBytes()
+			decoded, err := hex.ToBytes(string(result))
 			require.NoError(t, err)
 			require.Equal(t, tt.input, decoded)
 		})

--- a/mod/primitives/pkg/encoding/hex/hex_test.go
+++ b/mod/primitives/pkg/encoding/hex/hex_test.go
@@ -210,36 +210,6 @@ func TestUnmarshalJSONText(t *testing.T) {
 	}
 }
 
-func TestString_MustToBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    hex.String
-		expected []byte
-		panics   bool
-	}{
-		{"Valid hex string", "0x68656c6c6f", []byte("hello"), false},
-		{"Another valid hex string", "0x776f726c64", []byte("world"), false},
-		{"Invalid hex string", "0xinvalid", nil, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var (
-				res []byte
-				f   = func() {
-					res = tt.input.MustToBytes()
-				}
-			)
-			if tt.panics {
-				require.Panics(t, f, "Test case: %s", tt.name)
-			} else {
-				require.NotPanics(t, f)
-				require.Equal(t, tt.expected, res, "Test case: %s", tt.name)
-			}
-		})
-	}
-}
-
 func TestString_ToUint64(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/mod/primitives/pkg/encoding/hex/hex_test.go
+++ b/mod/primitives/pkg/encoding/hex/hex_test.go
@@ -33,54 +33,6 @@ import (
 )
 
 // ====================== Constructors ===========================.
-func TestNewStringStrictInvariants(t *testing.T) {
-	// NewStringStrict constructor should error if the input is invalid
-	tests := []struct {
-		name      string
-		input     string
-		expectErr bool
-	}{
-		{
-			name:      "Valid hex string",
-			input:     "0x48656c6c6f",
-			expectErr: false,
-		},
-		{
-			name:      "Empty string",
-			input:     "",
-			expectErr: true,
-		},
-		{
-			name:      "No 0x prefix",
-			input:     "48656c6c6f",
-			expectErr: true,
-		},
-		{
-			name:      "Valid single hex character",
-			input:     "0x0",
-			expectErr: false,
-		},
-		{
-			name:      "Empty hex string",
-			input:     "0x",
-			expectErr: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			str, err := hex.NewStringStrict(test.input)
-			if test.expectErr {
-				require.Error(t, err, "Test case: %s", test.name)
-			} else {
-				require.NoError(t, err, "Test case: %s", test.name)
-				_, err = hex.IsValidHex(str)
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestNewStringInvariants(t *testing.T) {
 	// NewString constructor should never error or panic
 	// output should always satisfy the string invariants regardless of input

--- a/mod/primitives/pkg/encoding/hex/string.go
+++ b/mod/primitives/pkg/encoding/hex/string.go
@@ -21,8 +21,6 @@
 package hex
 
 import (
-	"bytes"
-	"encoding/hex"
 	"math/big"
 	"strconv"
 	"strings"
@@ -96,25 +94,6 @@ func FromBigInt(bigint *big.Int) String {
 	return NewString(prefix + bigint.Text(hexBase)[1:])
 }
 
-func FromJSONString[B ~[]byte](b B) String {
-	return NewString(bytes.Trim(b, "\""))
-}
-
-// ToBytes decodes a hex string with 0x prefix.
-func (s String) ToBytes() ([]byte, error) {
-	return hex.DecodeString(string(s[prefixLen:]))
-}
-
-// MustToBytes decodes a hex string with 0x prefix.
-// It panics for invalid input.
-func (s String) MustToBytes() []byte {
-	b, err := s.ToBytes()
-	if err != nil {
-		panic(err)
-	}
-	return b
-}
-
 // ToUint64 decodes a hex string with 0x prefix.
 func (s String) ToUint64() (uint64, error) {
 	raw, err := formatAndValidateNumber(s.Unwrap())
@@ -176,10 +155,6 @@ func (s String) MustToBigInt() *big.Int {
 		panic(err)
 	}
 	return bi
-}
-
-func (s String) AddQuotes() String {
-	return "\"" + s + "\""
 }
 
 // Unwrap returns the string value.

--- a/mod/primitives/pkg/encoding/hex/string.go
+++ b/mod/primitives/pkg/encoding/hex/string.go
@@ -38,8 +38,14 @@ type String string
 // ensure that the string invariants are satisfied.
 func NewString[T []byte | string](s T) String {
 	str := string(s)
-	str = ensureStringInvariants(str)
-	return String(str)
+	switch _, err := IsValidHex(s); {
+	case errors.Is(err, ErrEmptyString):
+		return String(prefix + "0")
+	case err == nil:
+		return String(str)
+	default:
+		return String(prefix + string(s))
+	}
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.

--- a/mod/primitives/pkg/encoding/hex/string.go
+++ b/mod/primitives/pkg/encoding/hex/string.go
@@ -76,15 +76,6 @@ func IsValidHex[T ~[]byte | ~string](s T) (T, error) {
 	return s[prefixLen:], nil
 }
 
-// NewStringStrict creates a hex string with 0x prefix. It errors if any of the
-// string invariants are violated.
-func NewStringStrict[T []byte | string](s T) (String, error) {
-	if _, err := IsValidHex(s); err != nil {
-		return "", err
-	}
-	return String(s), nil
-}
-
 // FromBytes creates a hex string with 0x prefix.
 func FromBytes[B ~[]byte](input B) String {
 	b := EncodeBytes(input)

--- a/mod/primitives/pkg/encoding/hex/string.go
+++ b/mod/primitives/pkg/encoding/hex/string.go
@@ -76,12 +76,6 @@ func IsValidHex[T ~[]byte | ~string](s T) (T, error) {
 	return s[prefixLen:], nil
 }
 
-// FromBytes creates a hex string with 0x prefix.
-func FromBytes[B ~[]byte](input B) String {
-	b := EncodeBytes(input)
-	return NewString(b)
-}
-
 // FromUint64 encodes i as a hex string with 0x prefix.
 func FromUint64[U ~uint64](i U) String {
 	enc := make([]byte, prefixLen, initialCapacity)

--- a/mod/primitives/pkg/net/jwt/jwt.go
+++ b/mod/primitives/pkg/net/jwt/jwt.go
@@ -72,7 +72,7 @@ func NewRandom() (*Secret, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewFromHex(string(hex.EncodeBytes(secret)))
+	return NewFromHex(hex.EncodeBytes(secret))
 }
 
 // BuildSignedToken creates a signed JWT token from the secret.
@@ -90,13 +90,13 @@ func (s *Secret) BuildSignedToken() (string, error) {
 // String returns the JWT secret as a string with the first 8 characters
 // visible and the rest masked out for security.
 func (s *Secret) String() string {
-	secret := string(hex.EncodeBytes(s[:]))
+	secret := hex.EncodeBytes(s[:])
 	return secret[:8] + strings.Repeat("*", len(secret[8:]))
 }
 
 // Hex returns the JWT secret as a hexadecimal string.
 func (s *Secret) Hex() string {
-	return string(hex.EncodeBytes(s[:]))
+	return hex.EncodeBytes(s[:])
 }
 
 // Bytes returns the JWT secret as a byte array.

--- a/mod/primitives/pkg/net/jwt/jwt.go
+++ b/mod/primitives/pkg/net/jwt/jwt.go
@@ -72,7 +72,7 @@ func NewRandom() (*Secret, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewFromHex(hex.FromBytes(secret).Unwrap())
+	return NewFromHex(string(hex.EncodeBytes(secret)))
 }
 
 // BuildSignedToken creates a signed JWT token from the secret.
@@ -90,13 +90,13 @@ func (s *Secret) BuildSignedToken() (string, error) {
 // String returns the JWT secret as a string with the first 8 characters
 // visible and the rest masked out for security.
 func (s *Secret) String() string {
-	secret := hex.FromBytes(s[:]).Unwrap()
+	secret := string(hex.EncodeBytes(s[:]))
 	return secret[:8] + strings.Repeat("*", len(secret[8:]))
 }
 
 // Hex returns the JWT secret as a hexadecimal string.
 func (s *Secret) Hex() string {
-	return hex.FromBytes(s[:]).Unwrap()
+	return string(hex.EncodeBytes(s[:]))
 }
 
 // Bytes returns the JWT secret as a byte array.

--- a/mod/primitives/pkg/net/jwt/jwt_test.go
+++ b/mod/primitives/pkg/net/jwt/jwt_test.go
@@ -157,7 +157,7 @@ func TestSecretRoundTripEncoding(t *testing.T) {
 	require.NoError(t, err, "NewRandom() error")
 
 	// Encode the original secret to hex string
-	encodedSecret := string(hex.EncodeBytes(originalSecret.Bytes()))
+	encodedSecret := hex.EncodeBytes(originalSecret.Bytes())
 
 	// Decode the hex string back to secret
 	decodedSecret, err := jwt.NewFromHex(encodedSecret)

--- a/mod/primitives/pkg/net/jwt/jwt_test.go
+++ b/mod/primitives/pkg/net/jwt/jwt_test.go
@@ -157,10 +157,10 @@ func TestSecretRoundTripEncoding(t *testing.T) {
 	require.NoError(t, err, "NewRandom() error")
 
 	// Encode the original secret to hex string
-	encodedSecret := hex.FromBytes(originalSecret.Bytes())
+	encodedSecret := string(hex.EncodeBytes(originalSecret.Bytes()))
 
 	// Decode the hex string back to secret
-	decodedSecret, err := jwt.NewFromHex(encodedSecret.Unwrap())
+	decodedSecret, err := jwt.NewFromHex(encodedSecret)
 	require.NoError(t, err, "NewFromHex() error")
 
 	// Compare the original and decoded secrets

--- a/mod/storage/pkg/filedb/range_db.go
+++ b/mod/storage/pkg/filedb/range_db.go
@@ -119,7 +119,7 @@ func (db *RangeDB) Prune(start, end uint64) error {
 
 // prefix prefixes the given key with the index and a slash.
 func (db *RangeDB) prefix(index uint64, key []byte) []byte {
-	return []byte(fmt.Sprintf("%d/%s", index, hex.FromBytes(key).Unwrap()))
+	return []byte(fmt.Sprintf("%d/%s", index, hex.EncodeBytes(key)))
 }
 
 // ExtractIndex extracts the index from a prefixed key.


### PR DESCRIPTION
Step around simplification of hex encoding. Working to simplify `hex.String` so to remove any state that complicates reasoning about type conversions.

- Consolidated `hex.String` constructor
- Dropped `hex.NewStringStrict` constructor. Migrated related tests.
- Dropped `FromBytes` in favour of `EncodeBytes`. Consolidated unit tests.
  - Minor change of `EncodeBytes` return type to minimize type casting
- dropped `String.ToBytes` `String.MustToBytes` in favour of `ToBytes` `MustToBytes`.  Consolidated unit tests.
- dropped `String.FromJSONString` `String.AddQuotes` (not used)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined encoding for various byte types, enhancing their string representations.
	- Improved consistency in hexadecimal output across multiple components.

- **Bug Fixes**
	- Addressed inconsistencies in error handling and output formats for hex string conversions.

- **Tests**
	- Expanded and refined test coverage for hex encoding and decoding functionalities.
	- Updated test cases to align with new encoding methods and error handling strategies.

- **Documentation**
	- Enhanced clarity in the test suite, improving readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->