### PR TITLE
increase lint max line-length

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,7 +41,7 @@ linters-settings:
     # even if all enum members are not listed.
     # Default: false
     default-signifies-exhaustive: true
-    
+
   exhaustruct:
     # List of regular expressions to exclude struct packages and their names from checks.
     # Regular expressions must match complete canonical struct package/name/structname.
@@ -147,7 +147,7 @@ linters-settings:
     # Max line length, lines longer will be reported.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option.
     # Default: 120.
-    line-length: 80
+    line-length: 140
     # Tab width in spaces.
     # Default: 1
     tab-width: 1

--- a/beacon/validator/config.go
+++ b/beacon/validator/config.go
@@ -30,8 +30,6 @@ const (
 )
 
 // Config is the validator configuration.
-//
-//nolint:lll // struct tags.
 type Config struct {
 	// Graffiti is the string that will be included in the
 	// graffiti field of the beacon block.

--- a/chain-spec/chain/data.go
+++ b/chain-spec/chain/data.go
@@ -21,8 +21,6 @@
 package chain
 
 // SpecData is the underlying data structure for chain-specific parameters.
-//
-//nolint:lll // struct tags may create long lines.
 type SpecData[
 	DomainTypeT ~[4]byte,
 	EpochT ~uint64,

--- a/cli/commands/server/rollback.go
+++ b/cli/commands/server/rollback.go
@@ -47,7 +47,6 @@ func NewRollbackCmd[
 ) *cobra.Command {
 	var removeBlock bool
 
-	//nolint:lll // its okay.
 	cmd := &cobra.Command{
 		Use:   "rollback",
 		Short: "rollback Cosmos SDK and CometBFT state by one height",

--- a/cli/commands/server/start.go
+++ b/cli/commands/server/start.go
@@ -86,7 +86,6 @@ func StartCmdWithOptions[
 	appCreator types.AppCreator[T, LoggerT],
 	opts StartCmdOptions[T],
 ) *cobra.Command {
-	//nolint:lll // its okay.
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Run the node",
@@ -130,8 +129,6 @@ custom: allow pruning options to be manually specified through 'pruning-keep-rec
 }
 
 // addStartNodeFlags should be added to any CLI commands that start the network.
-//
-//nolint:lll // todo fix.
 func addStartNodeFlags[
 	T interface {
 		Start(context.Context) error

--- a/config/spec/special_cases.go
+++ b/config/spec/special_cases.go
@@ -27,7 +27,6 @@ import "math"
 const (
 	BartioChainID = TestnetEth1ChainID
 
-	//nolint:lll // temporary.
 	BartioValRoot = "0x9147586693b6e8faa837715c0f3071c2000045b54233901c2e7871b15872bc43"
 )
 

--- a/config/template/template.go
+++ b/config/template/template.go
@@ -20,7 +20,6 @@
 
 package template
 
-//nolint:lll // template.
 const TomlTemplate = `
 ###############################################################################
 ###                                BeaconKit                                ###
@@ -49,7 +48,7 @@ jwt-secret-path = "{{.BeaconKit.Engine.JWTSecretPath}}"
 # TimeFormat is a string that defines the format of the time in the logger.
 time-format = "{{.BeaconKit.Logger.TimeFormat}}"
 
-# LogLevel is the level of logging. Logger will log messages with verbosity up 
+# LogLevel is the level of logging. Logger will log messages with verbosity up
 # to LogLevel.
 log-level = "{{.BeaconKit.Logger.LogLevel}}"
 
@@ -68,7 +67,7 @@ implementation = "{{.BeaconKit.KZG.Implementation}}"
 # Enabled determines if the local payload builder is enabled.
 enabled = {{ .BeaconKit.PayloadBuilder.Enabled }}
 
-# Post bellatrix, this address will receive the transaction fees produced by any blocks 
+# Post bellatrix, this address will receive the transaction fees produced by any blocks
 # from this node.
 suggested-fee-recipient = "{{.BeaconKit.PayloadBuilder.SuggestedFeeRecipient}}"
 

--- a/consensus-types/types/deposit_message.go
+++ b/consensus-types/types/deposit_message.go
@@ -31,8 +31,6 @@ import (
 // DepositMessage represents a deposit message as defined in the Ethereum 2.0
 // specification.
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#depositmessage
-//
-//nolint:lll
 type DepositMessage struct {
 	// Public key of the validator specified in the deposit.
 	Pubkey crypto.BLSPubkey `json:"pubkey"`

--- a/consensus-types/types/fork.go
+++ b/consensus-types/types/fork.go
@@ -39,8 +39,6 @@ var (
 
 // Fork as defined in the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#fork
-//
-//nolint:lll
 type Fork struct {
 	// PreviousVersion is the last version before the fork.
 	PreviousVersion common.Version `json:"previous_version"`

--- a/consensus-types/types/fork_data.go
+++ b/consensus-types/types/fork_data.go
@@ -28,8 +28,6 @@ import (
 
 // ForkData as defined in the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#forkdata
-//
-//nolint:lll
 type ForkData struct {
 	// CurrentVersion is the current version of the fork.
 	CurrentVersion common.Version
@@ -94,8 +92,6 @@ func (fd *ForkData) UnmarshalSSZ(buf []byte) error {
 
 // ComputeDomain as defined in the Ethereum 2.0 specification.
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#compute_domain
-//
-//nolint:lll
 func (fd *ForkData) ComputeDomain(
 	domainType common.DomainType,
 ) common.Domain {

--- a/consensus-types/types/genesis.go
+++ b/consensus-types/types/genesis.go
@@ -41,8 +41,6 @@ const (
 
 // Genesis is a struct that contains the genesis information
 // need to start the beacon chain.
-//
-//nolint:lll
 type Genesis[
 	DepositT any,
 	ExecutionPayloadHeaderT interface {

--- a/consensus-types/types/payload_header_test.go
+++ b/consensus-types/types/payload_header_test.go
@@ -255,7 +255,6 @@ func TestExecutionPayloadHeader_Empty(t *testing.T) {
 	require.Equal(t, version.Deneb, emptyHeader.Version())
 }
 
-//nolint:lll
 func TestExecutablePayloadHeaderDeneb_UnmarshalJSON_Error(t *testing.T) {
 	original := generateExecutionPayloadHeader()
 	validJSON, err := original.MarshalJSON()

--- a/consensus-types/types/signing_data.go
+++ b/consensus-types/types/signing_data.go
@@ -30,8 +30,6 @@ import (
 
 // SigningData as defined in the Ethereum 2.0 specification.
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#signingdata
-//
-//nolint:lll // link.
 type SigningData struct {
 	// ObjectRoot is the hash tree root of the object being signed.
 	ObjectRoot common.Root
@@ -79,8 +77,6 @@ func (s *SigningData) UnmarshalSSZ(buf []byte) error {
 
 // ComputeSigningRoot as defined in the Ethereum 2.0 specification.
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#compute_signing_root
-//
-//nolint:lll // link.
 func ComputeSigningRoot(
 	sszObject interface{ HashTreeRoot() common.Root },
 	domain common.Domain,

--- a/consensus-types/types/validator.go
+++ b/consensus-types/types/validator.go
@@ -41,8 +41,6 @@ var (
 
 // Validator as defined in the Ethereum 2.0 Spec
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
-//
-//nolint:lll
 type Validator struct {
 	// Pubkey is the validator's 48-byte BLS public key.
 	Pubkey crypto.BLSPubkey `json:"pubkey"`
@@ -72,8 +70,6 @@ type Validator struct {
 //
 // As defined in the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#deposits
-//
-//nolint:lll
 func NewValidatorFromDeposit(
 	pubkey crypto.BLSPubkey,
 	withdrawalCredentials WithdrawalCredentials,
@@ -236,16 +232,12 @@ func (v *Validator) GetEffectiveBalance() math.Gwei {
 
 // IsActive as defined in the Ethereum 2.0 Spec
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#is_active_validator
-//
-//nolint:lll
 func (v Validator) IsActive(epoch math.Epoch) bool {
 	return v.ActivationEpoch <= epoch && epoch < v.ExitEpoch
 }
 
 // IsEligibleForActivation as defined in the Ethereum 2.0 Spec
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#is_eligible_for_activation_queue
-//
-//nolint:lll
 func (v Validator) IsEligibleForActivation(finalizedEpoch math.Epoch) bool {
 	return v.ActivationEligibilityEpoch <= finalizedEpoch &&
 		v.ActivationEpoch == math.Epoch(constants.FarFutureEpoch)
@@ -254,8 +246,6 @@ func (v Validator) IsEligibleForActivation(finalizedEpoch math.Epoch) bool {
 // IsEligibleForActivationQueue is defined slightly differently from Ethereum
 // 2.0 Spec
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#is_eligible_for_activation_queue
-//
-//nolint:lll
 func (v Validator) IsEligibleForActivationQueue(threshold math.Gwei) bool {
 	return v.ActivationEligibilityEpoch == math.Epoch(
 		constants.FarFutureEpoch,
@@ -265,8 +255,6 @@ func (v Validator) IsEligibleForActivationQueue(threshold math.Gwei) bool {
 
 // IsSlashable as defined in the Ethereum 2.0 Spec
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#is_slashable_validator
-//
-//nolint:lll
 func (v Validator) IsSlashable(epoch math.Epoch) bool {
 	return !v.Slashed && v.ActivationEpoch <= epoch &&
 		epoch < v.WithdrawableEpoch
@@ -279,8 +267,6 @@ func (v Validator) IsSlashed() bool {
 
 // IsFullyWithdrawable as defined in the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#is_fully_withdrawable_validator
-//
-//nolint:lll
 func (v Validator) IsFullyWithdrawable(
 	balance math.Gwei,
 	epoch math.Epoch,
@@ -291,8 +277,6 @@ func (v Validator) IsFullyWithdrawable(
 
 // IsPartiallyWithdrawable as defined in the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#is_partially_withdrawable_validator
-//
-//nolint:lll
 func (v Validator) IsPartiallyWithdrawable(
 	balance, maxEffectiveBalance math.Gwei,
 ) bool {
@@ -303,8 +287,6 @@ func (v Validator) IsPartiallyWithdrawable(
 
 // HasEth1WithdrawalCredentials as defined in the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#has_eth1_withdrawal_credential
-//
-//nolint:lll
 func (v Validator) HasEth1WithdrawalCredentials() bool {
 	return v.WithdrawalCredentials[0] == EthSecp256k1CredentialPrefix
 }

--- a/da/kzg/ckzg/ckzg_no_cgo_test.go
+++ b/da/kzg/ckzg/ckzg_no_cgo_test.go
@@ -64,7 +64,6 @@ func TestVerifyBlobKZGProof(t *testing.T) {
 				require.Error(
 					t,
 					err,
-					//nolint:lll
 					"github.com/ethereum/c-kzg-4844 requires an executable built with CGO_ENABLED=1",
 				)
 			} else {
@@ -119,7 +118,6 @@ func TestVerifyBlobProofBatch(t *testing.T) {
 	}
 
 	err = globalVerifier.VerifyBlobProofBatch(args)
-	//nolint:lll
 	require.Error(
 		t,
 		err,

--- a/da/types/sidecar.go
+++ b/da/types/sidecar.go
@@ -31,8 +31,6 @@ import (
 
 // BlobSidecar as per the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/p2p-interface.md?ref=bankless.ghost.io#blobsidecar
-//
-//nolint:lll
 type BlobSidecar struct {
 	// Index represents the index of the blob in the block.
 	Index uint64

--- a/engine-primitives/engine-primitives/engine.go
+++ b/engine-primitives/engine-primitives/engine.go
@@ -57,8 +57,6 @@ var (
 
 // ForkchoiceResponseV1 as per the EngineAPI Specification:
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#response-2
-//
-//nolint:lll // link.
 type ForkchoiceResponseV1 struct {
 	// PayloadStatus is the payload status.
 	PayloadStatus PayloadStatusV1 `json:"payloadStatus"`
@@ -69,8 +67,6 @@ type ForkchoiceResponseV1 struct {
 
 // ForkchoiceStateV1 as per the EngineAPI Specification:
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#forkchoicestatev1
-//
-//nolint:lll // link.
 type ForkchoiceStateV1 struct {
 	// HeadBlockHash is the desired block hash of the head of the canonical
 	// chain.
@@ -88,8 +84,6 @@ type ForkchoiceStateV1 struct {
 // PayloadStatusV1 represents the status of a payload as per the EngineAPI
 // Specification. For more details, see:
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#payloadstatusv1
-//
-//nolint:lll // link.
 type PayloadStatusV1 struct {
 	// Status string of the payload.
 	Status string `json:"status"`

--- a/engine-primitives/engine-primitives/requests.go
+++ b/engine-primitives/engine-primitives/requests.go
@@ -35,8 +35,6 @@ import (
 
 // NewPayloadRequest as per the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#modified-newpayloadrequest
-//
-//nolint:lll
 type NewPayloadRequest[
 	ExecutionPayloadT interface {
 		constraints.ForkTyped[ExecutionPayloadT]
@@ -126,8 +124,6 @@ func BuildNewPayloadRequest[
 // As per the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/beacon-chain.md#is_valid_block_hash
 // https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/beacon-chain.md#is_valid_versioned_hashes
-//
-//nolint:lll
 func (n *NewPayloadRequest[ExecutionPayloadT, WithdrawalsT]) HasValidVersionedAndBlockHashes() error {
 	var (
 		blobHashes = make([]gethprimitives.ExecutionHash, 0)

--- a/execution/client/config.go
+++ b/execution/client/config.go
@@ -51,8 +51,6 @@ func DefaultConfig() Config {
 }
 
 // Config is the configuration struct for the execution client.
-//
-//nolint:lll // struct tags.
 type Config struct {
 	// RPCDialURL is the HTTP url of the execution client JSON-RPC endpoint.
 	RPCDialURL *url.ConnectionURL `mapstructure:"rpc-dial-url"`

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -29,8 +29,6 @@ import (
 
 // ErrUnauthenticatedConnection indicates that the connection is not
 // authenticated.
-//
-//nolint:lll
 const (
 	UnauthenticatedConnectionErrorStr = `could not verify execution chain ID as your
 	connection is not authenticated. If connecting to your execution client via HTTP, you

--- a/node-api/handlers/beacon/types/request.go
+++ b/node-api/handlers/beacon/types/request.go
@@ -89,26 +89,20 @@ type GetBlockHeaderRequest struct {
 	types.BlockIDRequest
 }
 
-// TODO: body is big
-//
-//nolint:lll // tags get long
 type PostBlindedBlocksV1Request struct {
 	EthConsensusVersion string `json:"eth_consensus_version" validate:"required,eth_consensus_version"`
 }
 
-//nolint:lll // tags get long
 type PostBlindedBlocksV2Request struct {
 	PostBlindedBlocksV1Request
 	BroadcastValidation string `json:"broadcast_validation" validate:"required,broadcast_validation"`
 }
 
-//nolint:lll // tags get long
 type PostBlocksV1Request[BeaconBlockT any] struct {
 	EthConsensusVersion string       `json:"eth_consensus_version" validate:"required,eth_consensus_version"`
 	BeaconBlock         BeaconBlockT `json:"beacon_block"`
 }
 
-//nolint:lll // tags get long
 type PostBlocksV2Request[BeaconBlockT any] struct {
 	PostBlocksV1Request[BeaconBlockT]
 	BroadcastValidation string `json:"broadcast_validation" validate:"required,broadcast_validation"`

--- a/payload/builder/config.go
+++ b/payload/builder/config.go
@@ -33,8 +33,6 @@ const (
 )
 
 // Config is the configuration for the payload builder.
-//
-//nolint:lll // struct tags.
 type Config struct {
 	// Enabled determines if the local builder is enabled.
 	Enabled bool `mapstructure:"enabled"`

--- a/primitives/bytes/b32_test.go
+++ b/primitives/bytes/b32_test.go
@@ -18,7 +18,6 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-//nolint:lll // long strings.
 package bytes_test
 
 import (

--- a/primitives/bytes/b48_test.go
+++ b/primitives/bytes/b48_test.go
@@ -18,7 +18,6 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-//nolint:lll // long strings.
 package bytes_test
 
 import (

--- a/primitives/common/consensus.go
+++ b/primitives/common/consensus.go
@@ -28,7 +28,6 @@ import (
 	"github.com/berachain/beacon-kit/primitives/math"
 )
 
-//nolint:lll
 type (
 	// Bytes32 defines the commonly used 32-byte array.
 	Bytes32 = bytes.B32
@@ -38,12 +37,10 @@ type (
 
 	// Domain as per the Ethereum 2.0 Specification:
 	// https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#custom-types
-	//nolint:lll
 	Domain = bytes.B32
 
 	// DomainType as per the Ethereum 2.0 Specification:
 	// https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#custom-types
-	//nolint:lll
 	DomainType = bytes.B4
 
 	// Hash32 as per the Ethereum 2.0 Specification:

--- a/primitives/constants/misc.go
+++ b/primitives/constants/misc.go
@@ -22,8 +22,6 @@ package constants
 
 // This file contains various constants as defined:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#misc
-//
-//nolint:lll // link.
 const (
 	// GenesisSlot represents the initial slot in the system.
 	GenesisSlot uint64 = 0

--- a/primitives/crypto/bls.go
+++ b/primitives/crypto/bls.go
@@ -31,7 +31,6 @@ import (
 // algorithm.
 const CometBLSType = "bls12_381"
 
-//nolint:lll // link.
 type (
 	// BLSPubkey as per the Ethereum 2.0 Specification:
 	// https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#custom-types

--- a/primitives/crypto/sha256/sha256.go
+++ b/primitives/crypto/sha256/sha256.go
@@ -37,8 +37,6 @@ var sha256Pool = sync.Pool{New: func() interface{} {
 // Sha256 defines a function that returns the sha256 checksum of the data passed
 // in. Adheres to the crypto.HashFn signature.
 // https://github.com/ethereum/consensus-specs/blob/v0.9.3/specs/core/0_beacon-chain.md#hash
-//
-//nolint:lll // url.
 func Hash(data []byte) [32]byte {
 	h, ok := sha256Pool.Get().(hash.Hash)
 	if !ok {

--- a/primitives/eip4844/kzg_commitment.go
+++ b/primitives/eip4844/kzg_commitment.go
@@ -34,8 +34,6 @@ type KZGCommitment [48]byte
 // ToVersionedHash converts this KZG commitment into a versioned hash
 // as per the Ethereum 2.0 specification:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash
-//
-//nolint:lll // link.
 func (c KZGCommitment) ToVersionedHash() [32]byte {
 	sum := sha256.Hash(c[:])
 	// Prefix the hash with the BlobCommitmentVersion

--- a/primitives/encoding/hex/bit_int_test.go
+++ b/primitives/encoding/hex/bit_int_test.go
@@ -18,7 +18,6 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-//nolint:lll // long strings
 package hex_test
 
 import (

--- a/primitives/encoding/hex/bytes_test.go
+++ b/primitives/encoding/hex/bytes_test.go
@@ -18,7 +18,6 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-//nolint:lll // long strings
 package hex_test
 
 import (

--- a/primitives/encoding/ssz/merkle/index.go
+++ b/primitives/encoding/ssz/merkle/index.go
@@ -29,9 +29,6 @@ import (
 
 // Inspired by the Ethereum 2.0 spec:
 // https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#helpers-for-generalized-indices
-//
-//nolint:lll // link.
-
 type (
 	// GeneralizedIndex is a generalized index.
 	GeneralizedIndex uint64
@@ -43,8 +40,6 @@ type (
 // NewGeneralizedIndex calculates the generalized index from the depth and
 // index. Inspired by:
 // https://github.com/protolambda/remerkleable/blob/master/remerkleable/tree.py#L20
-//
-//nolint:lll // link.
 func NewGeneralizedIndex(
 	depth uint8,
 	index uint64,

--- a/primitives/encoding/ssz/merkle/proof.go
+++ b/primitives/encoding/ssz/merkle/proof.go
@@ -45,8 +45,6 @@ func BuildProofFromLeaves[RootT ~[32]byte](
 //
 // As defined in the Ethereum 2.0 Spec:
 // https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#generalized-merkle-tree-index
-//
-//nolint:lll // link.
 func newTree[RootT ~[32]byte](leaves []RootT) ([]RootT, uint8) {
 	bottomLength := pow.NextPowerOfTwo(uint64(len(leaves)))
 	//nolint:mnd // 2 is okay.
@@ -71,8 +69,6 @@ func newTree[RootT ~[32]byte](leaves []RootT) ([]RootT, uint8) {
 //
 // Inspired by the Ethereum 2.0 Spec:
 // https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/merkle.py
-//
-//nolint:lll // link.
 func buildSingleProofFromTree[RootT ~[32]byte](
 	tree []RootT,
 	index GeneralizedIndex,

--- a/primitives/encoding/ssz/merkle/tree.go
+++ b/primitives/encoding/ssz/merkle/tree.go
@@ -30,7 +30,6 @@ import (
 // Inspired by the Ethereum 2.0 spec:
 // https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs
 //
-//nolint:lll // link.
 
 // CalculateRoot calculates the Merkle root from the leaf and proof.
 func CalculateRoot[RootT ~[32]byte](

--- a/primitives/math/u64.go
+++ b/primitives/math/u64.go
@@ -30,7 +30,6 @@ import (
 	"github.com/berachain/beacon-kit/primitives/math/pow"
 )
 
-//nolint:lll
 type (
 	// U64 represents a 64-bit unsigned integer that is both SSZ and JSON
 	// marshallable. We marshal U64 as hex strings in JSON in order to keep the
@@ -110,8 +109,6 @@ func (u U64) UnwrapPtr() *uint64 {
 // Example: 0->1, 1->1, 2->2, 3->4, 4->4, 5->8, 6->8, 7->8, 8->8, 9->16.
 //
 // https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#helper-functions
-//
-//nolint:lll // powers of 2.
 func (u U64) NextPowerOfTwo() U64 {
 	return pow.NextPowerOfTwo(u)
 }
@@ -123,8 +120,6 @@ func (u U64) NextPowerOfTwo() U64 {
 // Example: 0->1, 1->1, 2->2, 3->2, 4->4, 5->4, 6->4, 7->4, 8->8, 9->8.
 //
 // https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#helper-functions
-//
-//nolint:lll // From Ethereum 2.0 spec.
 func (u U64) PrevPowerOfTwo() U64 {
 	return pow.PrevPowerOfTwo(u)
 }

--- a/primitives/merkle/proof.go
+++ b/primitives/merkle/proof.go
@@ -46,8 +46,6 @@ func VerifyProof[RootT, ProofT ~[32]byte](
 
 // IsValidMerkleBranch as per the Ethereum 2.0 spec:
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#is_valid_merkle_branch
-//
-//nolint:lll // link.
 func IsValidMerkleBranch[RootT, BranchT ~[32]byte](
 	leaf RootT, branch []BranchT, depth uint8, index uint64, root RootT,
 ) bool {
@@ -62,8 +60,6 @@ func IsValidMerkleBranch[RootT, BranchT ~[32]byte](
 // RootFromBranch calculates the Merkle root from a leaf and a branch.
 // Inspired by:
 // https://github.com/sigp/lighthouse/blob/stable/consensus/merkle_proof/src/lib.rs#L372
-//
-//nolint:lll
 func RootFromBranch[RootT, BranchT ~[32]byte](
 	leaf RootT,
 	branch []BranchT,

--- a/primitives/net/jwt/jwt.go
+++ b/primitives/net/jwt/jwt.go
@@ -37,8 +37,6 @@ var HexRegexp = regexp.MustCompile(`^(?:0x)?[0-9a-fA-F]*$`)
 // EthereumJWTLength defines the length of the JWT byte array to be 32 bytes as
 // defined the Engine API specification.
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md
-//
-//nolint:lll // link.
 const EthereumJWTLength = 32
 
 // Secret represents a JSON Web Token as a fixed-size byte array.

--- a/primitives/net/jwt/jwt_test.go
+++ b/primitives/net/jwt/jwt_test.go
@@ -18,7 +18,6 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-//nolint:lll // lots of hex strings.
 package jwt_test
 
 import (

--- a/state-transition/core/state/statedb.go
+++ b/state-transition/core/state/statedb.go
@@ -190,7 +190,7 @@ func (s *StateDB[
 // NOTE: This function is modified from the spec to allow a fixed withdrawal
 // (as the first withdrawal) used for EVM inflation.
 //
-//nolint:lll,funlen,gocognit // TODO: Simplify when dropping special cases.
+//nolint:funlen,gocognit // TODO: Simplify when dropping special cases.
 func (s *StateDB[
 	_, _, _, _, _, _, ValidatorT, _, WithdrawalT, _,
 ]) ExpectedWithdrawals() ([]WithdrawalT, error) {

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -488,8 +488,6 @@ func (sp *StateProcessor[
 
 // processEffectiveBalanceUpdates as defined in the Ethereum 2.0 specification.
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#effective-balances-updates
-//
-//nolint:lll
 func (sp *StateProcessor[
 	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
 ]) processEffectiveBalanceUpdates(

--- a/state-transition/core/state_processor_randao.go
+++ b/state-transition/core/state_processor_randao.go
@@ -94,8 +94,6 @@ func (sp *StateProcessor[
 
 // processRandaoMixesReset as defined in the Ethereum 2.0 specification.
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#randao-mixes-updates
-//
-//nolint:lll
 func (sp *StateProcessor[
 	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
 ]) processRandaoMixesReset(

--- a/state-transition/core/state_processor_slashing.go
+++ b/state-transition/core/state_processor_slashing.go
@@ -27,8 +27,6 @@ import (
 
 // processSlashingsReset as defined in the Ethereum 2.0 specification.
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#slashings-balances-updates
-//
-//nolint:lll
 func (sp *StateProcessor[
 	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
 ]) processSlashingsReset(

--- a/state-transition/core/state_processor_withdrawals.go
+++ b/state-transition/core/state_processor_withdrawals.go
@@ -36,10 +36,7 @@ import (
 // NOTE: Modified from the Ethereum 2.0 specification to support EVM inflation:
 // 1. The first withdrawal MUST be a fixed EVM inflation withdrawal
 // 2. Subsequent withdrawals (if any) are processed as validator withdrawals
-// 3. This modification reduces the maximum validator withdrawals per block by
-// one
-//
-//nolint:lll // TODO: Simplify when dropping special cases.
+// 3. This modification reduces the maximum validator withdrawals per block by one.
 func (sp *StateProcessor[
 	BeaconBlockT, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
 ]) processWithdrawals(

--- a/storage/beacondb/keys/keys.go
+++ b/storage/beacondb/keys/keys.go
@@ -46,7 +46,6 @@ const (
 	ForkPrefix
 )
 
-//nolint:lll
 const (
 	WithdrawalQueuePrefixHumanReadable                  = "WithdrawalQueuePrefix"
 	RandaoMixPrefixHumanReadable                        = "RandaoMixPrefix"


### PR DESCRIPTION
Currently running `make lint` runs linting according to the `.golangci.yaml` conf. In that file we set a max line-length of 80 which outputs linting errors for lines longer than that and results in failed CI. 

I propose we increase that limit to 140 as it allows more code to be viewed on screen at once as we usually have more horizontal screen space than vertical.  Go is also [typically not strict on line length](https://google.github.io/styleguide/go/guide#line-length). 

I would be fine with having no upper limit and make it up to the developer to make sure their code is readable, but lets start with this to get a discussion going.