### PR TITLE
chore(primitives): hardened NewRootFromHex

### DIFF
--- a/mod/primitives/pkg/bytes/b32.go
+++ b/mod/primitives/pkg/bytes/b32.go
@@ -32,7 +32,7 @@ const (
 
 // B32 represents a 32-byte fixed-size byte array.
 // For SSZ purposes it is serialized a `Vector[Byte, 32]`.
-type B32 [32]byte
+type B32 [B32Size]byte
 
 // ToBytes32 is a utility function that transforms a byte slice into a fixed
 // 32-byte array. If the input exceeds 32 bytes, it gets truncated.

--- a/mod/primitives/pkg/bytes/utils.go
+++ b/mod/primitives/pkg/bytes/utils.go
@@ -25,6 +25,8 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/encoding/hex"
 )
 
+var ErrIncorrectLenght = errors.New("incorrect length")
+
 // ------------------------------ Helpers ------------------------------
 
 // Helper function to unmarshal JSON for various byte types.
@@ -34,7 +36,7 @@ func UnmarshalJSONHelper(target []byte, input []byte) error {
 		return err
 	}
 	if len(bz) != len(target) {
-		return errors.New("incorrect length")
+		return ErrIncorrectLenght
 	}
 	copy(target, bz)
 	return nil
@@ -47,7 +49,7 @@ func UnmarshalTextHelper(target []byte, text []byte) error {
 		return err
 	}
 	if len(bz) != len(target) {
-		return errors.New("incorrect length")
+		return ErrIncorrectLenght
 	}
 	copy(target, bz)
 	return nil

--- a/mod/primitives/pkg/bytes/utils.go
+++ b/mod/primitives/pkg/bytes/utils.go
@@ -25,7 +25,7 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/encoding/hex"
 )
 
-var ErrIncorrectLenght = errors.New("incorrect length")
+var ErrIncorrectLength = errors.New("incorrect length")
 
 // ------------------------------ Helpers ------------------------------
 
@@ -36,7 +36,7 @@ func UnmarshalJSONHelper(target []byte, input []byte) error {
 		return err
 	}
 	if len(bz) != len(target) {
-		return ErrIncorrectLenght
+		return ErrIncorrectLength
 	}
 	copy(target, bz)
 	return nil
@@ -49,7 +49,7 @@ func UnmarshalTextHelper(target []byte, text []byte) error {
 		return err
 	}
 	if len(bz) != len(target) {
-		return ErrIncorrectLenght
+		return ErrIncorrectLength
 	}
 	copy(target, bz)
 	return nil

--- a/mod/primitives/pkg/common/consensus.go
+++ b/mod/primitives/pkg/common/consensus.go
@@ -76,7 +76,7 @@ func NewRootFromHex(input string) (Root, error) {
 		return Root{}, err
 	}
 	if len(val) != RootSize {
-		return Root{}, bytes.ErrIncorrectLenght
+		return Root{}, bytes.ErrIncorrectLength
 	}
 	return Root(val), nil
 }

