### PR TITLE
fix(beacon): consolidated next payload timestamp calculations

### DIFF
--- a/mod/beacon/block-time/payload.go
+++ b/mod/beacon/block-time/payload.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package blocktime
+
+import (
+	"time"
+
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
+)
+
+// NextPayloadTimeFromSuccess calculates the
+// next timestamp for an execution payload
+// once parent block has successfully verified or
+// has been accepted
+//
+// TODO: This is hood and needs to be improved.
+func NextPayloadTimeFromSuccess(
+	chainSpec common.ChainSpec,
+	parentPayloadTime math.U64,
+) uint64 {
+	//#nosec:G701 // not an issue in practice.
+	return max(
+		uint64(time.Now().Unix())+chainSpec.TargetSecondsPerEth1Block(),
+		uint64(parentPayloadTime+1),
+	)
+}
+
+// NextPayloadTimeFromFailure calculates the
+// next timestamp for an execution payload
+// once parent block has not verified.
+//
+// TODO: this is hood as fuck.
+func NextPayloadTimeFromFailure(parentPayloadTime math.U64) uint64 {
+	//#nosec:G701 // not an issue in practice.
+	return max(
+		uint64(time.Now().Add(time.Second).Unix()),
+		uint64(parentPayloadTime+1),
+	)
+}

--- a/mod/beacon/block-time/payload.go
+++ b/mod/beacon/block-time/payload.go
@@ -27,32 +27,17 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
 )
 
-// NextPayloadTimeFromSuccess calculates the
+// NextPayloadTime calculates the
 // next timestamp for an execution payload
-// once parent block has successfully verified or
-// has been accepted
 //
 // TODO: This is hood and needs to be improved.
