### PR TITLE
fix(consensus): raised max_tx_bytes will above txs size

### DIFF
--- a/testing/networks/80084/config.toml
+++ b/testing/networks/80084/config.toml
@@ -365,7 +365,7 @@ wal_dir = ""
 size = 0
 
 # Maximum size in bytes of a single transaction accepted into the mempool.
-max_tx_bytes = 1048576
+max_tx_bytes = 104857600 // 100 MB high enough to be impossible to hit
 
 # The maximum size in bytes of all transactions stored in the mempool.
 # This is the raw, total transaction size. For example, given 1MB


### PR DESCRIPTION
This PR sets `max_tx_bytes` configuration in CometBFT high enough such that it is impossible to ever encounter a tuple of (`BeaconBlock`, `BlobSidecars`) that exceeds the byte limit.
If that would happen, the proposed block will not be accepted and  since in the current state, honest validators do not prune transactions, the failing txs would be proposed over and over again.

We should consider enforcing that the increase limit is picked by default upon config files generation