### PR TITLE
chore(storage): close storage iterators

### DIFF
--- a/mod/node-core/pkg/components/depinject.go
+++ b/mod/node-core/pkg/components/depinject.go
@@ -51,7 +51,7 @@ type kvStoreService struct {
 }
 
 func (k kvStoreService) OpenKVStore(ctx context.Context) store.KVStore {
-	return newKVStore(sdk.UnwrapSDKContext(ctx).KVStore(k.key))
+	return NewKVStore(sdk.UnwrapSDKContext(ctx).KVStore(k.key))
 }
 
 // CoreKVStore is a wrapper of Core/Store kvstore interface
@@ -62,7 +62,7 @@ type coreKVStore struct {
 
 // NewKVStore returns a wrapper of Core/Store kvstore interface
 // Remove once store migrates to core/store kvstore interface.
-func newKVStore(store storetypes.KVStore) store.KVStore {
+func NewKVStore(store storetypes.KVStore) store.KVStore {
 	return coreKVStore{kvStore: store}
 }
 

--- a/mod/storage/pkg/beacondb/registry_test.go
+++ b/mod/storage/pkg/beacondb/registry_test.go
@@ -58,13 +58,13 @@ var (
 )
 
 func TestGetBalances(t *testing.T) {
-	ctx, err := initKvStore()
+	ctx, err := initStoreBanckend()
 	require.NoError(t, err)
 	testStoreService := &testKVStoreService{
 		ctx: ctx,
 	}
 
-	kvStore := beacondb.New[
+	store := beacondb.New[
 		*types.BeaconBlockHeader,
 		*types.Eth1Data,
 		*types.ExecutionPayloadHeader,
@@ -77,7 +77,7 @@ func TestGetBalances(t *testing.T) {
 	)
 
 	// no balance to start
-	res, err := kvStore.GetBalances()
+	res, err := store.GetBalances()
 	require.NoError(t, err)
 	require.Zero(t, res)
 
@@ -86,19 +86,19 @@ func TestGetBalances(t *testing.T) {
 		idx1, idx2     = math.U64(1_987), math.U64(1_989)
 		inBal1, inBal2 = math.U64(8_992), math.U64(10_000)
 	)
-	require.NoError(t, kvStore.SetBalance(idx1, inBal1))
-	require.NoError(t, kvStore.SetBalance(idx2, inBal2))
+	require.NoError(t, store.SetBalance(idx1, inBal1))
+	require.NoError(t, store.SetBalance(idx2, inBal2))
 
 	// check we can query added balances
-	balRes, err := kvStore.GetBalance(idx1)
+	balRes, err := store.GetBalance(idx1)
 	require.NoError(t, err)
 	require.Equal(t, balRes, inBal1)
 
-	balRes, err = kvStore.GetBalance(idx2)
+	balRes, err = store.GetBalance(idx2)
 	require.NoError(t, err)
 	require.Equal(t, balRes, inBal2)
 
-	res, err = kvStore.GetBalances()
+	res, err = store.GetBalances()
 	require.NoError(t, err)
 	require.Len(t, res, 2)
 	require.Equal(t, res[0], inBal1.Unwrap())
@@ -106,26 +106,26 @@ func TestGetBalances(t *testing.T) {
 
 	// update existing balances
 	newInBal1, newInBal2 := math.U64(0), inBal2*2
-	require.NoError(t, kvStore.SetBalance(idx1, newInBal1))
-	require.NoError(t, kvStore.SetBalance(idx2, newInBal2))
+	require.NoError(t, store.SetBalance(idx1, newInBal1))
+	require.NoError(t, store.SetBalance(idx2, newInBal2))
 
 	// check we can query updated balances
-	balRes, err = kvStore.GetBalance(idx1)
+	balRes, err = store.GetBalance(idx1)
 	require.NoError(t, err)
 	require.Equal(t, balRes, newInBal1)
 
-	balRes, err = kvStore.GetBalance(idx2)
+	balRes, err = store.GetBalance(idx2)
 	require.NoError(t, err)
 	require.Equal(t, balRes, newInBal2)
 
-	res, err = kvStore.GetBalances()
+	res, err = store.GetBalances()
 	require.NoError(t, err)
 	require.Len(t, res, 2)
 	require.Equal(t, res[0], newInBal1.Unwrap())
 	require.Equal(t, res[1], newInBal2.Unwrap())
 }
 
-func initKvStore() (sdk.Context, error) {
+func initStoreBanckend() (sdk.Context, error) {
 	db, err := db.OpenDB("", dbm.MemDBBackend)
 	if err != nil {
 		return sdk.Context{}, fmt.Errorf("failed opening mem db: %w", err)

--- a/mod/storage/pkg/beacondb/registry_test.go
+++ b/mod/storage/pkg/beacondb/registry_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package beacondb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corestore "cosmossdk.io/core/store"
+	"cosmossdk.io/log"
+	"cosmossdk.io/store"
+	"cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/berachain/beacon-kit/mod/consensus-types/pkg/types"
+	"github.com/berachain/beacon-kit/mod/node-core/pkg/components"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
+	"github.com/berachain/beacon-kit/mod/storage/pkg/beacondb"
+	"github.com/berachain/beacon-kit/mod/storage/pkg/db"
+	"github.com/berachain/beacon-kit/mod/storage/pkg/encoding"
+	dbm "github.com/cosmos/cosmos-db"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+type testKVStoreService struct {
+	ctx sdk.Context
+}
+
+func (kvs *testKVStoreService) OpenKVStore(context.Context) corestore.KVStore {
+	//nolint:contextcheck // fine with tests
+	return components.NewKVStore(
+		sdk.UnwrapSDKContext(kvs.ctx).KVStore(testStoreKey),
+	)
+}
+
+var (
+	testStoreKey = storetypes.NewKVStoreKey("storage-tests")
+	testCodec    = &encoding.SSZInterfaceCodec[*types.ExecutionPayloadHeader]{}
+)
+
+func TestGetBalances(t *testing.T) {
+	ctx, err := initKvStore()
+	require.NoError(t, err)
+	testStoreService := &testKVStoreService{
+		ctx: ctx,
+	}
+
+	kvStore := beacondb.New[
+		*types.BeaconBlockHeader,
+		*types.Eth1Data,
+		*types.ExecutionPayloadHeader,
+		*types.Fork,
+		*types.Validator,
+		[]*types.Validator,
+	](
+		testStoreService,
+		testCodec,
+	)
+
+	// no balance to start
+	res, err := kvStore.GetBalances()
+	require.NoError(t, err)
+	require.Zero(t, res)
+
+	// add balances
+	var (
+		idx1, idx2     = math.U64(1_987), math.U64(1_989)
+		inBal1, inBal2 = math.U64(8_992), math.U64(10_000)
+	)
+	require.NoError(t, kvStore.SetBalance(idx1, inBal1))
+	require.NoError(t, kvStore.SetBalance(idx2, inBal2))
+
+	// check we can query added balances
+	balRes, err := kvStore.GetBalance(idx1)
+	require.NoError(t, err)
+	require.Equal(t, balRes, inBal1)
+
+	balRes, err = kvStore.GetBalance(idx2)
+	require.NoError(t, err)
+	require.Equal(t, balRes, inBal2)
+
+	res, err = kvStore.GetBalances()
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+	require.Equal(t, res[0], inBal1.Unwrap())
+	require.Equal(t, res[1], inBal2.Unwrap())
+
+	// update existing balances
+	newInBal1, newInBal2 := math.U64(0), inBal2*2
+	require.NoError(t, kvStore.SetBalance(idx1, newInBal1))
+	require.NoError(t, kvStore.SetBalance(idx2, newInBal2))
+
+	// check we can query updated balances
+	balRes, err = kvStore.GetBalance(idx1)
+	require.NoError(t, err)
+	require.Equal(t, balRes, newInBal1)
+
+	balRes, err = kvStore.GetBalance(idx2)
+	require.NoError(t, err)
+	require.Equal(t, balRes, newInBal2)
+
+	res, err = kvStore.GetBalances()
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+	require.Equal(t, res[0], newInBal1.Unwrap())
+	require.Equal(t, res[1], newInBal2.Unwrap())
+}
+
+func initKvStore() (sdk.Context, error) {
+	db, err := db.OpenDB("", dbm.MemDBBackend)
+	if err != nil {
+		return sdk.Context{}, fmt.Errorf("failed opening mem db: %w", err)
+	}
+	var (
+		nopLog     = log.NewNopLogger()
+		nopMetrics = metrics.NewNoOpMetrics()
+	)
+
+	cms := store.NewCommitMultiStore(
+		db,
+		nopLog,
+		nopMetrics,
+	)
+
+	ctx := sdk.NewContext(cms, true, nopLog)
+	cms.MountStoreWithDB(testStoreKey, storetypes.StoreTypeIAVL, nil)
+	if err = cms.LoadLatestVersion(); err != nil {
+		return sdk.Context{}, fmt.Errorf("failed to load latest version: %w", err)
+	}
+	return ctx, nil
+}

--- a/mod/storage/pkg/beacondb/slashing.go
+++ b/mod/storage/pkg/beacondb/slashing.go
@@ -35,16 +35,19 @@ func (kv *KVStore[
 	if err != nil {
 		return nil, err
 	}
-	for iter.Valid() {
+	defer func() {
+		err = errors.Join(err, iter.Close())
+	}()
+
+	for ; iter.Valid(); iter.Next() {
 		var slashing uint64
 		slashing, err = iter.Value()
 		if err != nil {
 			return nil, err
 		}
 		slashings = append(slashings, math.Gwei(slashing))
-		iter.Next()
 	}
-	return slashings, nil
+	return slashings, err
 }
 
 // GetSlashingAtIndex retrieves the slashing amount by index from the store.


### PR DESCRIPTION
We left unclosed a few iterators once iteration is done.
The PR fixes the issue and add the first UTs of the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to register validators with their effective balances.
  - Added unit tests for managing balances and validators in the key-value store.

- **Bug Fixes**
  - Improved error handling in the management of validators and balances.

- **Refactor**
  - Enhanced iterator management for better error handling in the slashing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->