### PR TITLE
fix(state-transition): fix deposit index upon genesis processing

### DIFF
--- a/mod/state-transition/pkg/core/helpers_test.go
+++ b/mod/state-transition/pkg/core/helpers_test.go
@@ -30,12 +30,51 @@ import (
 	"cosmossdk.io/store/metrics"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/berachain/beacon-kit/mod/consensus-types/pkg/types"
+	engineprimitives "github.com/berachain/beacon-kit/mod/engine-primitives/pkg/engine-primitives"
 	"github.com/berachain/beacon-kit/mod/node-core/pkg/components"
+	statedb "github.com/berachain/beacon-kit/mod/state-transition/pkg/core/state"
 	"github.com/berachain/beacon-kit/mod/storage/pkg/beacondb"
 	"github.com/berachain/beacon-kit/mod/storage/pkg/db"
 	"github.com/berachain/beacon-kit/mod/storage/pkg/encoding"
 	dbm "github.com/cosmos/cosmos-db"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type (
+	TestBeaconStateMarshallableT = types.BeaconState[
+		*types.BeaconBlockHeader,
+		*types.Eth1Data,
+		*types.ExecutionPayloadHeader,
+		*types.Fork,
+		*types.Validator,
+		types.BeaconBlockHeader,
+		types.Eth1Data,
+		types.ExecutionPayloadHeader,
+		types.Fork,
+		types.Validator,
+	]
+
+	TestKVStoreT = beacondb.KVStore[
+		*types.BeaconBlockHeader,
+		*types.Eth1Data,
+		*types.ExecutionPayloadHeader,
+		*types.Fork,
+		*types.Validator,
+		types.Validators,
+	]
+
+	TestBeaconStateT = statedb.StateDB[
+		*types.BeaconBlockHeader,
+		*TestBeaconStateMarshallableT,
+		*types.Eth1Data,
+		*types.ExecutionPayloadHeader,
+		*types.Fork,
+		*TestKVStoreT,
+		*types.Validator,
+		types.Validators,
+		*engineprimitives.Withdrawal,
+		types.WithdrawalCredentials,
+	]
 )
 
 type testKVStoreService struct {

--- a/mod/state-transition/pkg/core/state_processor.go
+++ b/mod/state-transition/pkg/core/state_processor.go
@@ -85,6 +85,10 @@ type StateProcessor[
 	executionEngine ExecutionEngine[
 		ExecutionPayloadT, ExecutionPayloadHeaderT, WithdrawalsT,
 	]
+
+	// processingGenesis allows initializing correctly
+	// eth1 deposit index upon genesis
+	processingGenesis bool
 }
 
 // NewStateProcessor creates a new state processor.

--- a/mod/state-transition/pkg/core/state_processor_genesis_test.go
+++ b/mod/state-transition/pkg/core/state_processor_genesis_test.go
@@ -34,47 +34,8 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/version"
 	"github.com/berachain/beacon-kit/mod/state-transition/pkg/core"
 	"github.com/berachain/beacon-kit/mod/state-transition/pkg/core/mocks"
-	statedb "github.com/berachain/beacon-kit/mod/state-transition/pkg/core/state"
-	"github.com/berachain/beacon-kit/mod/storage/pkg/beacondb"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-)
-
-type (
-	TestBeaconStateMarshallableT = types.BeaconState[
-		*types.BeaconBlockHeader,
-		*types.Eth1Data,
-		*types.ExecutionPayloadHeader,
-		*types.Fork,
-		*types.Validator,
-		types.BeaconBlockHeader,
-		types.Eth1Data,
-		types.ExecutionPayloadHeader,
-		types.Fork,
-		types.Validator,
-	]
-
-	TestKVStoreT = beacondb.KVStore[
-		*types.BeaconBlockHeader,
-		*types.Eth1Data,
-		*types.ExecutionPayloadHeader,
-		*types.Fork,
-		*types.Validator,
-		types.Validators,
-	]
-
-	TestBeaconStateT = statedb.StateDB[
-		*types.BeaconBlockHeader,
-		*TestBeaconStateMarshallableT,
-		*types.Eth1Data,
-		*types.ExecutionPayloadHeader,
-		*types.Fork,
-		*TestKVStoreT,
-		*types.Validator,
-		types.Validators,
-		*engineprimitives.Withdrawal,
-		types.WithdrawalCredentials,
-	]
 )
 
 func TestInitialize(t *testing.T) {
@@ -183,4 +144,9 @@ func TestInitialize(t *testing.T) {
 		require.Equal(t, dep.Pubkey, val.Pubkey)
 		require.Equal(t, dep.Amount, val.EffectiveBalance)
 	}
+
+	// check that validator index is duly set
+	latestValIdx, err := beaconState.GetEth1DepositIndex()
+	require.NoError(t, err)
+	require.Equal(t, uint64(len(deposits)-1), latestValIdx)
 }

--- a/mod/state-transition/pkg/core/state_processor_staking.go
+++ b/mod/state-transition/pkg/core/state_processor_staking.go
@@ -21,6 +21,8 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/berachain/beacon-kit/mod/errors"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
@@ -83,14 +85,19 @@ func (sp *StateProcessor[
 	st BeaconStateT,
 	dep DepositT,
 ) error {
-	depositIndex, err := st.GetEth1DepositIndex()
-	if err != nil {
-		return err
+	var nextDepositIndex uint64
+	switch depositIndex, err := st.GetEth1DepositIndex(); {
+	case err == nil:
+		nextDepositIndex = depositIndex + 1
+	case sp.processingGenesis && err != nil:
+		// Eth1DepositIndex may have not been set yet
+		nextDepositIndex = 0
+	default:
+		// Failed retrieving Eth1DepositIndex outside genesis is an error
+		return fmt.Errorf("failed retrieving eth1 deposit index: %w", err)
 	}
 
-	if err = st.SetEth1DepositIndex(
-		depositIndex + 1,
-	); err != nil {
+	if err := st.SetEth1DepositIndex(nextDepositIndex); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/berachain/beacon-kit/issues/1538

The more general cleanup to drop Eth1Data is deferred to a future PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new package for mock generation to facilitate testing.
  - Introduced a new interface for managing withdrawals, enhancing clarity in the execution engine.

- **Bug Fixes**
  - Improved error handling in deposit processing and withdrawal functions.

- **Tests**
  - Added a test suite for validating the initialization of the state processor from Ethereum 1.0 data.

- **Documentation**
  - Enhanced comments and organization for better code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->