### PR TITLE
fix(state-transition): Let consensus control payload verification

### DIFF
--- a/mod/beacon/blockchain/process.go
+++ b/mod/beacon/blockchain/process.go
@@ -113,23 +113,9 @@ func (s *Service[
 			// bad peer, and we would likely AppHash anyways.
 			OptimisticEngine: true,
 
-			// When we are NOT synced to the tip, process proposal
-			// does NOT get called and thus we must ensure that
-			// NewPayload is called to get the execution
-			// client the payload.
-			//
-			// When we are synced to the tip, we can skip the
-			// NewPayload call since we already gave our execution client
-			// the payload in process proposal.
-			//
-			// In both cases the payload was already accepted by a majority
-			// of validators in their process proposal call and thus
-			// the "verification aspect" of this NewPayload call is
-			// actually irrelevant at this point.
-			SkipPayloadVerification: false,
-
-			ProposerAddress:      blk.GetProposerAddress(),
-			NextPayloadTimestamp: blk.GetNextPayloadTimestamp(),
+			SkipPayloadVerification: !blk.GetVerifyPayload(),
+			ProposerAddress:         blk.GetProposerAddress(),
+			NextPayloadTimestamp:    blk.GetNextPayloadTimestamp(),
 		},
 		st,
 		blk.GetBeaconBlock(),

--- a/mod/beacon/blockchain/types.go
+++ b/mod/beacon/blockchain/types.go
@@ -53,6 +53,11 @@ type ConsensusBlock[BeaconBlockT any] interface {
 	// consensus for the next payload to be proposed. It is also
 	// used to bound current payload upon validation
 	GetNextPayloadTimestamp() math.U64
+
+	// GetVerifyPayload signals whether execution payload should be
+	// verified or not. We should always verify it except when finalizing
+	// replayed blocks.
+	GetVerifyPayload() bool
 }
 
 // BeaconBlock represents a beacon block interface.

--- a/mod/consensus/pkg/cometbft/service/middleware/abci.go
+++ b/mod/consensus/pkg/cometbft/service/middleware/abci.go
@@ -221,6 +221,7 @@ func (h *ABCIMiddleware[
 		blk,
 		req.GetProposerAddress(),
 		req.GetTime().Add(h.minPayloadDelay),
+		true, // verify payload
 	)
 	blkEvent := async.NewEvent(ctx, async.BeaconBlockReceived, consensusBlk)
 	if err = h.dispatcher.Publish(blkEvent); err != nil {
@@ -346,6 +347,11 @@ func (h *ABCIMiddleware[
 		blk,
 		req.GetProposerAddress(),
 		req.GetTime().Add(h.minPayloadDelay),
+
+		// Finalize may be called while syncing. In such a case
+		// we can skip payload verification since block is guaranteed
+		// to have been accepted by a super majority of validators.
+		req.SyncingToHeight == req.Height,
 	)
 	blkEvent := async.NewEvent(
 		ctx,

--- a/mod/consensus/pkg/types/consensus_block.go
+++ b/mod/consensus/pkg/types/consensus_block.go
@@ -31,6 +31,8 @@ type ConsensusBlock[BeaconBlockT any] struct {
 
 	// some consensus data useful to build and verify the block
 	*commonConsensusData
+
+	verifyPayload bool
 }
 
 // New creates a new ConsensusBlock instance.
@@ -38,6 +40,7 @@ func (b *ConsensusBlock[BeaconBlockT]) New(
 	beaconBlock BeaconBlockT,
 	proposerAddress []byte,
 	nextPayloadTimestamp time.Time,
+	verifyPayload bool,
 ) *ConsensusBlock[BeaconBlockT] {
 	b = &ConsensusBlock[BeaconBlockT]{
 		blk: beaconBlock,
@@ -45,10 +48,15 @@ func (b *ConsensusBlock[BeaconBlockT]) New(
 			proposerAddress:      proposerAddress,
 			nextPayloadTimestamp: math.U64(nextPayloadTimestamp.Unix()),
 		},
+		verifyPayload: verifyPayload,
 	}
 	return b
 }
 
 func (b *ConsensusBlock[BeaconBlockT]) GetBeaconBlock() BeaconBlockT {
 	return b.blk
+}
+
+func (b *ConsensusBlock[BeaconBlockT]) GetVerifyPayload() bool {
+	return b.verifyPayload
 }

--- a/mod/node-core/pkg/components/interfaces.go
+++ b/mod/node-core/pkg/components/interfaces.go
@@ -91,6 +91,11 @@ type (
 		// consensus for the next payload to be proposed. It is also
 		// used to bound current payload upon validation
 		GetNextPayloadTimestamp() math.U64
+
+		// GetVerifyPayload signals whether execution payload should be
+		// verified or not. We should always verify it except when finalizing
+		// replayed blocks.
+		GetVerifyPayload() bool
 	}
 
 	// BeaconBlock represents a generic interface for a beacon block.


### PR DESCRIPTION
payload execution should be skipped during blocks replay