### PR TITLE
[WIP] fix validators ids filter behavior & comment status filters

### DIFF
--- a/examples/berad/pkg/storage/registry.go
+++ b/examples/berad/pkg/storage/registry.go
@@ -137,6 +137,31 @@ func (kv *KVStore[
 	return vals, nil
 }
 
+func (kv *KVStore[
+	BeaconBlockHeaderT, ExecutionPayloadHeaderT,
+	ForkT, ValidatorT, ValidatorsT, WithdrawalT, WithdrawalsT,
+]) GetValidatorIndices() (
+	[]uint64, error,
+) {
+	iter, err := kv.validators.Indexes.Pubkey.Iterate(
+		kv.ctx,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var indices []uint64
+	for ; iter.Valid(); iter.Next() {
+		index, err := iter.PrimaryKey()
+		if err != nil {
+			return nil, err
+		}
+		indices = append(indices, index)
+	}
+	return indices, nil
+}
+
 // GetTotalValidators returns the total number of validators.
 func (kv *KVStore[
 	BeaconBlockHeaderT, ExecutionPayloadHeaderT,

--- a/mod/node-api/engines/echo/vaildator.go
+++ b/mod/node-api/engines/echo/vaildator.go
@@ -63,6 +63,7 @@ func ConstructValidator() *validator.Validate {
 		"state_id":     ValidateStateID,
 		"block_id":     ValidateBlockID,
 		"execution_id": ValidateExecutionID,
+		// TODO: "validator_status":
 		"validator_id": ValidateValidatorID,
 		"epoch":        ValidateUint64,
 		"slot":         ValidateUint64,

--- a/mod/node-api/handlers/beacon/backend.go
+++ b/mod/node-api/handlers/beacon/backend.go
@@ -77,4 +77,9 @@ type ValidatorBackend[ValidatorT any] interface {
 		slot math.Slot,
 		ids []string,
 	) ([]*types.ValidatorBalanceData, error)
+	ListValidators(
+		slot math.Slot,
+		ids []string,
+		statuses []string,
+	) ([]*types.ValidatorData[ValidatorT], error)
 }

--- a/mod/node-api/handlers/beacon/types/request.go
+++ b/mod/node-api/handlers/beacon/types/request.go
@@ -39,13 +39,13 @@ type GetFinalityCheckpointsRequest struct {
 type GetStateValidatorsRequest struct {
 	types.StateIDRequest
 	IDs      []string `query:"id"     validate:"dive,validator_id"`
-	Statuses []string `query:"status" validate:"dive,validator_status"`
+	Statuses []string `query:"status" validate:"dive"`
 }
 
 type PostStateValidatorsRequest struct {
 	types.StateIDRequest
 	IDs      []string `json:"ids"      validate:"dive,validator_id"`
-	Statuses []string `json:"statuses" validate:"dive,validator_status"`
+	Statuses []string `json:"statuses" validate:"dive"`
 }
 
 type GetStateValidatorRequest struct {

--- a/mod/node-api/handlers/beacon/validators.go
+++ b/mod/node-api/handlers/beacon/validators.go
@@ -33,25 +33,29 @@ func (h *Handler[_, ContextT, _, _]) GetStateValidators(
 		c, h.Logger(),
 	)
 	if err != nil {
+		h.Logger().Error("ERROR AFTER BIND AND VALIDATE")
 		return nil, err
 	}
 	// TODO: remove this once status filter is implemented.
-	if len(req.Statuses) > 0 {
-		return nil, types.ErrNotImplemented
-	}
+	// if len(req.Statuses) > 0 {
+	// 	return nil, types.ErrNotImplemented
+	// }
 	slot, err := utils.SlotFromStateID(req.StateID, h.backend)
 	if err != nil {
+		h.Logger().Error("ERROR AFTER SLOT FROM STATE ID")
 		return nil, err
 	}
-	validators, err := h.backend.ValidatorsByIDs(
+	validators, err := h.backend.ListValidators(
 		slot,
 		req.IDs,
 		req.Statuses,
 	)
 	if err != nil {
+		h.Logger().Error("ERROR AFTER LIST VALIDATORS")
 		return nil, err
 	}
 	if len(validators) == 0 {
+		h.Logger().Error("NOT FOUND")
 		return nil, types.ErrNotFound
 	}
 	return beacontypes.ValidatorResponse{

--- a/mod/node-api/handlers/config/handler.go
+++ b/mod/node-api/handlers/config/handler.go
@@ -37,3 +37,78 @@ func NewHandler[ContextT context.Context]() *Handler[ContextT] {
 	}
 	return h
 }
+
+type Fork struct {
+	PreviousVersion string `json:"previous_version"`
+	CurrentVersion  string `json:"current_version"`
+	Epoch           string `json:"epoch"`
+}
+
+type ForksResponse struct {
+	Data []Fork `json:"data"`
+}
+
+type SpecData struct {
+	SecondsPerSlot                  string `json:"SECONDS_PER_SLOT"`
+	DepositContractAddress          string `json:"DEPOSIT_CONTRACT_ADDRESS"`
+	DepositNetworkID                string `json:"DEPOSIT_NETWORK_ID"`
+	DomainAggregateAndProof         string `json:"DOMAIN_AGGREGATE_AND_PROOF"`
+	InactivityPenaltyQuotient       string `json:"INACTIVITY_PENALTY_QUOTIENT"`
+	InactivityPenaltyQuotientAltair string `json:"INACTIVITY_PENALTY_QUOTIENT_ALTAIR"`
+	BellatrixForkVersion            string `json:"BELLATRIX_FORK_VERSION"`
+	DenebForkVersion                string `json:"DENEb_FORK_VERSION"`
+	CapellaForkVersion              string `json:"CAPELLA_FORK_VERSION"`
+}
+
+type SpecResponse struct {
+	Data SpecData `json:"data"`
+}
+
+type DepositContractData struct {
+	ChainID string `json:"chain_id"`
+	Address string `json:"address"`
+}
+
+type DepositContractResponse struct {
+	Data DepositContractData `json:"data"`
+}
+
+func (h *Handler[Context]) GetForkSchedule(c Context) (any, error) {
+	response := ForksResponse{
+		Data: []Fork{
+			{
+				PreviousVersion: "0x00000000",
+				CurrentVersion:  "0x00000000",
+				Epoch:           "1",
+			},
+		},
+	}
+	return response, nil
+}
+
+func (h *Handler[Context]) GetSpec(c Context) (any, error) {
+	response := SpecResponse{
+		Data: SpecData{
+			SecondsPerSlot:                  "2",
+			DepositNetworkID:                "80087",
+			DepositContractAddress:          "0x4242424242424242424242424242424242424242",
+			InactivityPenaltyQuotient:       "1",
+			InactivityPenaltyQuotientAltair: "1",
+			DomainAggregateAndProof:         "0x06000000",
+			BellatrixForkVersion:            "0x02000000",
+			DenebForkVersion:                "0x02000000",
+			CapellaForkVersion:              "0x02000000",
+		},
+	}
+	return response, nil
+}
+
+func (h *Handler[Context]) GetDepositContract(c Context) (any, error) {
+	response := DepositContractResponse{
+		Data: DepositContractData{
+			ChainID: "80087",
+			Address: "0x4242424242424242424242424242424242424242",
+		},
+	}
+	return response, nil
+}

--- a/mod/node-api/handlers/config/routes.go
+++ b/mod/node-api/handlers/config/routes.go
@@ -35,17 +35,17 @@ func (h *Handler[ContextT]) RegisterRoutes(
 		{
 			Method:  http.MethodGet,
 			Path:    "/eth/v1/config/fork_schedule",
-			Handler: h.NotImplemented,
+			Handler: h.GetForkSchedule,
 		},
 		{
 			Method:  http.MethodGet,
 			Path:    "/eth/v1/config/spec",
-			Handler: h.NotImplemented,
+			Handler: h.GetSpec,
 		},
 		{
 			Method:  http.MethodGet,
 			Path:    "/eth/v1/config/deposit_contract",
-			Handler: h.NotImplemented,
+			Handler: h.GetDepositContract,
 		},
 	})
 }

--- a/mod/node-core/pkg/components/interfaces.go
+++ b/mod/node-core/pkg/components/interfaces.go
@@ -956,6 +956,9 @@ type (
 		GetLatestBlockHeader() (BeaconBlockHeaderT, error)
 		GetTotalActiveBalances(uint64) (math.Gwei, error)
 		GetValidators() (ValidatorsT, error)
+		/// HERE
+		GetValidatorIndices() ([]math.ValidatorIndex, error)
+		///
 		GetSlashingAtIndex(uint64) (math.Gwei, error)
 		GetTotalSlashing() (math.Gwei, error)
 		GetNextWithdrawalIndex() (uint64, error)
@@ -1155,6 +1158,11 @@ type (
 			slot math.Slot, id string,
 		) (*types.ValidatorData[ValidatorT], error)
 		ValidatorsByIDs(
+			slot math.Slot,
+			ids []string,
+			statuses []string,
+		) ([]*types.ValidatorData[ValidatorT], error)
+		ListValidators(
 			slot math.Slot,
 			ids []string,
 			statuses []string,

--- a/mod/state-transition/pkg/core/interfaces.go
+++ b/mod/state-transition/pkg/core/interfaces.go
@@ -77,6 +77,7 @@ type ReadOnlyBeaconState[
 	GetLatestBlockHeader() (BeaconBlockHeaderT, error)
 	GetTotalActiveBalances(uint64) (math.Gwei, error)
 	GetValidators() (ValidatorsT, error)
+	GetValidatorIndices() ([]math.ValidatorIndex, error)
 	GetSlashingAtIndex(uint64) (math.Gwei, error)
 	GetTotalSlashing() (math.Gwei, error)
 	GetNextWithdrawalIndex() (uint64, error)

--- a/mod/state-transition/pkg/core/state/interfaces.go
+++ b/mod/state-transition/pkg/core/state/interfaces.go
@@ -89,6 +89,9 @@ type KVStore[
 	SetEth1Data(data Eth1DataT) error
 	// GetValidators retrieves all validators.
 	GetValidators() (ValidatorsT, error)
+	/// HERE
+	GetValidatorIndices() ([]math.ValidatorIndex, error)
+	///
 	// GetBalances retrieves all balances.
 	GetBalances() ([]uint64, error)
 	// GetNextWithdrawalIndex retrieves the next withdrawal index.

--- a/mod/storage/pkg/beacondb/registry.go
+++ b/mod/storage/pkg/beacondb/registry.go
@@ -161,6 +161,31 @@ func (kv *KVStore[
 	return vals, nil
 }
 
+func (kv *KVStore[
+	BeaconBlockHeaderT, Eth1DataT, ExecutionPayloadHeaderT,
+	ForkT, ValidatorT, ValidatorsT,
+]) GetValidatorIndices() (
+	[]math.ValidatorIndex, error,
+) {
+	iter, err := kv.validators.Indexes.Pubkey.Iterate(
+		kv.ctx,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var indices []math.ValidatorIndex
+	for ; iter.Valid(); iter.Next() {
+		index, err := iter.PrimaryKey()
+		if err != nil {
+			return nil, err
+		}
+		indices = append(indices, math.ValidatorIndex(index))
+	}
+	return indices, nil
+}
+
 // GetTotalValidators returns the total number of validators.
 func (kv *KVStore[
 	BeaconBlockHeaderT, Eth1DataT, ExecutionPayloadHeaderT,


### PR DESCRIPTION
- Issue: https://github.com/berachain/beacon-kit/issues/2071
- Context: [Node API changes doc](https://forested-starfish-e00.notion.site/Node-API-11db920ebf9780d8b543fdc32462ff10)

This PR fixes the behavior of the `/eth/v1/beacon/states/:state/validators` regarding IDs filters: the current behavior is listing over the IDs filter, but it's optional, leaving no way to list validators without previously knowing their IDs. We fixed this by exposing a new method on the backend and implementing a new query.

It's not ready yet because we still have to implement `validator_status` validation function and status filters. I would love some pointers to the right direction for implementing this.

Also please let me know about any changes to the code I need to make to make sure it matches the codebase's standards. I know I still left some comments and stuff I have to remove before we merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods for retrieving validator indices and lists, enhancing the ability to manage validator data.
	- Added new endpoints for fetching fork schedule, specification data, and deposit contract information.
	- Implemented a validation function for checking validator statuses.

- **Bug Fixes**
	- Improved error handling and logging for validator retrieval processes.

- **Documentation**
	- Updated comments to clarify the purpose of new methods and potential future changes.

- **Chores**
	- Simplified validation requirements for request types related to validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->