### PR TITLE
chore(execution): fixed failedBlocks concurrency

### DIFF
--- a/mod/execution/pkg/deposit/service.go
+++ b/mod/execution/pkg/deposit/service.go
@@ -157,7 +157,7 @@ func (s *Service[
 func (s *Service[
 	_, _, _, _, _,
 ]) getFailedBlocks() []math.U64 {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return slices.Collect(maps.Keys(s.failedBlocks))
 }

--- a/mod/execution/pkg/deposit/sync.go
+++ b/mod/execution/pkg/deposit/sync.go
@@ -75,6 +75,7 @@ func (s *Service[
 ]) fetchAndStoreDeposits(ctx context.Context, blockNum math.U64) {
 	deposits, err := s.dc.ReadDeposits(ctx, blockNum)
 	if err != nil {
+		s.logger.Error("Failed to read deposits", "error", err)
 		s.metrics.markFailedToGetBlockLogs(blockNum)
 		s.markFailedBlock(blockNum)
 		return


### PR DESCRIPTION
The s.failedBlocks map is used concurrently in the [depositCatchupFetcher()](https://github.com/berachain/beacon-kit/blob/dd024c5b196afe43cf871b5f825a7e371fc4542e/mod/execution/pkg/deposit/sync.go#L47) and in the [depositFetcher()](https://github.com/berachain/beacon-kit/blob/dd024c5b196afe43cf871b5f825a7e371fc4542e/mod/execution/pkg/deposit/sync.go#L38).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of failed block management for improved concurrency.
	- Introduced methods to mark, clear, and retrieve failed blocks.

- **Bug Fixes**
	- Improved logic for processing failed blocks, enhancing clarity and maintainability.
	- Updated error handling for deposit reading failures.

- **Refactor**
	- Streamlined methods related to failed block handling for better readability and encapsulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->