### PR TITLE
fix: endless loop if DefaultE2ETestTimeout timeout is reached

### DIFF
--- a/testing/e2e/suite/setup.go
+++ b/testing/e2e/suite/setup.go
@@ -339,6 +339,13 @@ func (s *KurtosisE2ESuite) WaitForFinalizedBlockNumber(
 	defer ticker.Stop()
 	var finalBlockNum uint64
 	for finalBlockNum < target {
+		// check if cctx deadline is exceeded to prevent endless loop
+		select {
+		case <-cctx.Done():
+			return cctx.Err()
+		default:
+		}
+
 		var err error
 		finalBlockNum, err = s.JSONRPCBalancer().BlockNumber(cctx)
 		if err != nil {


### PR DESCRIPTION
**Context**
In our e2e tests while running `WaitForFinalizedBlockNumber` we poll for the most recent blocknumber. This polling is run using a context with a timeout specified by `DefaultE2ETestTimeout` constant which is currently set to 5 minutes. If that timeout is reached 
the poll to get the blocknumber fails and we retry in a loop without checking if the deadline is reached.

Currently on `main` the `test-e2e` is flaky and I observed stuck action runs due to this endless loop causing followup PRs to not trigger any CI actions.

**Fix**
This PR addresses this by checking if context is `Done()` inside the polling loop.

**Test plan**
Before applying the changes in this PR I tried lowering the `DefaultE2ETestTimeout` locally so it triggered a timeout and ran `make test-e2e`, it caused the same issue as the one on GH:

![image](https://github.com/user-attachments/assets/1b675e40-7db5-4b55-9484-f936b9806afb)

When applying the fix we now don't get an endless loop and fail gracefully:

![image](https://github.com/user-attachments/assets/b9c0587d-ef91-4203-8e5e-ca71a7f422a7)