--- a/mod/primitives/pkg/common/consensus.go
+++ b/mod/primitives/pkg/common/consensus.go
@@ -46,7 +46,7 @@ type (
 	//nolint:lll
 	DomainType = bytes.B4
 
-	// Hash32 as er the Ethereum 2.0 Specification:
+	// Hash32 as per the Ethereum 2.0 Specification:
 	// https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#custom-types
 	Hash32 = bytes.B32
 
@@ -65,13 +65,18 @@ type (
 
 // Root represents a 32-byte Merkle root.
 // We use this type to represent roots that come from the consensus layer.
-type Root [32]byte
+type Root [RootSize]byte
+
+const RootSize = 32
 
 // NewRootFromHex creates a new root from a hex string.
 func NewRootFromHex(input string) (Root, error) {
 	val, err := hex.ToBytes(input)
 	if err != nil {
 		return Root{}, err
+	}
+	if len(val) != RootSize {
+		return Root{}, bytes.ErrIncorrectLenght
 	}
 	return Root(val), nil
 }

--- a/mod/primitives/pkg/common/consensus_test.go
+++ b/mod/primitives/pkg/common/consensus_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package common_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/bytes"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/encoding/hex"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRootFromHex(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       func() string
+		expectedErr error
+	}{
+		{
+			name: "ShortSize",
+			input: func() string {
+				return hex.Prefix + strings.Repeat("f", 2*common.RootSize-1)
+			},
+			expectedErr: bytes.ErrIncorrectLenght,
+		},
+		{
+			name: "RightSize",
+			input: func() string {
+				return hex.Prefix + strings.Repeat("f", 2*common.RootSize)
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "LongSize",
+			input: func() string {
+				return hex.Prefix + strings.Repeat("f", 2*common.RootSize+1)
+			},
+			expectedErr: bytes.ErrIncorrectLenght,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			f := func() {
+				input := tt.input()
+				_, err = common.NewRootFromHex(input)
+			}
+			require.NotPanics(t, f)
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/mod/primitives/pkg/common/consensus_test.go
+++ b/mod/primitives/pkg/common/consensus_test.go
@@ -41,7 +41,7 @@ func TestNewRootFromHex(t *testing.T) {
 			input: func() string {
 				return hex.Prefix + strings.Repeat("f", 2*common.RootSize-1)
 			},
-			expectedErr: bytes.ErrIncorrectLenght,
+			expectedErr: bytes.ErrIncorrectLength,
 		},
 		{
 			name: "RightSize",
@@ -55,7 +55,7 @@ func TestNewRootFromHex(t *testing.T) {
 			input: func() string {
 				return hex.Prefix + strings.Repeat("f", 2*common.RootSize+1)
 			},
-			expectedErr: bytes.ErrIncorrectLenght,
+			expectedErr: bytes.ErrIncorrectLength,
 		},
 	}
 

--- a/mod/primitives/pkg/common/consensus_test.go
+++ b/mod/primitives/pkg/common/consensus_test.go
@@ -37,9 +37,16 @@ func TestNewRootFromHex(t *testing.T) {
 		expectedErr error
 	}{
 		{
+			name: "EmptyString",
+			input: func() string {
+				return ""
+			},
+			expectedErr: hex.ErrEmptyString,
+		},
+		{
 			name: "ShortSize",
 			input: func() string {
-				return hex.Prefix + strings.Repeat("f", 2*common.RootSize-1)
+				return hex.Prefix + strings.Repeat("f", 2*common.RootSize-2)
 			},
 			expectedErr: bytes.ErrIncorrectLength,
 		},
@@ -53,7 +60,7 @@ func TestNewRootFromHex(t *testing.T) {
 		{
 			name: "LongSize",
 			input: func() string {
-				return hex.Prefix + strings.Repeat("f", 2*common.RootSize+1)
+				return hex.Prefix + strings.Repeat("f", 2*common.RootSize+2)
 			},
 			expectedErr: bytes.ErrIncorrectLength,
 		},
@@ -68,7 +75,7 @@ func TestNewRootFromHex(t *testing.T) {
 			}
 			require.NotPanics(t, f)
 			if tt.expectedErr != nil {
-				require.Error(t, err)
+				require.ErrorIs(t, err, tt.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/mod/primitives/pkg/encoding/hex/bytes.go
+++ b/mod/primitives/pkg/encoding/hex/bytes.go
@@ -32,7 +32,7 @@ var ErrInvalidHexStringLength = errors.New("invalid hex string length")
 // Inverse operation is ToBytes or MustToBytes.
 func EncodeBytes(b []byte) string {
 	hexStr := make([]byte, len(b)*2+prefixLen)
-	copy(hexStr, prefix)
+	copy(hexStr, Prefix)
 	hex.Encode(hexStr[prefixLen:], b)
 	return string(hexStr)
 }

--- a/mod/primitives/pkg/encoding/hex/const.go
+++ b/mod/primitives/pkg/encoding/hex/const.go
@@ -21,8 +21,8 @@
 package hex
 
 const (
-	prefix            = "0x"
-	prefixLen         = len(prefix)
+	Prefix            = "0x"
+	prefixLen         = len(Prefix)
 	badNibble         = ^uint64(0)
 	hexBase           = 16
 	initialCapacity   = 10

--- a/mod/primitives/pkg/encoding/hex/string.go
+++ b/mod/primitives/pkg/encoding/hex/string.go
@@ -38,11 +38,11 @@ func NewString[T []byte | string](s T) String {
 	str := string(s)
 	switch _, err := IsValidHex(s); {
 	case errors.Is(err, ErrEmptyString):
-		return String(prefix + "0")
+		return String(Prefix + "0")
 	case err == nil:
 		return String(str)
 	default:
-		return String(prefix + string(s))
+		return String(Prefix + string(s))
 	}
 }
 
@@ -68,7 +68,7 @@ func IsValidHex[T ~[]byte | ~string](s T) (T, error) {
 	if len(s) < prefixLen {
 		return *new(T), ErrMissingPrefix
 	}
-	if strings.ToLower(string(s[:prefixLen])) != prefix {
+	if strings.ToLower(string(s[:prefixLen])) != Prefix {
 		return *new(T), ErrMissingPrefix
 	}
 	return s[prefixLen:], nil
@@ -77,7 +77,7 @@ func IsValidHex[T ~[]byte | ~string](s T) (T, error) {
 // FromUint64 encodes i as a hex string with 0x prefix.
 func FromUint64[U ~uint64](i U) String {
 	enc := make([]byte, prefixLen, initialCapacity)
-	copy(enc, prefix)
+	copy(enc, Prefix)
 	//#nosec:G701 // i is a uint64, so it can't overflow.
 	return String(strconv.AppendUint(enc, uint64(i), hexBase))
 }
@@ -86,12 +86,12 @@ func FromUint64[U ~uint64](i U) String {
 // Precondition: bigint is non-negative.
 func FromBigInt(bigint *big.Int) String {
 	if sign := bigint.Sign(); sign == 0 {
-		return NewString(prefix + "0")
+		return NewString(Prefix + "0")
 	} else if sign > 0 {
-		return NewString(prefix + bigint.Text(hexBase))
+		return NewString(Prefix + bigint.Text(hexBase))
 	}
 	// this return should never reach if precondition is met
-	return NewString(prefix + bigint.Text(hexBase)[1:])
+	return NewString(Prefix + bigint.Text(hexBase)[1:])
 }
 
 // ToUint64 decodes a hex string with 0x prefix.

--- a/mod/primitives/pkg/encoding/hex/u64.go
+++ b/mod/primitives/pkg/encoding/hex/u64.go
@@ -32,7 +32,7 @@ import (
 // of uint64 input.
 func MarshalText(b uint64) ([]byte, error) {
 	buf := make([]byte, prefixLen, initialCapacity)
-	copy(buf, prefix)
+	copy(buf, Prefix)
 	buf = strconv.AppendUint(buf, b, hexBase)
 	return buf, nil
 }


### PR DESCRIPTION
`NewRootFromHex` would panic if `input` length is less than 32.
A related question is if should define `Root` as an alias of `bytes.B32`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new error variable for incorrect length handling to streamline error management.
	- Added unit tests for enhanced coverage of the `NewRootFromHex` function.

- **Improvements**
	- Updated type declarations for `B32` and `Root` to use constants for better maintainability.
	- Enhanced hex encoding functionality with consistent use of the `Prefix` variable.

- **Bug Fixes**
	- Implemented length checks in the `NewRootFromHex` function to ensure proper error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->