### PR TITLE
Add telemetry for diff btw payload and consensus timestamps

### DIFF
--- a/mod/node-core/pkg/components/metrics/sink.go
+++ b/mod/node-core/pkg/components/metrics/sink.go
@@ -78,3 +78,20 @@ func argsToLabels(args ...string) []metrics.Label {
 	}
 	return labels
 }
+
+// NoOpTelemetrySink is a no-op implementation of the TelemetrySink interface.
+type NoOpTelemetrySink struct{}
+
+// NewNoOpMetricsSink creates a new NoOpTelemetrySink.
+func NewNoOpMetricsSink() NoOpTelemetrySink {
+	return NoOpTelemetrySink{}
+}
+
+// IncrementCounter is a no-op implementation of the TelemetrySink interface.
+func (NoOpTelemetrySink) IncrementCounter(key string, args ...string) {}
+
+// SetGauge is a no-op implementation of the TelemetrySink interface.
+func (NoOpTelemetrySink) SetGauge(key string, value int64, args ...string) {}
+
+// MeasureSince is a no-op implementation of the TelemetrySink interface.
+func (NoOpTelemetrySink) MeasureSince(key string, start time.Time, args ...string) {}

--- a/mod/node-core/pkg/components/metrics/sink.go
+++ b/mod/node-core/pkg/components/metrics/sink.go
@@ -82,8 +82,8 @@ func argsToLabels(args ...string) []metrics.Label {
 // NoOpTelemetrySink is a no-op implementation of the TelemetrySink interface.
 type NoOpTelemetrySink struct{}
 
-// NewNoOpMetricsSink creates a new NoOpTelemetrySink.
-func NewNoOpMetricsSink() NoOpTelemetrySink {
+// NewNoOpTelemetrySink creates a new NoOpTelemetrySink.
+func NewNoOpTelemetrySink() NoOpTelemetrySink {
 	return NoOpTelemetrySink{}
 }
 

--- a/mod/node-core/pkg/components/metrics/sink.go
+++ b/mod/node-core/pkg/components/metrics/sink.go
@@ -88,10 +88,10 @@ func NewNoOpTelemetrySink() NoOpTelemetrySink {
 }
 
 // IncrementCounter is a no-op implementation of the TelemetrySink interface.
-func (NoOpTelemetrySink) IncrementCounter(key string, args ...string) {}
+func (NoOpTelemetrySink) IncrementCounter(string, ...string) {}
 
 // SetGauge is a no-op implementation of the TelemetrySink interface.
-func (NoOpTelemetrySink) SetGauge(key string, value int64, args ...string) {}
+func (NoOpTelemetrySink) SetGauge(string, int64, ...string) {}
 
 // MeasureSince is a no-op implementation of the TelemetrySink interface.
-func (NoOpTelemetrySink) MeasureSince(key string, start time.Time, args ...string) {}
+func (NoOpTelemetrySink) MeasureSince(string, time.Time, ...string) {}

--- a/mod/node-core/pkg/components/state_processor.go
+++ b/mod/node-core/pkg/components/state_processor.go
@@ -25,6 +25,7 @@ import (
 	engineprimitives "github.com/berachain/beacon-kit/mod/engine-primitives/pkg/engine-primitives"
 	"github.com/berachain/beacon-kit/mod/execution/pkg/engine"
 	"github.com/berachain/beacon-kit/mod/log"
+	"github.com/berachain/beacon-kit/mod/node-core/pkg/components/metrics"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/crypto"
 	"github.com/berachain/beacon-kit/mod/state-transition/pkg/core"
@@ -51,8 +52,9 @@ type StateProcessorInput[
 		PayloadID,
 		WithdrawalsT,
 	]
-	DepositStore DepositStore[DepositT]
-	Signer       crypto.BLSSigner
+	DepositStore  DepositStore[DepositT]
+	Signer        crypto.BLSSigner
+	TelemetrySink *metrics.TelemetrySink
 }
 
 // ProvideStateProcessor provides the state processor to the depinject
@@ -120,5 +122,6 @@ func ProvideStateProcessor[
 		in.DepositStore,
 		in.Signer,
 		crypto.GetAddressFromPubKey,
+		in.TelemetrySink,
 	)
 }

--- a/mod/state-transition/pkg/core/helpers_test.go
+++ b/mod/state-transition/pkg/core/helpers_test.go
@@ -34,6 +34,7 @@ import (
 	engineprimitives "github.com/berachain/beacon-kit/mod/engine-primitives/pkg/engine-primitives"
 	"github.com/berachain/beacon-kit/mod/log/pkg/noop"
 	"github.com/berachain/beacon-kit/mod/node-core/pkg/components"
+	nodemetrics "github.com/berachain/beacon-kit/mod/node-core/pkg/components/metrics"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/common"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/crypto"
 	"github.com/berachain/beacon-kit/mod/primitives/pkg/transition"
@@ -139,6 +140,7 @@ func createStateProcessor(
 		ds,
 		signer,
 		fGetAddressFromPubKey,
+		nodemetrics.NewNoOpMetricsSink(),
 	)
 }
 

--- a/mod/state-transition/pkg/core/helpers_test.go
+++ b/mod/state-transition/pkg/core/helpers_test.go
@@ -140,7 +140,7 @@ func createStateProcessor(
 		ds,
 		signer,
 		fGetAddressFromPubKey,
-		nodemetrics.NewNoOpMetricsSink(),
+		nodemetrics.NewNoOpTelemetrySink(),
 	)
 }
 

