### PR TITLE
fix(consensus, beacon): let consensus tell SuggestedNextPayloadTimestamp

### DIFF
--- a/mod/beacon/blockchain/execution_engine.go
+++ b/mod/beacon/blockchain/execution_engine.go
@@ -79,7 +79,7 @@ func (s *Service[
 		ctx,
 		stCopy,
 		beaconBlk.GetSlot()+1,
-		blk.GetConsensusTime().Unwrap(),
+		blk.GetNextPayloadTimestamp().Unwrap(),
 		prevBlockRoot,
 		lph.GetBlockHash(),
 		lph.GetParentHash(),

--- a/mod/beacon/blockchain/payload.go
+++ b/mod/beacon/blockchain/payload.go
@@ -60,12 +60,12 @@ func (s *Service[
 ]) handleRebuildPayloadForRejectedBlock(
 	ctx context.Context,
 	st BeaconStateT,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 ) {
 	if err := s.rebuildPayloadForRejectedBlock(
 		ctx,
 		st,
-		consensusTime,
+		nextPayloadTimestamp,
 	); err != nil {
 		s.logger.Error(
 			"failed to rebuild payload for nil block",
@@ -86,7 +86,7 @@ func (s *Service[
 ]) rebuildPayloadForRejectedBlock(
 	ctx context.Context,
 	st BeaconStateT,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 ) error {
 	s.logger.Info("Rebuilding payload for rejected block ⏳ ")
 
@@ -120,7 +120,7 @@ func (s *Service[
 		st,
 		// We are rebuilding for the current slot.
 		stateSlot,
-		consensusTime.Unwrap(),
+		nextPayloadTimestamp.Unwrap(),
 		// We set the parent root to the previous block root.
 		latestHeader.HashTreeRoot(),
 		// We set the head of our chain to the previous finalized block.
@@ -145,13 +145,13 @@ func (s *Service[
 	ctx context.Context,
 	st BeaconStateT,
 	blk BeaconBlockT,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 ) {
 	if err := s.optimisticPayloadBuild(
 		ctx,
 		st,
 		blk,
-		consensusTime,
+		nextPayloadTimestamp,
 	); err != nil {
 		s.logger.Error(
 			"Failed to build optimistic payload",
@@ -168,7 +168,7 @@ func (s *Service[
 	ctx context.Context,
 	st BeaconStateT,
 	blk BeaconBlockT,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 ) error {
 	// We are building for the next slot, so we increment the slot relative
 	// to the block we just processed.
@@ -189,7 +189,7 @@ func (s *Service[
 	if _, err := s.localBuilder.RequestPayloadAsync(
 		ctx, st,
 		slot,
-		consensusTime.Unwrap(),
+		nextPayloadTimestamp.Unwrap(),
 		// The previous block root is simply the root of the block we just
 		// processed.
 		blk.HashTreeRoot(),

--- a/mod/beacon/blockchain/process.go
+++ b/mod/beacon/blockchain/process.go
@@ -128,7 +128,7 @@ func (s *Service[
 			// actually irrelevant at this point.
 			SkipPayloadVerification: false,
 
-			ConsensusTime: blk.GetConsensusTime(),
+			NextPayloadTimestamp: blk.GetNextPayloadTimestamp(),
 		},
 		st,
 		blk.GetBeaconBlock(),

--- a/mod/beacon/blockchain/receive.go
+++ b/mod/beacon/blockchain/receive.go
@@ -38,8 +38,8 @@ func (s *Service[
 	blk ConsensusBlockT,
 ) error {
 	var (
-		beaconBlk     = blk.GetBeaconBlock()
-		consensusTime = blk.GetConsensusTime()
+		beaconBlk            = blk.GetBeaconBlock()
+		nextPayloadTimestamp = blk.GetNextPayloadTimestamp()
 	)
 
 	// Grab a copy of the state to verify the incoming block.
@@ -84,7 +84,7 @@ func (s *Service[
 			go s.handleRebuildPayloadForRejectedBlock(
 				ctx,
 				preState,
-				consensusTime,
+				nextPayloadTimestamp,
 			)
 		}
 
@@ -102,7 +102,7 @@ func (s *Service[
 			ctx,
 			postState,
 			beaconBlk,
-			consensusTime,
+			nextPayloadTimestamp,
 		)
 	}
 
@@ -128,7 +128,7 @@ func (s *Service[
 			SkipPayloadVerification: false,
 			SkipValidateResult:      false,
 			SkipValidateRandao:      false,
-			ConsensusTime:           blk.GetConsensusTime(),
+			NextPayloadTimestamp:    blk.GetNextPayloadTimestamp(),
 		},
 		st, blk.GetBeaconBlock(),
 	)

--- a/mod/beacon/blockchain/types.go
+++ b/mod/beacon/blockchain/types.go
@@ -45,6 +45,9 @@ type AvailabilityStore[BeaconBlockBodyT any] interface {
 type ConsensusBlock[BeaconBlockT any] interface {
 	GetBeaconBlock() BeaconBlockT
 
+	// GetNextPayloadTimestamp returns the timestamp proposed by
+	// consensus for the next payload to be proposed. It is also
+	// used to bound current payload upon validation
 	GetNextPayloadTimestamp() math.U64
 }
 

--- a/mod/beacon/blockchain/types.go
+++ b/mod/beacon/blockchain/types.go
@@ -45,7 +45,7 @@ type AvailabilityStore[BeaconBlockBodyT any] interface {
 type ConsensusBlock[BeaconBlockT any] interface {
 	GetBeaconBlock() BeaconBlockT
 
-	GetConsensusTime() math.U64
+	GetNextPayloadTimestamp() math.U64
 }
 
 // BeaconBlock represents a beacon block interface.

--- a/mod/beacon/validator/block_builder.go
+++ b/mod/beacon/validator/block_builder.go
@@ -75,9 +75,7 @@ func (s *Service[
 	}
 
 	// Create a new empty block from the current state.
-	blk, err = s.getEmptyBeaconBlockForSlot(
-		st, slotData.GetSlot(),
-	)
+	blk, err = s.getEmptyBeaconBlockForSlot(st, slotData.GetSlot())
 	if err != nil {
 		return blk, sidecars, err
 	}
@@ -116,7 +114,7 @@ func (s *Service[
 	g.Go(func() error {
 		return s.computeAndSetStateRoot(
 			ctx,
-			slotData.GetConsensusTime(),
+			slotData.GetNextPayloadTimestamp(),
 			st,
 			blk,
 		)
@@ -243,7 +241,7 @@ func (s *Service[
 			ctx,
 			st,
 			blk.GetSlot(),
-			uint64(slotData.GetConsensusTime()),
+			slotData.GetNextPayloadTimestamp().Unwrap(),
 			blk.GetParentBlockRoot(),
 			lph.GetBlockHash(),
 			lph.GetParentHash(),
@@ -338,11 +336,11 @@ func (s *Service[
 	_, BeaconBlockT, _, BeaconStateT, _, _, _, _, _, _, _, _, _,
 ]) computeAndSetStateRoot(
 	ctx context.Context,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 	st BeaconStateT,
 	blk BeaconBlockT,
 ) error {
-	stateRoot, err := s.computeStateRoot(ctx, consensusTime, st, blk)
+	stateRoot, err := s.computeStateRoot(ctx, nextPayloadTimestamp, st, blk)
 	if err != nil {
 		s.logger.Error(
 			"failed to compute state root while building block ❗️ ",
@@ -360,7 +358,7 @@ func (s *Service[
 	_, BeaconBlockT, _, BeaconStateT, _, _, _, _, _, _, _, _, _,
 ]) computeStateRoot(
 	ctx context.Context,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 	st BeaconStateT,
 	blk BeaconBlockT,
 ) (common.Root, error) {
@@ -376,7 +374,7 @@ func (s *Service[
 			SkipPayloadVerification: true,
 			SkipValidateResult:      true,
 			SkipValidateRandao:      true,
-			ConsensusTime:           consensusTime,
+			NextPayloadTimestamp:    nextPayloadTimestamp,
 		},
 		st, blk,
 	); err != nil {

--- a/mod/beacon/validator/types.go
+++ b/mod/beacon/validator/types.go
@@ -190,8 +190,9 @@ type SlotData[AttestationDataT, SlashingInfoT any] interface {
 	GetAttestationData() []AttestationDataT
 	// GetSlashingInfo returns the slashing info of the incoming slot.
 	GetSlashingInfo() []SlashingInfoT
-	// GetNextPayloadTimestamp returns the consensus proposed timestamp
-	// for the next execution payload
+	// GetNextPayloadTimestamp returns the timestamp proposed by
+	// consensus for the next payload to be proposed. It is also
+	// used to bound current payload upon validation
 	GetNextPayloadTimestamp() math.U64
 }
 

--- a/mod/beacon/validator/types.go
+++ b/mod/beacon/validator/types.go
@@ -190,8 +190,9 @@ type SlotData[AttestationDataT, SlashingInfoT any] interface {
 	GetAttestationData() []AttestationDataT
 	// GetSlashingInfo returns the slashing info of the incoming slot.
 	GetSlashingInfo() []SlashingInfoT
-	// GetConsensusTime returns network agreed time when slot is proposed
-	GetConsensusTime() math.U64
+	// GetNextPayloadTimestamp returns the consensus proposed timestamp
+	// for the next execution payload
+	GetNextPayloadTimestamp() math.U64
 }
 
 // StateProcessor defines the interface for processing the state.

--- a/mod/consensus/pkg/cometbft/service/abci.go
+++ b/mod/consensus/pkg/cometbft/service/abci.go
@@ -212,7 +212,11 @@ func (s *Service[LoggerT]) PrepareProposal(
 		math.Slot(req.GetHeight()),
 		nil,
 		nil,
-		math.U64(req.GetTime().Unix()),
+
+		// we do not add h.minPayloadDelay here since req.GetTime()
+		// is guaranteed to be strictly larger than
+		// prevBlock.GetTime() + h.minPayloadDelay
+		req.GetTime(),
 	)
 	blkBz, sidecarsBz, err := s.Middleware.PrepareProposal(
 		s.prepareProposalState.Context(),

--- a/mod/consensus/pkg/cometbft/service/middleware/abci.go
+++ b/mod/consensus/pkg/cometbft/service/middleware/abci.go
@@ -224,7 +224,7 @@ func (h *ABCIMiddleware[
 	var enrichedBlk *types.ConsensusBlock[BeaconBlockT]
 	enrichedBlk = enrichedBlk.New(
 		blk,
-		req.GetTime(),
+		req.GetTime().Add(h.minPayloadDelay),
 	)
 	blkEvent := async.NewEvent(ctx, async.BeaconBlockReceived, enrichedBlk)
 	if err = h.dispatcher.Publish(blkEvent); err != nil {
@@ -341,7 +341,7 @@ func (h *ABCIMiddleware[
 	var enrichedBlk *types.ConsensusBlock[BeaconBlockT]
 	enrichedBlk = enrichedBlk.New(
 		blk,
-		req.GetTime(),
+		req.GetTime().Add(h.minPayloadDelay),
 	)
 	blkEvent := async.NewEvent(ctx, async.FinalBeaconBlockReceived, enrichedBlk)
 	if err = h.dispatcher.Publish(blkEvent); err != nil {

--- a/mod/consensus/pkg/cometbft/service/middleware/middleware.go
+++ b/mod/consensus/pkg/cometbft/service/middleware/middleware.go
@@ -22,12 +22,14 @@ package middleware
 
 import (
 	"context"
+	"time"
 
 	"github.com/berachain/beacon-kit/mod/async/pkg/types"
 	"github.com/berachain/beacon-kit/mod/log"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/async"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/encoding/json"
+	cmtcfg "github.com/cometbft/cometbft/config"
 )
 
 // ABCIMiddleware is a middleware between ABCI and the validator logic.
@@ -39,6 +41,9 @@ type ABCIMiddleware[
 ] struct {
 	// chainSpec is the chain specification.
 	chainSpec common.ChainSpec
+	// minimum delay among blocks, useful to set a strictly increasing
+	// execution payload timestamp
+	minPayloadDelay time.Duration
 	// dispatcher is the central dispatcher to
 	dispatcher types.EventDispatcher
 	// metrics is the metrics emitter.
@@ -68,16 +73,25 @@ func NewABCIMiddleware[
 	SlotDataT any,
 ](
 	chainSpec common.ChainSpec,
+	cmtCfg *cmtcfg.Config,
 	dispatcher types.EventDispatcher,
 	logger log.Logger,
 	telemetrySink TelemetrySink,
 ) *ABCIMiddleware[
 	BeaconBlockT, BlobSidecarsT, GenesisT, SlotDataT,
 ] {
+	minPayloadDelay := min(
+		cmtCfg.Consensus.TimeoutPropose,
+		cmtCfg.Consensus.TimeoutPrevote,
+		cmtCfg.Consensus.TimeoutPrecommit,
+		cmtCfg.Consensus.TimeoutCommit,
+	)
+
 	return &ABCIMiddleware[
 		BeaconBlockT, BlobSidecarsT, GenesisT, SlotDataT,
 	]{
 		chainSpec:                chainSpec,
+		minPayloadDelay:          minPayloadDelay,
 		dispatcher:               dispatcher,
 		logger:                   logger,
 		metrics:                  newABCIMiddlewareMetrics(telemetrySink),

--- a/mod/consensus/pkg/cometbft/service/middleware/middleware.go
+++ b/mod/consensus/pkg/cometbft/service/middleware/middleware.go
@@ -42,7 +42,7 @@ type ABCIMiddleware[
 	// chainSpec is the chain specification.
 	chainSpec common.ChainSpec
 	// minimum delay among blocks, useful to set a strictly increasing
-	// execution payload timestamp
+	// execution payload timestamp.
 	minPayloadDelay time.Duration
 	// dispatcher is the central dispatcher to
 	dispatcher types.EventDispatcher
@@ -80,6 +80,10 @@ func NewABCIMiddleware[
 ) *ABCIMiddleware[
 	BeaconBlockT, BlobSidecarsT, GenesisT, SlotDataT,
 ] {
+	// We may build execution payload optimistically, i.e. build execution
+	// payload for next block while current block is being verified and not yet
+	// finalized. Hence we need a minPayloadDelay that guarantees that:
+	// curr
 	minPayloadDelay := min(
 		cmtCfg.Consensus.TimeoutPropose,
 		cmtCfg.Consensus.TimeoutPrevote,

--- a/mod/consensus/pkg/cometbft/service/service.go
+++ b/mod/consensus/pkg/cometbft/service/service.go
@@ -82,6 +82,10 @@ type Service[
 	initialHeight   int64
 	minRetainBlocks uint64
 
+	// minimum delay among blocks, useful to set a strictly increasing
+	// execution payload timestamp
+	minPayloadDelay uint64
+
 	chainID string
 }
 
@@ -121,6 +125,13 @@ func NewService[
 	if err := s.sm.LoadLatestVersion(); err != nil {
 		panic(err)
 	}
+
+	s.minPayloadDelay = uint64(min(
+		cmtCfg.Consensus.TimeoutPropose,
+		cmtCfg.Consensus.TimeoutPrevote,
+		cmtCfg.Consensus.TimeoutPrecommit,
+		cmtCfg.Consensus.TimeoutCommit,
+	))
 
 	return s
 }

--- a/mod/consensus/pkg/cometbft/service/service.go
+++ b/mod/consensus/pkg/cometbft/service/service.go
@@ -82,10 +82,6 @@ type Service[
 	initialHeight   int64
 	minRetainBlocks uint64
 
-	// minimum delay among blocks, useful to set a strictly increasing
-	// execution payload timestamp
-	minPayloadDelay uint64
-
 	chainID string
 }
 
@@ -125,13 +121,6 @@ func NewService[
 	if err := s.sm.LoadLatestVersion(); err != nil {
 		panic(err)
 	}
-
-	s.minPayloadDelay = uint64(min(
-		cmtCfg.Consensus.TimeoutPropose,
-		cmtCfg.Consensus.TimeoutPrevote,
-		cmtCfg.Consensus.TimeoutPrecommit,
-		cmtCfg.Consensus.TimeoutCommit,
-	))
 
 	return s
 }

--- a/mod/consensus/pkg/types/consensus_block.go
+++ b/mod/consensus/pkg/types/consensus_block.go
@@ -29,9 +29,6 @@ import (
 type ConsensusBlock[BeaconBlockT any] struct {
 	blk BeaconBlockT
 
-	// nextPayloadTimestamp is the timestamp proposed by consensus
-	// for the next payload to be proposed.
-	// TODO: consider validating that it is strictly bounded and increasing
 	nextPayloadTimestamp math.U64
 }
 
@@ -51,6 +48,9 @@ func (b *ConsensusBlock[BeaconBlockT]) GetBeaconBlock() BeaconBlockT {
 	return b.blk
 }
 
+// GetNextPayloadTimestamp returns the timestamp proposed by consensus
+// for the next payload to be proposed. It is also used to bound
+// current payload upon validation.
 func (b *ConsensusBlock[_]) GetNextPayloadTimestamp() math.U64 {
 	return b.nextPayloadTimestamp
 }

--- a/mod/consensus/pkg/types/consensus_block.go
+++ b/mod/consensus/pkg/types/consensus_block.go
@@ -29,18 +29,20 @@ import (
 type ConsensusBlock[BeaconBlockT any] struct {
 	blk BeaconBlockT
 
-	// consensusTime assigned by CometBFT to the beacon block
-	consensusTime math.U64
+	// nextPayloadTimestamp is the timestamp proposed by consensus
+	// for the next payload to be proposed.
+	// TODO: consider validating that it is strictly bounded and increasing
+	nextPayloadTimestamp math.U64
 }
 
 // New creates a new SlotData instance.
 func (b *ConsensusBlock[BeaconBlockT]) New(
 	beaconBlock BeaconBlockT,
-	blkTime time.Time,
+	nextPayloadTimestamp time.Time,
 ) *ConsensusBlock[BeaconBlockT] {
 	b = &ConsensusBlock[BeaconBlockT]{
-		blk:           beaconBlock,
-		consensusTime: math.U64(blkTime.Unix()),
+		blk:                  beaconBlock,
+		nextPayloadTimestamp: math.U64(nextPayloadTimestamp.Unix()),
 	}
 	return b
 }
@@ -49,6 +51,6 @@ func (b *ConsensusBlock[BeaconBlockT]) GetBeaconBlock() BeaconBlockT {
 	return b.blk
 }
 
-func (b *ConsensusBlock[_]) GetConsensusTime() math.U64 {
-	return b.consensusTime
+func (b *ConsensusBlock[_]) GetNextPayloadTimestamp() math.U64 {
+	return b.nextPayloadTimestamp
 }

--- a/mod/consensus/pkg/types/slot_data.go
+++ b/mod/consensus/pkg/types/slot_data.go
@@ -34,9 +34,9 @@ type SlotData[AttestationDataT, SlashingInfoT any] struct {
 	attestationData []AttestationDataT
 	// slashingInfo is the slashing info of the incoming slot.
 	slashingInfo []SlashingInfoT
-	// nextPayloadTimestamp is the timestamp proposed by consensus
-	// for the next payload to be proposed.
-	// TODO: consider validating that it is strictly bounded and increasing
+	// nextPayloadTimestamp is the timestamp proposed by
+	// consensus for the next payload to be proposed. It is also
+	// used to bound current payload upon validation
 	nextPayloadTimestamp math.U64
 }
 

--- a/mod/consensus/pkg/types/slot_data.go
+++ b/mod/consensus/pkg/types/slot_data.go
@@ -30,8 +30,10 @@ type SlotData[AttestationDataT, SlashingInfoT any] struct {
 	attestationData []AttestationDataT
 	// slashingInfo is the slashing info of the incoming slot.
 	slashingInfo []SlashingInfoT
-	// Time tracked by consensus engine at the time SlotData is emitted.
-	consensusTime math.U64
+	// nextPayloadTimestamp is the timestamp proposed by consensus
+	// for the next payload to be proposed.
+	// TODO: consider validating that it is strictly bounded and increasing
+	nextPayloadTimestamp math.U64
 }
 
 // New creates a new SlotData instance.
@@ -39,13 +41,13 @@ func (b *SlotData[AttestationDataT, SlashingInfoT]) New(
 	slot math.Slot,
 	attestationData []AttestationDataT,
 	slashingInfo []SlashingInfoT,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 ) *SlotData[AttestationDataT, SlashingInfoT] {
 	b = &SlotData[AttestationDataT, SlashingInfoT]{
-		slot:            slot,
-		attestationData: attestationData,
-		slashingInfo:    slashingInfo,
-		consensusTime:   consensusTime,
+		slot:                 slot,
+		attestationData:      attestationData,
+		slashingInfo:         slashingInfo,
+		nextPayloadTimestamp: nextPayloadTimestamp,
 	}
 	return b
 }
@@ -71,12 +73,12 @@ func (b *SlotData[
 	return b.slashingInfo
 }
 
-// GetConsensusTime retrieves the consensus time.
+// GetNextPayloadTimestamp retrieves the proposed next payload timestamp.
 func (b *SlotData[
 	AttestationDataT,
 	SlashingInfoT,
-]) GetConsensusTime() math.U64 {
-	return b.consensusTime
+]) GetNextPayloadTimestamp() math.U64 {
+	return b.nextPayloadTimestamp
 }
 
 // SetAttestationData sets the attestation data of the SlotData.

--- a/mod/consensus/pkg/types/slot_data.go
+++ b/mod/consensus/pkg/types/slot_data.go
@@ -20,7 +20,11 @@
 
 package types
 
-import "github.com/berachain/beacon-kit/mod/primitives/pkg/math"
+import (
+	"time"
+
+	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
+)
 
 // SlotData represents the data to be used to propose a block.
 type SlotData[AttestationDataT, SlashingInfoT any] struct {
@@ -41,13 +45,13 @@ func (b *SlotData[AttestationDataT, SlashingInfoT]) New(
 	slot math.Slot,
 	attestationData []AttestationDataT,
 	slashingInfo []SlashingInfoT,
-	nextPayloadTimestamp math.U64,
+	nextPayloadTimestamp time.Time,
 ) *SlotData[AttestationDataT, SlashingInfoT] {
 	b = &SlotData[AttestationDataT, SlashingInfoT]{
 		slot:                 slot,
 		attestationData:      attestationData,
 		slashingInfo:         slashingInfo,
-		nextPayloadTimestamp: nextPayloadTimestamp,
+		nextPayloadTimestamp: math.U64(nextPayloadTimestamp.Unix()),
 	}
 	return b
 }

--- a/mod/node-core/pkg/components/interfaces.go
+++ b/mod/node-core/pkg/components/interfaces.go
@@ -83,6 +83,9 @@ type (
 	ConsensusBlock[BeaconBlockT any] interface {
 		GetBeaconBlock() BeaconBlockT
 
+		// GetNextPayloadTimestamp returns the timestamp proposed by
+		// consensus for the next payload to be proposed. It is also
+		// used to bound current payload upon validation
 		GetNextPayloadTimestamp() math.U64
 	}
 

--- a/mod/node-core/pkg/components/interfaces.go
+++ b/mod/node-core/pkg/components/interfaces.go
@@ -83,7 +83,7 @@ type (
 	ConsensusBlock[BeaconBlockT any] interface {
 		GetBeaconBlock() BeaconBlockT
 
-		GetConsensusTime() math.U64
+		GetNextPayloadTimestamp() math.U64
 	}
 
 	// BeaconBlock represents a generic interface for a beacon block.

--- a/mod/node-core/pkg/components/middleware.go
+++ b/mod/node-core/pkg/components/middleware.go
@@ -26,6 +26,7 @@ import (
 	"github.com/berachain/beacon-kit/mod/log"
 	"github.com/berachain/beacon-kit/mod/node-core/pkg/components/metrics"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
+	cmtcfg "github.com/cometbft/cometbft/config"
 )
 
 // ABCIMiddlewareInput is the input for the validator middleware provider.
@@ -36,6 +37,7 @@ type ABCIMiddlewareInput[
 ] struct {
 	depinject.In
 	ChainSpec     common.ChainSpec
+	CmtCfg        *cmtcfg.Config
 	Dispatcher    Dispatcher
 	Logger        LoggerT
 	TelemetrySink *metrics.TelemetrySink
@@ -65,6 +67,7 @@ func ProvideABCIMiddleware[
 		*SlotData,
 	](
 		in.ChainSpec,
+		in.CmtCfg,
 		in.Dispatcher,
 		in.Logger,
 		in.TelemetrySink,

--- a/mod/primitives/pkg/transition/context.go
+++ b/mod/primitives/pkg/transition/context.go
@@ -42,8 +42,9 @@ type Context struct {
 	// SkipValidateResult indicates whether to validate the result of
 	// the state transition.
 	SkipValidateResult bool
-	// NextPayloadTimestamp is consensus proposed timestamp for the
-	// next payload to be built
+	// NextPayloadTimestamp is the timestamp proposed by
+	// consensus for the next payload to be proposed. It is also
+	// used to bound current payload upon validation
 	NextPayloadTimestamp math.U64
 }
 
@@ -73,7 +74,8 @@ func (c *Context) GetSkipValidateResult() bool {
 }
 
 // GetNextPayloadTimestamp returns the timestamp proposed by consensus
-// for the next payload to be built.
+// for the next payload to be proposed. It is also used to bound
+// current payload upon validation.
 func (c *Context) GetNextPayloadTimestamp() math.U64 {
 	return c.NextPayloadTimestamp
 }

--- a/mod/primitives/pkg/transition/context.go
+++ b/mod/primitives/pkg/transition/context.go
@@ -42,9 +42,9 @@ type Context struct {
 	// SkipValidateResult indicates whether to validate the result of
 	// the state transition.
 	SkipValidateResult bool
-	// ConsensusTime is the network agreed time for the block causing the
-	// state transition to be performed
-	ConsensusTime math.U64
+	// NextPayloadTimestamp is consensus proposed timestamp for the
+	// next payload to be built
+	NextPayloadTimestamp math.U64
 }
 
 // GetOptimisticEngine returns whether to optimistically assume the execution
@@ -72,10 +72,10 @@ func (c *Context) GetSkipValidateResult() bool {
 	return c.SkipValidateResult
 }
 
-// GetConsensusTime returns the consensus time for the block causing
-// the state transition.
-func (c *Context) GetConsensusTime() math.U64 {
-	return c.ConsensusTime
+// GetNextPayloadTimestamp returns the timestamp proposed by consensus
+// for the next payload to be built.
+func (c *Context) GetNextPayloadTimestamp() math.U64 {
+	return c.NextPayloadTimestamp
 }
 
 // Unwrap returns the underlying standard context.

--- a/mod/state-transition/pkg/core/state_processor_payload.go
+++ b/mod/state-transition/pkg/core/state_processor_payload.go
@@ -51,7 +51,7 @@ func (sp *StateProcessor[
 		g.Go(func() error {
 			return sp.validateExecutionPayload(
 				gCtx, st, blk,
-				ctx.GetConsensusTime(),
+				ctx.GetNextPayloadTimestamp(),
 				ctx.GetOptimisticEngine(),
 			)
 		})
@@ -87,10 +87,10 @@ func (sp *StateProcessor[
 	ctx context.Context,
 	st BeaconStateT,
 	blk BeaconBlockT,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 	optimisticEngine bool,
 ) error {
-	if err := sp.validateStatelessPayload(blk, consensusTime); err != nil {
+	if err := sp.validateStatelessPayload(blk, nextPayloadTimestamp); err != nil {
 		return err
 	}
 	return sp.validateStatefulPayload(ctx, st, blk, optimisticEngine)
@@ -102,12 +102,13 @@ func (sp *StateProcessor[
 	_, _, _, _, _, _, _, _, _, _, _, _, _,
 ]) validateStatelessPayload(
 	blk BeaconBlockT,
-	consensusTime math.U64,
+	nextPayloadTimestamp math.U64,
 ) error {
 	body := blk.GetBody()
 	payload := body.GetExecutionPayload()
 
-	timeBound := consensusTime + math.U64(sp.cs.TargetSecondsPerEth1Block())
+	timeBound := nextPayloadTimestamp +
+		math.U64(sp.cs.TargetSecondsPerEth1Block()) // TODO: consider other bound
 	if pt := payload.GetTimestamp(); pt > timeBound {
 		return errors.Wrapf(
 			ErrTooFarInTheFuture,

--- a/mod/state-transition/pkg/core/state_processor_payload.go
+++ b/mod/state-transition/pkg/core/state_processor_payload.go
@@ -107,13 +107,11 @@ func (sp *StateProcessor[
 	body := blk.GetBody()
 	payload := body.GetExecutionPayload()
 
-	timeBound := nextPayloadTimestamp +
-		math.U64(sp.cs.TargetSecondsPerEth1Block()) // TODO: consider other bound
-	if pt := payload.GetTimestamp(); pt > timeBound {
+	if pt := payload.GetTimestamp(); pt > nextPayloadTimestamp {
 		return errors.Wrapf(
 			ErrTooFarInTheFuture,
 			"payload timestamp, max: %d, got: %d",
-			timeBound, pt,
+			nextPayloadTimestamp, pt,
 		)
 	}
 

--- a/mod/state-transition/pkg/core/types.go
+++ b/mod/state-transition/pkg/core/types.go
@@ -118,8 +118,9 @@ type Context interface {
 	// GetSkipValidateResult returns whether to validate the result of the state
 	// transition.
 	GetSkipValidateResult() bool
-	// GetNextPayloadTimestamp returns the consensus proposed timestamp
-	// for the next payload to be built.
+	// GetNextPayloadTimestamp returns the timestamp proposed by
+	// consensus for the next payload to be proposed. It is also
+	// used to bound current payload upon validation
 	GetNextPayloadTimestamp() math.U64
 }
 

--- a/mod/state-transition/pkg/core/types.go
+++ b/mod/state-transition/pkg/core/types.go
@@ -118,9 +118,9 @@ type Context interface {
 	// GetSkipValidateResult returns whether to validate the result of the state
 	// transition.
 	GetSkipValidateResult() bool
-	// GetConsensusTime returns the consensus time for the block causing
-	// the state transition.
-	GetConsensusTime() math.U64
+	// GetNextPayloadTimestamp returns the consensus proposed timestamp
+	// for the next payload to be built.
+	GetNextPayloadTimestamp() math.U64
 }
 
 // Deposit is the interface for a deposit.


### PR DESCRIPTION
We let a consensus block indicate the proposed timestamp for the next payload, which:

- Is built to be strictly monotonic across all ABCI requests (Propose/Prepare/FinalizeBlock)
- Is used to bound current payload timestamp, to avoid dangerous run-aways