### PR TITLE
fix(node-api): Use the correct id in the proof endpoints routes

### DIFF
--- a/mod/node-api/handlers/proof/routes.go
+++ b/mod/node-api/handlers/proof/routes.go
@@ -34,17 +34,17 @@ func (
 	h.BaseHandler.AddRoutes([]*handlers.Route[ContextT]{
 		{
 			Method:  http.MethodGet,
-			Path:    "bkit/v1/proof/block_proposer/:execution_id",
+			Path:    "bkit/v1/proof/block_proposer/:timestamp_id",
 			Handler: h.GetBlockProposer,
 		},
 		{
 			Method:  http.MethodGet,
-			Path:    "bkit/v1/proof/execution_number/:execution_id",
+			Path:    "bkit/v1/proof/execution_number/:timestamp_id",
 			Handler: h.GetExecutionNumber,
 		},
 		{
 			Method:  http.MethodGet,
-			Path:    "bkit/v1/proof/execution_fee_recipient/:execution_id",
+			Path:    "bkit/v1/proof/execution_fee_recipient/:timestamp_id",
 			Handler: h.GetExecutionFeeRecipient,
 		},
 	})

--- a/mod/node-api/handlers/proof/types/response.go
+++ b/mod/node-api/handlers/proof/types/response.go
@@ -27,7 +27,7 @@ import (
 )
 
 // BlockProposerResponse is the response for the
-// `/proof/block_proposer/{execution_id}` endpoint.
+// `/proof/block_proposer/{timestamp_id}` endpoint.
 type BlockProposerResponse[BeaconBlockHeaderT any] struct {
 	// BeaconBlockHeader is the block header of which the hash tree root is the
 	// beacon block root to verify against.
@@ -47,7 +47,7 @@ type BlockProposerResponse[BeaconBlockHeaderT any] struct {
 }
 
 // ExecutionNumberResponse is the response for the
-// `/proof/execution_number/{execution_id}` endpoint.
+// `/proof/execution_number/{timestamp_id}` endpoint.
 type ExecutionNumberResponse[BeaconBlockHeaderT any] struct {
 	// BeaconBlockHeader is the block header of which the hash tree root is the
 	// beacon block root to verify against.
@@ -65,7 +65,7 @@ type ExecutionNumberResponse[BeaconBlockHeaderT any] struct {
 }
 
 // ExecutionFeeRecipientResponse is the response for the
-// `/proof/execution_fee_recipient/{execution_id}` endpoint.
+// `/proof/execution_fee_recipient/{timestamp_id}` endpoint.
 type ExecutionFeeRecipientResponse[BeaconBlockHeaderT any] struct {
 	// BeaconBlockHeader is the block header of which the hash tree root is the
 	// beacon block root to verify against.


### PR DESCRIPTION
Fix the routes, from #2066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated API endpoints for retrieving block proposer, execution number, and execution fee recipient with new path identifiers.
	- Improved clarity in route paths by replacing `execution_id` with `timestamp_id`.
- **Documentation**
	- Updated comments for response types to reflect the new endpoint identifiers using `timestamp_id` instead of `execution_id`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->