--- a/mod/state-transition/pkg/core/metrics.go
+++ b/mod/state-transition/pkg/core/metrics.go
@@ -40,6 +40,6 @@ func (s *stateProcessorMetrics) gaugeTimestamps(
 ) {
 	// the diff can be positive or negative depending on whether the payload timestamp is
 	// ahead or behind the consensus timestamp
-	diff := int64(payloadTimestamp) - int64(consensusTimestamp)
+	diff := int64(payloadTimestamp) - int64(consensusTimestamp) //#nosec:G701
 	s.sink.SetGauge("beacon_kit.state.payload_consensus_timestamp_diff", diff)
 }

--- a/mod/state-transition/pkg/core/metrics.go
+++ b/mod/state-transition/pkg/core/metrics.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package core
+
+type stateProcessorMetrics struct {
+	// sink is the sink for the metrics.
+	sink TelemetrySink
+}
+
+// newStateProcessorMetrics creates a new stateProcessorMetrics.
+func newStateProcessorMetrics(
+	sink TelemetrySink,
+) *stateProcessorMetrics {
+	return &stateProcessorMetrics{
+		sink: sink,
+	}
+}
+
+func (s *stateProcessorMetrics) gaugeTimestamps(
+	payloadTimestamp uint64,
+	consensusTimestamp uint64,
+) {
+	// the diff can be positive or negative depending on whether the payload timestamp is
+	// ahead or behind the consensus timestamp
+	diff := int64(payloadTimestamp) - int64(consensusTimestamp)
+	s.sink.SetGauge("beacon_kit.state.paylod_consensus_timestamp_diff", diff)
+}

--- a/mod/state-transition/pkg/core/metrics.go
+++ b/mod/state-transition/pkg/core/metrics.go
@@ -38,8 +38,8 @@ func (s *stateProcessorMetrics) gaugeTimestamps(
 	payloadTimestamp uint64,
 	consensusTimestamp uint64,
 ) {
-	// the diff can be positive or negative depending on whether the payload timestamp is
-	// ahead or behind the consensus timestamp
+	// the diff can be positive or negative depending on whether the payload
+	// timestamp is ahead or behind the consensus timestamp
 	diff := int64(payloadTimestamp) - int64(consensusTimestamp) //#nosec:G701
 	s.sink.SetGauge("beacon_kit.state.payload_consensus_timestamp_diff", diff)
 }