-func NextPayloadTimeFromSuccess(
+func NextPayloadTime(
 	chainSpec common.ChainSpec,
 	parentPayloadTime math.U64,
 ) uint64 {
 	//#nosec:G701 // not an issue in practice.
 	return max(
 		uint64(time.Now().Unix())+chainSpec.TargetSecondsPerEth1Block(),
-		uint64(parentPayloadTime+1),
-	)
-}
-
-// NextPayloadTimeFromFailure calculates the
-// next timestamp for an execution payload
-// once parent block has not verified.
-//
-// TODO: this is hood as fuck.
-func NextPayloadTimeFromFailure(parentPayloadTime math.U64) uint64 {
-	//#nosec:G701 // not an issue in practice.
-	return max(
-		uint64(time.Now().Add(time.Second).Unix()),
 		uint64(parentPayloadTime+1),
 	)
 }

--- a/mod/beacon/blockchain/execution_engine.go
+++ b/mod/beacon/blockchain/execution_engine.go
@@ -23,7 +23,7 @@ package blockchain
 import (
 	"context"
 
-	blocktime "github.com/berachain/beacon-kit/mod/beacon/block-time"
+	payloadtime "github.com/berachain/beacon-kit/mod/beacon/payload-time"
 	engineprimitives "github.com/berachain/beacon-kit/mod/engine-primitives/pkg/engine-primitives"
 )
 
@@ -80,7 +80,7 @@ func (s *Service[
 		ctx,
 		stCopy,
 		blk.GetSlot()+1,
-		blocktime.NextPayloadTime(s.chainSpec, payloadTime),
+		payloadtime.Next(s.chainSpec, payloadTime),
 		prevBlockRoot,
 		lph.GetBlockHash(),
 		lph.GetParentHash(),

--- a/mod/beacon/blockchain/execution_engine.go
+++ b/mod/beacon/blockchain/execution_engine.go
@@ -80,7 +80,7 @@ func (s *Service[
 		ctx,
 		stCopy,
 		blk.GetSlot()+1,
-		blocktime.NextPayloadTimeFromSuccess(s.chainSpec, payloadTime),
+		blocktime.NextPayloadTime(s.chainSpec, payloadTime),
 		prevBlockRoot,
 		lph.GetBlockHash(),
 		lph.GetParentHash(),

--- a/mod/beacon/blockchain/execution_engine.go
+++ b/mod/beacon/blockchain/execution_engine.go
@@ -22,8 +22,8 @@ package blockchain
 
 import (
 	"context"
-	"time"
 
+	blocktime "github.com/berachain/beacon-kit/mod/beacon/block-time"
 	engineprimitives "github.com/berachain/beacon-kit/mod/engine-primitives/pkg/engine-primitives"
 )
 
@@ -75,11 +75,12 @@ func (s *Service[
 	}
 
 	prevBlockRoot := blk.HashTreeRoot()
+	payloadTime := blk.GetBody().GetExecutionPayload().GetTimestamp()
 	if _, err = s.localBuilder.RequestPayloadAsync(
 		ctx,
 		stCopy,
 		blk.GetSlot()+1,
-		s.calculateNextTimestamp(blk),
+		blocktime.NextPayloadTimeFromSuccess(s.chainSpec, payloadTime),
 		prevBlockRoot,
 		lph.GetBlockHash(),
 		lph.GetParentHash(),
@@ -120,19 +121,4 @@ func (s *Service[
 			"error", err,
 		)
 	}
-}
-
-// calculateNextTimestamp calculates the next timestamp for an execution
-// payload.
-//
-// TODO: This is hood and needs to be improved.
-func (s *Service[
-	_, BeaconBlockT, _, _, _, _, _, _, _, _,
-]) calculateNextTimestamp(blk BeaconBlockT) uint64 {
-	//#nosec:G701 // not an issue in practice.
-	return max(
-		uint64(time.Now().Unix()+
-			int64(s.chainSpec.TargetSecondsPerEth1Block())),
-		uint64(blk.GetBody().GetExecutionPayload().GetTimestamp()+1),
-	)
 }

--- a/mod/beacon/blockchain/payload.go
+++ b/mod/beacon/blockchain/payload.go
@@ -114,7 +114,7 @@ func (s *Service[
 		st,
 		// We are rebuilding for the current slot.
 		stateSlot,
-		blocktime.NextPayloadTimeFromFailure(lph.GetTimestamp()),
+		blocktime.NextPayloadTime(s.chainSpec, lph.GetTimestamp()),
 		// We set the parent root to the previous block root.
 		latestHeader.HashTreeRoot(),
 		// We set the head of our chain to the previous finalized block.
@@ -176,7 +176,7 @@ func (s *Service[
 	if _, err := s.localBuilder.RequestPayloadAsync(
 		ctx, st,
 		slot,
-		blocktime.NextPayloadTimeFromSuccess(s.chainSpec, payload.GetTimestamp()),
+		blocktime.NextPayloadTime(s.chainSpec, payload.GetTimestamp()),
 		// The previous block root is simply the root of the block we just
 		// processed.
 		blk.HashTreeRoot(),

--- a/mod/beacon/blockchain/payload.go
+++ b/mod/beacon/blockchain/payload.go
@@ -23,7 +23,7 @@ package blockchain
 import (
 	"context"
 
-	blocktime "github.com/berachain/beacon-kit/mod/beacon/block-time"
+	payloadtime "github.com/berachain/beacon-kit/mod/beacon/payload-time"
 )
 
 // forceStartupHead sends a force head FCU to the execution client.
@@ -114,7 +114,7 @@ func (s *Service[
 		st,
 		// We are rebuilding for the current slot.
 		stateSlot,
-		blocktime.NextPayloadTime(s.chainSpec, lph.GetTimestamp()),
+		payloadtime.Next(s.chainSpec, lph.GetTimestamp()),
 		// We set the parent root to the previous block root.
 		latestHeader.HashTreeRoot(),
 		// We set the head of our chain to the previous finalized block.
@@ -176,7 +176,7 @@ func (s *Service[
 	if _, err := s.localBuilder.RequestPayloadAsync(
 		ctx, st,
 		slot,
-		blocktime.NextPayloadTime(s.chainSpec, payload.GetTimestamp()),
+		payloadtime.Next(s.chainSpec, payload.GetTimestamp()),
 		// The previous block root is simply the root of the block we just
 		// processed.
 		blk.HashTreeRoot(),

--- a/mod/beacon/blockchain/payload.go
+++ b/mod/beacon/blockchain/payload.go
@@ -22,7 +22,8 @@ package blockchain
 
 import (
 	"context"
-	"time"
+
+	blocktime "github.com/berachain/beacon-kit/mod/beacon/block-time"
 )
 
 // forceStartupHead sends a force head FCU to the execution client.
@@ -113,12 +114,7 @@ func (s *Service[
 		st,
 		// We are rebuilding for the current slot.
 		stateSlot,
-		// TODO: this is hood as fuck.
-		max(
-			//#nosec:G701
-			uint64(time.Now().Unix()+1),
-			uint64((lph.GetTimestamp()+1)),
-		),
+		blocktime.NextPayloadTimeFromFailure(lph.GetTimestamp()),
 		// We set the parent root to the previous block root.
 		latestHeader.HashTreeRoot(),
 		// We set the head of our chain to the previous finalized block.
@@ -180,12 +176,7 @@ func (s *Service[
 	if _, err := s.localBuilder.RequestPayloadAsync(
 		ctx, st,
 		slot,
-		// TODO: this is hood as fuck.
-		max(
-			//#nosec:G701
-			uint64(time.Now().Unix()+int64(s.chainSpec.TargetSecondsPerEth1Block())),
-			uint64((payload.GetTimestamp()+1)),
-		),
+		blocktime.NextPayloadTimeFromSuccess(s.chainSpec, payload.GetTimestamp()),
 		// The previous block root is simply the root of the block we just
 		// processed.
 		blk.HashTreeRoot(),

--- a/mod/beacon/blockchain/process.go
+++ b/mod/beacon/blockchain/process.go
@@ -57,11 +57,6 @@ func (s *Service[
 		return nil, ErrNilBlk
 	}
 
-	// We set `OptimisticEngine` to true since this is called during
-	// FinalizeBlock. We want to assume the payload is valid. If it
-	// ends up not being valid later, the node will simply AppHash,
-	// which is completely fine. This means we were syncing from a
-	// bad peer, and we would likely AppHash anyways.
 	st := s.storageBackend.StateFromContext(ctx)
 	valUpdates, err := s.executeStateTransition(ctx, st, blk)
 	if err != nil {
@@ -107,8 +102,15 @@ func (s *Service[
 	defer s.metrics.measureStateTransitionDuration(startTime)
 	valUpdates, err := s.stateProcessor.Transition(
 		&transition.Context{
-			Context:          ctx,
+			Context: ctx,
+
+			// We set `OptimisticEngine` to true since this is called during
+			// FinalizeBlock. We want to assume the payload is valid. If it
+			// ends up not being valid later, the node will simply AppHash,
+			// which is completely fine. This means we were syncing from a
+			// bad peer, and we would likely AppHash anyways.
 			OptimisticEngine: true,
+
 			// When we are NOT synced to the tip, process proposal
 			// does NOT get called and thus we must ensure that
 			// NewPayload is called to get the execution

--- a/mod/beacon/blockchain/receive.go
+++ b/mod/beacon/blockchain/receive.go
@@ -59,16 +59,14 @@ func (s *Service[
 		"state_root", blk.GetStateRoot(), "slot", blk.GetSlot(),
 	)
 
-	// We purposefully make a copy of the BeaconState in orer
+	// We purposefully make a copy of the BeaconState in order
 	// to avoid modifying the underlying state, for the event in which
 	// we have to rebuild a payload for this slot again, if we do not agree
 	// with the incoming block.
 	postState := preState.Copy()
 
 	// Verify the state root of the incoming block.
-	if err := s.verifyStateRoot(
-		ctx, postState, blk,
-	); err != nil {
+	if err := s.verifyStateRoot(ctx, postState, blk); err != nil {
 		s.logger.Error(
 			"Rejecting incoming beacon block ❌ ",
 			"state_root",

--- a/mod/beacon/blockchain/service.go
+++ b/mod/beacon/blockchain/service.go
@@ -255,8 +255,8 @@ func (s *Service[
 		return
 	}
 
-	// emit a BeaconBlockVerified event with the error result from \
-	// VerifyIncomingBlock
+	// emit a BeaconBlockVerified event with
+	// the error result from VerifyIncomingBlock
 	if err := s.dispatcher.Publish(
 		async.NewEvent(
 			msg.Context(),

--- a/mod/beacon/payload-time/time.go
+++ b/mod/beacon/payload-time/time.go
@@ -18,7 +18,7 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-package blocktime
+package payloadtime
 
 import (
 	"time"
@@ -27,11 +27,11 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
 )
 
-// NextPayloadTime calculates the
+// Next calculates the
 // next timestamp for an execution payload
 //
 // TODO: This is hood and needs to be improved.
-func NextPayloadTime(
+func Next(
 	chainSpec common.ChainSpec,
 	parentPayloadTime math.U64,
 ) uint64 {

--- a/mod/beacon/validator/block_builder.go
+++ b/mod/beacon/validator/block_builder.go
@@ -222,7 +222,7 @@ func (s *Service[
 			return nil, err
 		}
 
-		// If we failed to retrieve the payload, request a synchrnous payload.
+		// If we failed to retrieve the payload, request a synchronous payload.
 		//
 		// NOTE: The state here is properly configured by the
 		// prepareStateForBuilding

--- a/mod/beacon/validator/block_builder.go
+++ b/mod/beacon/validator/block_builder.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"time"
 
+	blocktime "github.com/berachain/beacon-kit/mod/beacon/block-time"
 	engineprimitives "github.com/berachain/beacon-kit/mod/engine-primitives/pkg/engine-primitives"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/bytes"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
@@ -234,12 +235,7 @@ func (s *Service[
 			ctx,
 			st,
 			blk.GetSlot(),
-			// TODO: this is hood.
-			max(
-				//#nosec:G701
-				uint64(time.Now().Unix()+1),
-				uint64((lph.GetTimestamp()+1)),
-			),
+			blocktime.NextPayloadTimeFromFailure(lph.GetTimestamp()),
 			blk.GetParentBlockRoot(),
 			lph.GetBlockHash(),
 			lph.GetParentHash(),

--- a/mod/beacon/validator/block_builder.go
+++ b/mod/beacon/validator/block_builder.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"time"
 
-	blocktime "github.com/berachain/beacon-kit/mod/beacon/block-time"
+	payloadtime "github.com/berachain/beacon-kit/mod/beacon/payload-time"
 	engineprimitives "github.com/berachain/beacon-kit/mod/engine-primitives/pkg/engine-primitives"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/bytes"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
@@ -235,7 +235,7 @@ func (s *Service[
 			ctx,
 			st,
 			blk.GetSlot(),
-			blocktime.NextPayloadTime(s.chainSpec, lph.GetTimestamp()),
+			payloadtime.Next(s.chainSpec, lph.GetTimestamp()),
 			blk.GetParentBlockRoot(),
 			lph.GetBlockHash(),
 			lph.GetParentHash(),

--- a/mod/beacon/validator/block_builder.go
+++ b/mod/beacon/validator/block_builder.go
@@ -235,7 +235,7 @@ func (s *Service[
 			ctx,
 			st,
 			blk.GetSlot(),
-			blocktime.NextPayloadTimeFromFailure(lph.GetTimestamp()),
+			blocktime.NextPayloadTime(s.chainSpec, lph.GetTimestamp()),
 			blk.GetParentBlockRoot(),
 			lph.GetBlockHash(),
 			lph.GetParentHash(),


### PR DESCRIPTION
- fixed `markRebuildPayloadForRejectedBlockFailure` metric
-  consolidated next payload timestamp calculations
- nits and typos

Note: the PR simply enforces a single function to calculate next payload time. The logic by which this timestamp is chosen will be revised in an upcoming PR