### PR TITLE
Update suppress_rpc_check in config.toml.tmpl 

### DIFF
--- a/kurtosis/src/services/blutgang/config.toml.tmpl
+++ b/kurtosis/src/services/blutgang/config.toml.tmpl
@@ -24,7 +24,7 @@ expected_block_time = 13000
 # Time between health checks in ms
 health_check_ttl = 400
 # Suppress the health check running info messages
-supress_rpc_check = false
+suppress_rpc_check = false
 
 # Note: the admin namespace contains volatile functions and
 # should not be exposed publicly.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the spelling of the configuration key from `supress_rpc_check` to `suppress_rpc_check` for the `blutgang` service, ensuring proper application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->