--- a/mod/state-transition/pkg/core/metrics.go
+++ b/mod/state-transition/pkg/core/metrics.go
@@ -41,5 +41,5 @@ func (s *stateProcessorMetrics) gaugeTimestamps(
 	// the diff can be positive or negative depending on whether the payload timestamp is
 	// ahead or behind the consensus timestamp
 	diff := int64(payloadTimestamp) - int64(consensusTimestamp)
-	s.sink.SetGauge("beacon_kit.state.paylod_consensus_timestamp_diff", diff)
+	s.sink.SetGauge("beacon_kit.state.payload_consensus_timestamp_diff", diff)
 }

--- a/mod/state-transition/pkg/core/state_processor.go
+++ b/mod/state-transition/pkg/core/state_processor.go
@@ -96,6 +96,8 @@ type StateProcessor[
 	]
 	// ds allows checking payload deposits against the deposit contract
 	ds DepositStore[DepositT]
+	// metrics is the metrics for the service.
+	metrics *stateProcessorMetrics
 }
 
 // NewStateProcessor creates a new state processor.
@@ -151,6 +153,7 @@ func NewStateProcessor[
 	ds DepositStore[DepositT],
 	signer crypto.BLSSigner,
 	fGetAddressFromPubKey func(crypto.BLSPubkey) ([]byte, error),
+	telemetrySink TelemetrySink,
 ) *StateProcessor[
 	BeaconBlockT, BeaconBlockBodyT, BeaconBlockHeaderT,
 	BeaconStateT, ContextT, DepositT, Eth1DataT, ExecutionPayloadT,
@@ -169,6 +172,7 @@ func NewStateProcessor[
 		signer:                signer,
 		fGetAddressFromPubKey: fGetAddressFromPubKey,
 		ds:                    ds,
+		metrics:               newStateProcessorMetrics(telemetrySink),
 	}
 }
 

--- a/mod/state-transition/pkg/core/state_processor_payload.go
+++ b/mod/state-transition/pkg/core/state_processor_payload.go
@@ -48,11 +48,16 @@ func (sp *StateProcessor[
 		g, gCtx = errgroup.WithContext(context.Background())
 	)
 
+	payloadTimestamp := payload.GetTimestamp().Unwrap()
+	consensusTimestamp := ctx.GetConsensusTime().Unwrap()
+
+	sp.metrics.gaugeTimestamps(payloadTimestamp, consensusTimestamp)
+
 	sp.logger.Info("processExecutionPayload",
 		"consensus height", blk.GetSlot().Unwrap(),
 		"payload height", payload.GetNumber().Unwrap(),
-		"payload timestamp", payload.GetTimestamp().Unwrap(),
-		"consensus timestamp", ctx.GetConsensusTime().Unwrap(),
+		"payload timestamp", payloadTimestamp,
+		"consensus timestamp", consensusTimestamp,
 		"skip payload verification", ctx.GetSkipPayloadVerification(),
 	)
 

--- a/mod/state-transition/pkg/core/types.go
+++ b/mod/state-transition/pkg/core/types.go
@@ -270,3 +270,8 @@ type Withdrawal[WithdrawalT any] interface {
 	// GetAddress returns the address of the withdrawal.
 	GetAddress() common.ExecutionAddress
 }
+
+// TelemetrySink is an interface for sending metrics to a telemetry backend.
+type TelemetrySink interface {
+	SetGauge(key string, value int64, args ...string)
+}


### PR DESCRIPTION
**Context**
This PR adds a new telemetry gauge value `beacon_kit.state.payload_consensus_timestamp_diff` which represents the time difference (in seconds) between the payload and consensus timestamps. This allows us to detect if either falls behind.

**Test plan**
I started a local node and confirmed the metrics was emitted on http://localhost:26660/metrics. 

<img width="992" alt="image" src="https://github.com/user-attachments/assets/046bb811-bb5d-4982-993d-fbcc742da4f7">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a no-op telemetry sink to avoid unnecessary processing when telemetry is not required.
	- Enhanced state processing capabilities by integrating telemetry metrics.
	- Added functionality for tracking and reporting differences between payload and consensus timestamps.
	- Introduced a new interface for structured metric reporting.

- **Bug Fixes**
	- Improved readability of logging in the state processor by refining timestamp handling.

- **Documentation**
	- Added comments to clarify the purpose of new telemetry-related fields and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->