### PR TITLE
Check for int64 overflow when computing uint64 diff

### DIFF
--- a/mod/primitives/pkg/math/u64.go
+++ b/mod/primitives/pkg/math/u64.go
@@ -21,6 +21,7 @@
 package math
 
 import (
+	"math"
 	"math/big"
 	"strconv"
 
@@ -159,4 +160,30 @@ func GweiFromWei(i *big.Int) (Gwei, error) {
 // ToWei converts a value from Gwei to Wei.
 func (u Gwei) ToWei() *U256 {
 	return (&U256{}).Mul(NewU256(uint64(u)), NewU256(GweiPerWei))
+}
+
+// ---------------------------- Diff ----------------------------
+
+var ErrDiffOverflow = errors.New("diff overflows int64")
+
+// DiffUint64 returns the difference between two U64 values as int64
+// and returns an error if the difference overflows int64.
+func DiffUint64(a, b U64) (int64, error) {
+	var diff U64
+	if a > b {
+		diff = a - b
+	} else {
+		diff = b - a
+	}
+
+	if diff > math.MaxInt64 {
+		return 0, ErrDiffOverflow
+	}
+
+	//#nosec:G701 // should be safe as we checked for overflow above.
+	signedDiff := int64(diff)
+	if a < b {
+		return -signedDiff, nil
+	}
+	return signedDiff, nil
 }

--- a/mod/primitives/pkg/math/u64_test.go
+++ b/mod/primitives/pkg/math/u64_test.go
@@ -548,3 +548,68 @@ func TestU64_UnwrapPtr(t *testing.T) {
 		})
 	}
 }
+
+func TestU64_Int64Diff(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        math.U64
+		b        math.U64
+		expected int64
+		err      error
+	}{
+		{
+			name:     "a > b",
+			a:        math.U64(10),
+			b:        math.U64(5),
+			expected: 5,
+			err:      nil,
+		},
+		{
+			name:     "a < b",
+			a:        math.U64(5),
+			b:        math.U64(10),
+			expected: -5,
+			err:      nil,
+		},
+		{
+			name:     "a = b",
+			a:        math.U64(5),
+			b:        math.U64(5),
+			expected: 0,
+			err:      nil,
+		},
+		{
+			name:     "large a = b should no overflow",
+			a:        math.U64(1<<64 - 1),
+			b:        math.U64(1<<64 - 1),
+			expected: 0,
+			err:      nil,
+		},
+		{
+			name:     "a > b, overflow",
+			a:        math.U64(1<<64 - 1),
+			b:        0,
+			expected: 0,
+			err:      math.ErrDiffOverflow,
+		},
+		{
+			name:     "a < b, overflow",
+			a:        0,
+			b:        math.U64(1<<64 - 1),
+			expected: 0,
+			err:      math.ErrDiffOverflow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff, err := math.DiffUint64(tt.a, tt.b)
+			if tt.err != nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, diff)
+			}
+		})
+	}
+}

--- a/mod/state-transition/pkg/core/metrics.go
+++ b/mod/state-transition/pkg/core/metrics.go
@@ -20,6 +20,8 @@
 
 package core
 
+import "github.com/berachain/beacon-kit/mod/primitives/pkg/math"
+
 type stateProcessorMetrics struct {
 	// sink is the sink for the metrics.
 	sink TelemetrySink
@@ -34,12 +36,21 @@ func newStateProcessorMetrics(
 	}
 }
 
-func (s *stateProcessorMetrics) gaugeTimestamps(
+func (s *stateProcessorMetrics) gaugePayloadConsensusTimestampDiff(
 	payloadTimestamp uint64,
 	consensusTimestamp uint64,
-) {
+) error {
 	// the diff can be positive or negative depending on whether the payload
 	// timestamp is ahead or behind the consensus timestamp
-	diff := int64(payloadTimestamp) - int64(consensusTimestamp) //#nosec:G701
+	diff, err := math.DiffUint64(
+		math.U64(payloadTimestamp),
+		math.U64(consensusTimestamp),
+	)
+	if err != nil {
+		return err
+	}
+
 	s.sink.SetGauge("beacon_kit.state.payload_consensus_timestamp_diff", diff)
+
+	return nil
 }


### PR DESCRIPTION
In https://github.com/berachain/beacon-kit/pull/2171 we added the `beacon_kit.state.payload_consensus_timestamp_diff` metric for tracking the diff between the payload and consensus timestamps. 

In that PR we ignored int64 overflow which this PR addresses. Here we explicitly check ahead of time if an overflow will happen and log an error if that is the case. 
