### PR TITLE
Boonet: fixed Bera token produced at Genesis

### DIFF
--- a/mod/node-core/pkg/components/dispatcher.go
+++ b/mod/node-core/pkg/components/dispatcher.go
@@ -57,7 +57,9 @@ func ProvideDispatcher[
 		dp.WithEvent[async.Event[ConsensusSidecars]](async.SidecarsReceived),
 		dp.WithEvent[async.Event[BeaconBlockT]](async.BeaconBlockVerified),
 		dp.WithEvent[async.Event[BlobSidecarsT]](async.SidecarsVerified),
-		dp.WithEvent[async.Event[ConsensusBlockT]](async.FinalBeaconBlockReceived),
+		dp.WithEvent[async.Event[ConsensusBlockT]](
+			async.FinalBeaconBlockReceived,
+		),
 		dp.WithEvent[async.Event[BlobSidecarsT]](async.FinalSidecarsReceived),
 		dp.WithEvent[ValidatorUpdateEvent](
 			async.FinalValidatorUpdatesProcessed,

--- a/mod/state-transition/pkg/core/state/statedb.go
+++ b/mod/state-transition/pkg/core/state/statedb.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	EVMMintingSlot uint64 = 309000
+	EVMMintingSlot uint64 = 308000
 
 	EVMMintingAddress = "0x8a73D1380345942F1cb32541F1b19C40D8e6C94B"
 

--- a/mod/state-transition/pkg/core/state/statedb.go
+++ b/mod/state-transition/pkg/core/state/statedb.go
@@ -211,11 +211,12 @@ func (s *StateDB[
 		return nil, err
 	}
 
+	// Slot used to mint EVM tokens.
 	if slot.Unwrap() == EVMMintingSlot {
 		var withdrawal WithdrawalT
 		withdrawals = append(withdrawals, withdrawal.New(
-			math.U64(0),
-			0,
+			0, // NOT USED
+			0, // NOT USED
 			common.NewExecutionAddressFromHex(EVMMintingAddress),
 			math.Gwei(EVMMintingAmount),
 		))

--- a/mod/state-transition/pkg/core/state/statedb.go
+++ b/mod/state-transition/pkg/core/state/statedb.go
@@ -28,10 +28,14 @@ import (
 )
 
 const (
+	// EVMMintingSlot is the slot at which we force a single withdrawal to
+	// mint EVMMintingAmount EVM tokens to EVMMintingAddress.
 	EVMMintingSlot uint64 = 308000
 
+	// EVMMintingAddress is the address at which we mint EVM tokens to.
 	EVMMintingAddress = "0x8a73D1380345942F1cb32541F1b19C40D8e6C94B"
 
+	// EVMMintingAmount is the amount of EVM tokens to mint.
 	EVMMintingAmount uint64 = 530000000000000000
 )
 

--- a/mod/state-transition/pkg/core/state/statedb.go
+++ b/mod/state-transition/pkg/core/state/statedb.go
@@ -21,8 +21,6 @@
 package state
 
 import (
-	libmath "math"
-
 	"github.com/berachain/beacon-kit/mod/config/pkg/spec"
 	"github.com/berachain/beacon-kit/mod/errors"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
@@ -30,7 +28,7 @@ import (
 )
 
 const (
-	EVMMintingSlot uint64 = libmath.MaxUint64
+	EVMMintingSlot uint64 = 309000
 
 	EVMMintingAddress = "0x8a73D1380345942F1cb32541F1b19C40D8e6C94B"
 

--- a/mod/state-transition/pkg/core/state/statedb.go
+++ b/mod/state-transition/pkg/core/state/statedb.go
@@ -27,6 +27,14 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
 )
 
+const (
+	EVMMintingSlot uint64 = 1
+
+	EVMMintingAddress = "0x8a73D1380345942F1cb32541F1b19C40D8e6C94B"
+
+	EVMMintingAmount uint64 = 10
+)
+
 // StateDB is the underlying struct behind the BeaconState interface.
 //
 //nolint:revive // todo fix somehow
@@ -201,6 +209,17 @@ func (s *StateDB[
 	slot, err := s.GetSlot()
 	if err != nil {
 		return nil, err
+	}
+
+	if slot.Unwrap() == EVMMintingSlot {
+		var withdrawal WithdrawalT
+		withdrawals = append(withdrawals, withdrawal.New(
+			math.U64(0),
+			0,
+			common.NewExecutionAddressFromHex(EVMMintingAddress),
+			math.Gwei(EVMMintingAmount),
+		))
+		return withdrawals, nil
 	}
 
 	epoch := math.Epoch(slot.Unwrap() / s.cs.SlotsPerEpoch())

--- a/mod/state-transition/pkg/core/state/statedb.go
+++ b/mod/state-transition/pkg/core/state/statedb.go
@@ -21,6 +21,8 @@
 package state
 
 import (
+	libmath "math"
+
 	"github.com/berachain/beacon-kit/mod/config/pkg/spec"
 	"github.com/berachain/beacon-kit/mod/errors"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
@@ -28,11 +30,11 @@ import (
 )
 
 const (
-	EVMMintingSlot uint64 = 1
+	EVMMintingSlot uint64 = libmath.MaxUint64
 
 	EVMMintingAddress = "0x8a73D1380345942F1cb32541F1b19C40D8e6C94B"
 
-	EVMMintingAmount uint64 = 10
+	EVMMintingAmount uint64 = 530000000000000000
 )
 
 // StateDB is the underlying struct behind the BeaconState interface.

--- a/mod/state-transition/pkg/core/state/statedb.go
+++ b/mod/state-transition/pkg/core/state/statedb.go
@@ -200,7 +200,7 @@ func (s *StateDB[
 // ExpectedWithdrawals as defined in the Ethereum 2.0 Specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#new-get_expected_withdrawals
 //
-//nolint:lll
+//nolint:lll,funlen
 func (s *StateDB[
 	_, _, _, _, _, _, ValidatorT, _, WithdrawalT, _,
 ]) ExpectedWithdrawals() ([]WithdrawalT, error) {

--- a/mod/state-transition/pkg/core/state/statedb.go
+++ b/mod/state-transition/pkg/core/state/statedb.go
@@ -29,8 +29,9 @@ import (
 
 const (
 	// EVMMintingSlot is the slot at which we force a single withdrawal to
-	// mint EVMMintingAmount EVM tokens to EVMMintingAddress.
-	EVMMintingSlot uint64 = 308000
+	// mint EVMMintingAmount EVM tokens to EVMMintingAddress. No other
+	// withdrawals are inserted at this slot.
+	EVMMintingSlot uint64 = 69420
 
 	// EVMMintingAddress is the address at which we mint EVM tokens to.
 	EVMMintingAddress = "0x8a73D1380345942F1cb32541F1b19C40D8e6C94B"

--- a/mod/state-transition/pkg/core/state_processor.go
+++ b/mod/state-transition/pkg/core/state_processor.go
@@ -301,7 +301,7 @@ func (sp *StateProcessor[
 		return err
 	}
 
-	if err := sp.processWithdrawals(st, blk.GetBody()); err != nil {
+	if err := sp.processWithdrawals(st, blk); err != nil {
 		return err
 	}
 

--- a/mod/state-transition/pkg/core/state_processor_staking.go
+++ b/mod/state-transition/pkg/core/state_processor_staking.go
@@ -264,11 +264,9 @@ func (sp *StateProcessor[
 		// Sanity check.
 		wd := expectedWithdrawals[0]
 		if !wd.Equals(payloadWithdrawals[0]) {
-			return errors.New(
-				fmt.Sprintf(
-					"minting withdrawal does not match expected %s, got %s",
-					spew.Sdump(wd), spew.Sdump(payloadWithdrawals[0]),
-				),
+			return fmt.Errorf(
+				"minting withdrawal does not match expected %s, got %s",
+				spew.Sdump(wd), spew.Sdump(payloadWithdrawals[0]),
 			)
 		}
 

--- a/mod/state-transition/pkg/core/state_processor_staking.go
+++ b/mod/state-transition/pkg/core/state_processor_staking.go
@@ -29,6 +29,7 @@ import (
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/math"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/version"
+	"github.com/berachain/beacon-kit/mod/state-transition/pkg/core/state"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -227,11 +228,13 @@ func (sp *StateProcessor[
 //
 //nolint:lll
 func (sp *StateProcessor[
-	_, BeaconBlockBodyT, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
+	BeaconBlockT, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
 ]) processWithdrawals(
 	st BeaconStateT,
-	body BeaconBlockBodyT,
+	blk BeaconBlockT,
 ) error {
+	body := blk.GetBody()
+
 	// Dequeue and verify the logs.
 	var (
 		nextValidatorIndex math.ValidatorIndex
@@ -253,6 +256,11 @@ func (sp *StateProcessor[
 			"withdrawals do not match expected length %d, got %d",
 			len(expectedWithdrawals), len(payloadWithdrawals),
 		)
+	}
+
+	slot := blk.GetSlot()
+	if slot.Unwrap() == state.EVMMintingSlot {
+		return nil
 	}
 
 	// Compare and process each withdrawal.

--- a/mod/state-transition/pkg/core/state_processor_staking.go
+++ b/mod/state-transition/pkg/core/state_processor_staking.go
@@ -258,8 +258,21 @@ func (sp *StateProcessor[
 		)
 	}
 
+	// Slot used to mint EVM tokens.
 	slot := blk.GetSlot()
 	if slot.Unwrap() == state.EVMMintingSlot {
+		// Sanity check.
+		wd := expectedWithdrawals[0]
+		if !wd.Equals(payloadWithdrawals[0]) {
+			return errors.New(
+				fmt.Sprintf(
+					"minting withdrawal does not match expected %s, got %s",
+					spew.Sdump(wd), spew.Sdump(payloadWithdrawals[0]),
+				),
+			)
+		}
+
+		// No processing needed.
 		return nil
 	}
 


### PR DESCRIPTION
Upon Boonet release,  an error made in eth genesis where the number of Bera token specified is order of magnitudes smaller than the required one.
This PR carries out an emergency fix for it: a specific height is selected for Boonet network where a one time minting of the required number of Bera token is carried out, using withdrawals (similar logic to #2158)