### PR TITLE
fix: broken start-erigon make target

### DIFF
--- a/build/scripts/testing.mk
+++ b/build/scripts/testing.mk
@@ -205,7 +205,7 @@ start-erigon: ## start an ephemeral `erigon` node
 	-v $(PWD)/.tmp:/.tmp \
 	erigontech/erigon:latest init \
 	--datadir /.tmp/erigon \
-	/${TESTAPP_FILES_DIR}/eth-genesis.json
+	/${ETH_GENESIS_PATH}
 
 	docker run \
 	-p 30303:30303 \


### PR DESCRIPTION
Fixes: https://github.com/berachain/beacon-kit/issues/2169

This PR fixes the `start-erigon` make target. The root cause was invalid paths used as params to docker and that erigon Dockerfile had changed to a different userid/group. To address that I specified to docker to run as user 1000:1000 as it was before it was changed (now it defaults to having a erigon user with id 3473:3473)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration for running Ethereum nodes to improve user permissions and streamline execution commands.
	- Adjusted file paths for data directories and authentication secrets for better clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->