### PR TITLE
Fix - Update makefile to use new kurtosis repo

### DIFF
--- a/kurtosis/Makefile
+++ b/kurtosis/Makefile
@@ -17,7 +17,8 @@ install-kurtosis:
 			if [ "$$ARCH" = "x86_64" ]; then ARCH="amd64"; \
 			elif [ "$$ARCH" = "arm64" ]; then ARCH="arm64"; \
 			else echo "Unsupported architecture $$ARCH for Kurtosis installation" && exit 1; fi; \
-			curl -Lo kurtosis.tar.gz "https://github.com/kurtosis-tech/kurtosis-cli/releases/latest/download/kurtosis-$$OS-$$ARCH.tar.gz"; \
+			TAG=`curl -s "https://api.github.com/repos/kurtosis-tech/kurtosis-cli-release-artifacts/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`; \
+			curl -Lo kurtosis.tar.gz "https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/latest/download/kurtosis-$$TAG-$$OS-$$ARCH.tar.gz"; \
 			tar -xzf kurtosis.tar.gz; \
 			rm kurtosis.tar.gz; \
 			chmod +x kurtosis; \

--- a/kurtosis/Makefile
+++ b/kurtosis/Makefile
@@ -18,7 +18,7 @@ install-kurtosis:
 			elif [ "$$ARCH" = "arm64" ]; then ARCH="arm64"; \
 			else echo "Unsupported architecture $$ARCH for Kurtosis installation" && exit 1; fi; \
 			TAG=`curl -s "https://api.github.com/repos/kurtosis-tech/kurtosis-cli-release-artifacts/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`; \
-			curl -Lo kurtosis.tar.gz "https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/latest/download/kurtosis-$$TAG-$$OS-$$ARCH.tar.gz"; \
+			curl -Lo kurtosis.tar.gz "https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/download/$TAG/kurtosis-cli_${TAG}_${OS}_${ARCH}.tar.gz"; \
 			tar -xzf kurtosis.tar.gz; \
 			rm kurtosis.tar.gz; \
 			chmod +x kurtosis; \


### PR DESCRIPTION
This PR updates the location for the binaries used to install kurtosis cli during `make start-devnet`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the installation process for the Kurtosis CLI to dynamically retrieve the latest release artifact, ensuring users always get the most recent version.
- **Bug Fixes**
	- Maintained error handling for unsupported architectures during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->