### PR TITLE
Fixed a typo in the word  README.md

### DIFF
--- a/kurtosis/README.md
+++ b/kurtosis/README.md
@@ -22,7 +22,7 @@ beacon-kit repo:
 make start-devnet
 ```
 
-This will automatically build your beacond docker image from the local source
+This will automatically build your beacon docker image from the local source
 code, and spin up a Kurtosis network based on the config file in
 `kurtosis/beaconkit-all.yaml`. Once complete, this will output all the
 network information for your nodes like so:


### PR DESCRIPTION
Fixed a typo in the word ** "beacond" ** on ** "beacon" ** for the correctness of the text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README to correct terminology from "beacond" to "beacon" for clarity on building the Docker image.
	- Maintained existing instructions for setup and management of the network in local and GCP environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->