### PR TITLE
Fix - Increase docker pull limit for E2E Testing

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -126,6 +126,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: https://index.docker.io/v1/
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
We're hitting `error response from daemon: toomanyrequests: You have reached your pull rate limit` when running E2E tests. 

Change proposed: Authenticating into Docker Hub, which doubles the rate limit
https://www.docker.com/increase-rate-limits/

If required, we can set up a paid subscription on this account that will increase it even further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CI/CD pipeline with Docker Hub login functionality.
	- Conditional authentication for Docker image pushes to GitHub and Google Cloud registries. 

- **Bug Fixes**
	- Improved reliability of Docker image deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->