### PR TITLE
protect valSetByEpoch for concurrent access

### DIFF
--- a/mod/state-transition/pkg/core/state_processor.go
+++ b/mod/state-transition/pkg/core/state_processor.go
@@ -23,6 +23,7 @@ package core
 import (
 	"bytes"
 	"fmt"
+	"sync"
 
 	"github.com/berachain/beacon-kit/mod/config/pkg/spec"
 	"github.com/berachain/beacon-kit/mod/consensus-types/pkg/types"
@@ -109,6 +110,9 @@ type StateProcessor[
 	// ones.
 	// We prune the map to preserve only current and previous epoch
 	valSetByEpoch map[math.Epoch][]ValidatorT
+
+	// valSetMu protects valSetByEpoch from concurrent accesses
+	valSetMu sync.RWMutex
 }
 
 // NewStateProcessor creates a new state processor.

--- a/mod/state-transition/pkg/core/state_processor.go
+++ b/mod/state-transition/pkg/core/state_processor.go
@@ -101,6 +101,9 @@ type StateProcessor[
 	// metrics is the metrics for the service.
 	metrics *stateProcessorMetrics
 
+	// valSetMu protects valSetByEpoch from concurrent accesses
+	valSetMu sync.RWMutex
+
 	// valSetByEpoch tracks the set of validators active at the latest epochs.
 	// This is useful to optimize validators set updates.
 	// Note: Transition may be called multiple times on different,
@@ -110,9 +113,6 @@ type StateProcessor[
 	// ones.
 	// We prune the map to preserve only current and previous epoch
 	valSetByEpoch map[math.Epoch][]ValidatorT
-
-	// valSetMu protects valSetByEpoch from concurrent accesses
-	valSetMu sync.RWMutex
 }
 
 // NewStateProcessor creates a new state processor.

--- a/mod/state-transition/pkg/core/state_processor_validators.go
+++ b/mod/state-transition/pkg/core/state_processor_validators.go
@@ -52,6 +52,9 @@ func (sp *StateProcessor[
 		return nil, err
 	}
 
+	sp.valSetMu.Lock()
+	defer sp.valSetMu.Unlock()
+
 	// prevEpoch is calculated assuming current block
 	// will turn epoch but we have not update slot yet
 	prevEpoch := sp.cs.SlotToEpoch(slot)


### PR DESCRIPTION
I recently introduced a `valSetByEpoch` map to track some validator sets by epoch. The map must be protected for concurrent access, since `Transition` function is called both by block verification/finalization routines (sequentially, so no issues) and by block building (concurrently, to check that produced block is valid)

This PR fixes the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced thread safety for validator set updates with the introduction of a locking mechanism.
- **Bug Fixes**
	- Improved concurrency control to prevent potential race conditions when accessing validator sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->