### PR TITLE
docs: erc -> eip

### DIFF
--- a/contracts/src/eip4788/README.md
+++ b/contracts/src/eip4788/README.md
@@ -1,3 +1,3 @@
-# ERC-4788 Bytecode
+# EIP-4788 Bytecode
 
 As taken from: [https://etherscan.io/address/0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02#code](https://etherscan.io/address/0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02#code)


### PR DESCRIPTION
EIP-4788 is an Ethereum Improvement Proposal, not an ERC (Ethereum Request for Comments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README header for the EIP-4788 specification to reflect the correct terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->