### PR TITLE
fix: let the create-validator command retrieve the loaded configuration.

### DIFF
--- a/mod/cli/pkg/commands/deposit/create.go
+++ b/mod/cli/pkg/commands/deposit/create.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"cosmossdk.io/log"
+	clicontext "github.com/berachain/beacon-kit/mod/cli/pkg/context"
 	"github.com/berachain/beacon-kit/mod/cli/pkg/utils/parser"
 	"github.com/berachain/beacon-kit/mod/consensus-types/pkg/types"
 	"github.com/berachain/beacon-kit/mod/node-core/pkg/components"
@@ -31,7 +32,6 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/constraints"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/crypto"
-	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 )
 
@@ -164,7 +164,7 @@ func getBLSSigner(
 
 	return components.ProvideBlsSigner(
 		components.BlsSignerInput{
-			AppOpts: client.GetViperFromCmd(cmd),
+			AppOpts: clicontext.GetViperFromCmd(cmd),
 			PrivKey: legacyKey,
 		},
 	)


### PR DESCRIPTION
Upon CLI bootstrapping, a `PersistentPreRunE` handler is added to the command in order to, among other things, load the configuration in a viper instance and store it into the command's context with a `ViperContextKey` key.

The `create-validator` command was using the wrong, but homonymous, `ViperContextKey` for retrieving the viper configuration from the command context.

As a result, the command implementation was not able to find some configuration values which were silently used as empty strings that, eventually, would halt the execution with unexpected errors.

This commit replaces the source package of the `ViperContextKey` key from `github.com/cosmos/cosmos-sdk/client`
to `github.com/berachain/beacon-kit/mod/cli/pkg/context`

This should also fix the issue #2122 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved command for validator deposits with enhanced context management.
- **Bug Fixes**
	- Enhanced error handling for input conversions during deposit message creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->