### PR TITLE
Fix - Update erigon repo

### DIFF
--- a/build/scripts/testing.mk
+++ b/build/scripts/testing.mk
@@ -202,7 +202,7 @@ start-erigon: ## start an ephemeral `erigon` node
 	docker run \
     --rm -v $(PWD)/${TESTAPP_FILES_DIR}:/${TESTAPP_FILES_DIR} \
     -v $(PWD)/.tmp:/.tmp \
-    thorax/erigon:latest init \
+    erigontech/erigon:latest init \
     --datadir .tmp/erigon \
     ${ETH_GENESIS_PATH}
 
@@ -212,7 +212,7 @@ start-erigon: ## start an ephemeral `erigon` node
 	-p 8551:8551 \
 	--rm -v $(PWD)/${TESTAPP_FILES_DIR}:/${TESTAPP_FILES_DIR} \
 	-v $(PWD)/.tmp:/.tmp \
-	thorax/erigon:latest \
+	erigontech/erigon:latest \
 	--http \
 	--http.addr 0.0.0.0 \
 	--http.api eth,net \

--- a/kurtosis/beaconkit-all.yaml
+++ b/kurtosis/beaconkit-all.yaml
@@ -93,7 +93,7 @@ node_settings:
       max_memory: 2048
     images:
       besu: hyperledger/besu:24.5.4
-      erigon: thorax/erigon:v2.60.1
+      erigon: erigontech/erigon:v2.60.1
       ethereumjs: ethpandaops/ethereumjs:stable
       geth: ethereum/client-go:latest
       nethermind: nethermind/nethermind:latest

--- a/kurtosis/beaconkit-all.yaml
+++ b/kurtosis/beaconkit-all.yaml
@@ -93,7 +93,7 @@ node_settings:
       max_memory: 2048
     images:
       besu: hyperledger/besu:24.5.4
-      erigon: erigontech/erigon:v2.60.1
+      erigon: erigontech/erigon:v2.60.9
       ethereumjs: ethpandaops/ethereumjs:stable
       geth: ethereum/client-go:latest
       nethermind: nethermind/nethermind:latest

--- a/kurtosis/beaconkit-base-gcp.yaml
+++ b/kurtosis/beaconkit-base-gcp.yaml
@@ -88,7 +88,7 @@ node_settings:
       max_memory: 32768
     images:
       besu: hyperledger/besu:latest
-      erigon: thorax/erigon:v2.60.1
+      erigon: erigontech/erigon:v2.60.1
       ethereumjs: ethpandaops/ethereumjs:stable
       geth: ethereum/client-go:latest
       nethermind: nethermind/nethermind:latest

--- a/kurtosis/beaconkit-base-gcp.yaml
+++ b/kurtosis/beaconkit-base-gcp.yaml
@@ -88,7 +88,7 @@ node_settings:
       max_memory: 32768
     images:
       besu: hyperledger/besu:latest
-      erigon: erigontech/erigon:v2.60.1
+      erigon: erigontech/erigon:v2.60.9
       ethereumjs: ethpandaops/ethereumjs:stable
       geth: ethereum/client-go:latest
       nethermind: nethermind/nethermind:latest

--- a/kurtosis/src/nodes/nodes.star
+++ b/kurtosis/src/nodes/nodes.star
@@ -33,7 +33,7 @@ EXECUTION_DEFAULT_SETTINGS = {
     },
     "images": {
         "besu": "hyperledger/besu:latest",
-        "erigon": "erigontech/erigon:v2.60.1",
+        "erigon": "erigontech/erigon:v2.60.9",
         "ethereumjs": "ethpandaops/ethereumjs:stable",
         "geth": "ethereum/client-go:latest",
         "nethermind": "nethermind/nethermind:latest",

--- a/kurtosis/src/nodes/nodes.star
+++ b/kurtosis/src/nodes/nodes.star
@@ -33,7 +33,7 @@ EXECUTION_DEFAULT_SETTINGS = {
     },
     "images": {
         "besu": "hyperledger/besu:latest",
-        "erigon": "thorax/erigon:v2.60.1",
+        "erigon": "erigontech/erigon:v2.60.1",
         "ethereumjs": "ethpandaops/ethereumjs:stable",
         "geth": "ethereum/client-go:latest",
         "nethermind": "nethermind/nethermind:latest",

--- a/testing/e2e/config/config.go
+++ b/testing/e2e/config/config.go
@@ -272,7 +272,7 @@ func defaultExecutionSettings() ExecutionSettings {
 		},
 		Images: map[string]string{
 			"besu":       "hyperledger/besu:24.5.4",
-			"erigon":     "erigontech/erigon:v2.60.1",
+			"erigon":     "erigontech/erigon:v2.60.9",
 			"ethereumjs": "ethpandaops/ethereumjs:stable",
 			"geth":       "ethereum/client-go:stable",
 			"nethermind": "nethermind/nethermind:latest",

--- a/testing/e2e/config/config.go
+++ b/testing/e2e/config/config.go
@@ -272,7 +272,7 @@ func defaultExecutionSettings() ExecutionSettings {
 		},
 		Images: map[string]string{
 			"besu":       "hyperledger/besu:24.5.4",
-			"erigon":     "thorax/erigon:v2.60.1",
+			"erigon":     "erigontech/erigon:v2.60.1",
 			"ethereumjs": "ethpandaops/ethereumjs:stable",
 			"geth":       "ethereum/client-go:stable",
 			"nethermind": "nethermind/nethermind:latest",


### PR DESCRIPTION
Erigon repo has moved from `thorax/erigon` to `erigontech/erigon`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Docker image for the Erigon client across various configuration files to version `v2.60.9`, enhancing performance and compatibility.

- **Chores**
	- Cleaned up configuration files by removing outdated comments and references, improving clarity and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->