### PR TITLE
chore(execution): protect `rpc.header` for concurrent access

### DIFF
--- a/mod/execution/pkg/client/ethclient/rpc/client.go
+++ b/mod/execution/pkg/client/ethclient/rpc/client.go
@@ -47,9 +47,10 @@ type Client struct {
 	// refreshed.
 	jwtRefreshInterval time.Duration
 
-	// header is the HTTP header used for RPC requests. header is
-	// accessed by multiple goroutines, so it's protected by a mutex.
-	mtx    sync.RWMutex
+	// mu protects header for concurrent access.
+	mu sync.RWMutex
+
+	// header is the HTTP header used for RPC requests.
 	header http.Header
 }
 
@@ -147,9 +148,9 @@ func (rpc *Client) CallRaw(
 		return nil, err
 	}
 
-	rpc.mtx.RLock()
+	rpc.mu.RLock()
 	req.Header = rpc.header.Clone()
-	rpc.mtx.RUnlock()
+	rpc.mu.RUnlock()
 
 	response, err := rpc.client.Do(req)
 	if err != nil {

--- a/mod/execution/pkg/client/ethclient/rpc/client.go
+++ b/mod/execution/pkg/client/ethclient/rpc/client.go
@@ -148,8 +148,8 @@ func (rpc *Client) CallRaw(
 	}
 
 	rpc.mtx.RLock()
-	defer rpc.mtx.RUnlock()
-	req.Header = rpc.header
+	req.Header = rpc.header.Clone()
+	rpc.mtx.RUnlock()
 
 	response, err := rpc.client.Do(req)
 	if err != nil {

--- a/mod/execution/pkg/client/ethclient/rpc/client.go
+++ b/mod/execution/pkg/client/ethclient/rpc/client.go
@@ -46,7 +46,10 @@ type Client struct {
 	// jwtRefershInterval is the interval at which the JWT token should be
 	// refreshed.
 	jwtRefreshInterval time.Duration
-	// header is the HTTP header used for RPC requests.
+
+	// header is the HTTP header used for RPC requests. header is
+	// accessed by multiple goroutines, so it's protected by a mutex.
+	mtx    sync.RWMutex
 	header http.Header
 }
 
@@ -143,6 +146,9 @@ func (rpc *Client) CallRaw(
 	if err != nil {
 		return nil, err
 	}
+
+	rpc.mtx.Lock()
+	defer rpc.mtx.Unlock()
 	req.Header = rpc.header
 
 	response, err := rpc.client.Do(req)

--- a/mod/execution/pkg/client/ethclient/rpc/client.go
+++ b/mod/execution/pkg/client/ethclient/rpc/client.go
@@ -147,8 +147,8 @@ func (rpc *Client) CallRaw(
 		return nil, err
 	}
 
-	rpc.mtx.Lock()
-	defer rpc.mtx.Unlock()
+	rpc.mtx.RLock()
+	defer rpc.mtx.RUnlock()
 	req.Header = rpc.header
 
 	response, err := rpc.client.Do(req)

--- a/mod/execution/pkg/client/ethclient/rpc/header.go
+++ b/mod/execution/pkg/client/ethclient/rpc/header.go
@@ -29,7 +29,9 @@ func (rpc *Client) updateHeader() error {
 		return err
 	}
 
-	// Add the JWT token to the headers.
+	// Add the JWT token to the headers. Access header safely.
+	rpc.mtx.Lock()
+	defer rpc.mtx.Unlock()
 	rpc.header.Set("Authorization", "Bearer "+token)
 	return nil
 }

--- a/mod/execution/pkg/client/ethclient/rpc/header.go
+++ b/mod/execution/pkg/client/ethclient/rpc/header.go
@@ -30,8 +30,8 @@ func (rpc *Client) updateHeader() error {
 	}
 
 	// Add the JWT token to the headers. Access header safely.
-	rpc.mtx.Lock()
-	defer rpc.mtx.Unlock()
+	rpc.mu.Lock()
+	defer rpc.mu.Unlock()
 	rpc.header.Set("Authorization", "Bearer "+token)
 	return nil
 }


### PR DESCRIPTION
`rpc.header` is access by two different goroutines [rpc.Start()](https://github.com/berachain/beacon-kit/blob/dd024c5b196afe43cf871b5f825a7e371fc4542e/mod/execution/pkg/client/ethclient/rpc/client.go#L88) and [rpc.CallRaw()](https://github.com/berachain/beacon-kit/blob/dd024c5b196afe43cf871b5f825a7e371fc4542e/mod/execution/pkg/client/ethclient/rpc/client.go#L146) respectively.
This PR adds a mutex to safely access header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced thread safety for HTTP header management in RPC requests.

- **Bug Fixes**
	- Resolved potential race conditions when accessing and modifying HTTP headers concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->