### PR TITLE
chore(payload): uniform error handling for ExecutionPayload retrieval

### DIFF
--- a/mod/payload/pkg/builder/payload.go
+++ b/mod/payload/pkg/builder/payload.go
@@ -121,7 +121,8 @@ func (pb *PayloadBuilder[
 	)
 	if err != nil {
 		return nil, err
-	} else if payloadID == nil {
+	}
+	if payloadID == nil {
 		return nil, ErrNilPayloadID
 	}
 
@@ -140,13 +141,20 @@ func (pb *PayloadBuilder[
 	}
 
 	// Get the payload from the execution client.
-	return pb.ee.GetPayload(
+	envelope, err := pb.ee.GetPayload(
 		ctx,
 		&engineprimitives.GetPayloadRequest[PayloadIDT]{
 			PayloadID:   *payloadID,
 			ForkVersion: pb.chainSpec.ActiveForkVersionForSlot(slot),
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+	if envelope == nil {
+		return nil, ErrNilPayloadEnvelope
+	}
+	return envelope, nil
 }
 
 // RetrievePayload attempts to pull a previously built payload
@@ -181,7 +189,8 @@ func (pb *PayloadBuilder[
 	)
 	if err != nil {
 		return nil, err
-	} else if envelope == nil {
+	}
+	if envelope == nil {
 		return nil, ErrNilPayloadEnvelope
 	}
 


### PR DESCRIPTION
Let [RequestPayloadSync](https://github.com/berachain/beacon-kit/blob/dd024c5b196afe43cf871b5f825a7e371fc4542e/mod/payload/pkg/builder/payload.go#L98) and [RetrievePayload](https://github.com/berachain/beacon-kit/blob/dd024c5b196afe43cf871b5f825a7e371fc4542e/mod/payload/pkg/builder/payload.go#L159) validate the payload in the same way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for streamlined payload retrieval, enhancing clarity and maintainability.
  
- **Bug Fixes**
	- Simplified error handling for nil `payloadID` and `envelope`, improving control flow and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->