### PR TITLE
chore(execution): fixed tickers stop

### DIFF
--- a/mod/execution/pkg/client/ethclient/rpc/client.go
+++ b/mod/execution/pkg/client/ethclient/rpc/client.go
@@ -76,13 +76,14 @@ func NewClient(url string, options ...func(rpc *Client)) *Client {
 // Start starts the rpc client.
 func (rpc *Client) Start(ctx context.Context) {
 	ticker := time.NewTicker(rpc.jwtRefreshInterval)
+	defer ticker.Stop()
+
 	if err := rpc.updateHeader(); err != nil {
 		panic(err)
 	}
 	for {
 		select {
 		case <-ctx.Done():
-			ticker.Stop()
 			return
 		case <-ticker.C:
 			if err := rpc.updateHeader(); err != nil {

--- a/mod/node-core/pkg/services/version/version.go
+++ b/mod/node-core/pkg/services/version/version.go
@@ -66,6 +66,8 @@ func (*ReportingService) Name() string {
 // Start begins the periodic logging of the chain version.
 func (v *ReportingService) Start(ctx context.Context) error {
 	ticker := time.NewTicker(v.reportingInterval)
+	defer ticker.Stop()
+
 	v.metrics.reportVersion(v.version)
 	go func() {
 		for {
@@ -74,7 +76,6 @@ func (v *ReportingService) Start(ctx context.Context) error {
 				v.metrics.reportVersion(v.version)
 				continue
 			case <-ctx.Done():
-				ticker.Stop()
 				return
 			}
 		}


### PR DESCRIPTION
A couple of tickers are not properly stopped in every relevant code path. Fixed via defer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management by ensuring proper stopping of the ticker in the `Start` method, enhancing application stability.

- **Refactor**
	- Updated internal logic for the `Start` method in the `ReportingService` to streamline the handling of the ticker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->