### PR TITLE
docs: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _The project is still heavily under construction, see the [disclaimer below](#st
 
 [![CI status](https://github.com/berachain/beacon-kit/workflows/pipeline/badge.svg)](https://github.com/berachain/beacon-kit/actions/workflows/pipeline.yml)
 [![CodeCov](https://codecov.io/gh/berachain/beacon-kit/graph/badge.svg?token=0l5iJ3ZbzV)](https://codecov.io/gh/berachain/beacon-kit)
-[![Telegram Chat](https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fbeacon_kit)](https://t.me/beacon_kit)
+[![Telegram Chat](https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fbeacon_kit)](https://t.me/BerachainPortal)
 [![X Follow](https://img.shields.io/twitter/follow/berachain)](https://x.com/berachain)
 [![Discord](https://img.shields.io/discord/924442927399313448?label=discord)](https://discord.gg/berachain)
 


### PR DESCRIPTION
In my opinion, the new link will be considered more correct. Even the Beacon-kit main site links to this link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Telegram chat link in the README file to direct users to the new Berachain Portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->