### PR TITLE
chore(primitives): add recover to MustToBytes

### DIFF
--- a/mod/consensus-types/pkg/types/genesis.go
+++ b/mod/consensus-types/pkg/types/genesis.go
@@ -138,7 +138,7 @@ func DefaultGenesisExecutionPayloadHeaderDeneb() (
 	*ExecutionPayloadHeader, error,
 ) {
 	stateRoot, err := byteslib.ToBytes32(
-		hex.MustToBytes(
+		hex.ToBytesSafe(
 			"0x12965ab9cbe2d2203f61d23636eb7e998f167cb79d02e452f532535641e35bcc",
 		),
 	)
@@ -147,7 +147,7 @@ func DefaultGenesisExecutionPayloadHeaderDeneb() (
 	}
 
 	receiptsRoot, err := byteslib.ToBytes32(
-		hex.MustToBytes(
+		hex.ToBytesSafe(
 			"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
 		),
 	)

--- a/mod/da/pkg/kzg/ckzg/ckzg.go
+++ b/mod/da/pkg/kzg/ckzg/ckzg.go
@@ -49,11 +49,11 @@ func NewVerifier(ts *gokzg4844.JSONTrustedSetup) (*Verifier, error) {
 		len(ts.SetupG1Lagrange)*(len(ts.SetupG1Lagrange[0])-2)/2,
 	)
 	for i, g1 := range ts.SetupG1Lagrange {
-		copy(g1s[i*(len(g1)-2)/2:], hex.MustToBytes(g1))
+		copy(g1s[i*(len(g1)-2)/2:], hex.ToBytesSafe(g1))
 	}
 	g2s := make([]byte, len(ts.SetupG2)*(len(ts.SetupG2[0])-2)/2)
 	for i, g2 := range ts.SetupG2 {
-		copy(g2s[i*(len(g2)-2)/2:], hex.MustToBytes(g2))
+		copy(g2s[i*(len(g2)-2)/2:], hex.ToBytesSafe(g2))
 	}
 	if err := ckzg4844.LoadTrustedSetup(g1s, g2s); err != nil {
 		return nil, err

--- a/mod/primitives/pkg/bytes/b_test.go
+++ b/mod/primitives/pkg/bytes/b_test.go
@@ -120,7 +120,7 @@ func TestMustFromHex(t *testing.T) {
 			var (
 				res []byte
 				f   = func() {
-					res = hex.MustToBytes(tt.input)
+					res = hex.ToBytesSafe(tt.input)
 				}
 			)
 			if tt.shouldPanic {

--- a/mod/primitives/pkg/bytes/b_test.go
+++ b/mod/primitives/pkg/bytes/b_test.go
@@ -82,7 +82,7 @@ func TestFromHex(t *testing.T) {
 	}
 }
 
-func TestMustFromHex(t *testing.T) {
+func TestToBytesSafe(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
@@ -111,7 +111,7 @@ func TestMustFromHex(t *testing.T) {
 			name:        "Invalid hex string",
 			input:       "0x12345",
 			expected:    nil,
-			shouldPanic: true,
+			shouldPanic: false,
 		},
 	}
 

--- a/mod/primitives/pkg/common/execution.go
+++ b/mod/primitives/pkg/common/execution.go
@@ -52,7 +52,7 @@ type ExecutionHash [32]byte
 
 // NewExecutionHashFromHex creates a new hash from a hex string.
 func NewExecutionHashFromHex(input string) ExecutionHash {
-	return ExecutionHash(hex.MustToBytes(input))
+	return ExecutionHash(hex.ToBytesSafe(input))
 }
 
 // Hex converts a hash to a hex string.
@@ -95,7 +95,7 @@ type ExecutionAddress [20]byte
 
 // NewExecutionAddressFromHex creates a new address from a hex string.
 func NewExecutionAddressFromHex(input string) ExecutionAddress {
-	return ExecutionAddress(hex.MustToBytes(input))
+	return ExecutionAddress(hex.ToBytesSafe(input))
 }
 
 // Equals returns true if the two addresses are the same.

--- a/mod/primitives/pkg/encoding/hex/bytes.go
+++ b/mod/primitives/pkg/encoding/hex/bytes.go
@@ -22,7 +22,6 @@ package hex
 
 import (
 	"encoding/hex"
-	"fmt"
 
 	"github.com/berachain/beacon-kit/mod/errors"
 )
@@ -30,7 +29,7 @@ import (
 var ErrInvalidHexStringLength = errors.New("invalid hex string length")
 
 // EncodeBytes creates a hex string with 0x prefix.
-// Inverse operation is ToBytes or MustToBytes.
+// Inverse operation is ToBytes or ToBytesSafe.
 func EncodeBytes(b []byte) string {
 	hexStr := make([]byte, len(b)*2+prefixLen)
 	copy(hexStr, Prefix)
@@ -38,12 +37,12 @@ func EncodeBytes(b []byte) string {
 	return string(hexStr)
 }
 
-// MustToBytes returns the bytes represented by the given hex string.
-// It panics if the input is not a valid hex string.
-func MustToBytes(input string) (bz []byte) {
+// ToBytesSafe returns the bytes represented by the given hex string.
+// If the input is not a valid hex string, it returns an empty byte slice.
+func ToBytesSafe(input string) []byte {
+	var bz []byte
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Errorf("failed to decode hex string: %v", r)
 			bz = []byte{}
 		}
 	}()

--- a/mod/primitives/pkg/encoding/hex/bytes.go
+++ b/mod/primitives/pkg/encoding/hex/bytes.go
@@ -22,6 +22,7 @@ package hex
 
 import (
 	"encoding/hex"
+	"fmt"
 
 	"github.com/berachain/beacon-kit/mod/errors"
 )
@@ -39,7 +40,13 @@ func EncodeBytes(b []byte) string {
 
 // MustToBytes returns the bytes represented by the given hex string.
 // It panics if the input is not a valid hex string.
-func MustToBytes(input string) []byte {
+func MustToBytes(input string) (bz []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Errorf("failed to decode hex string: %v", r)
+			bz = []byte{}
+		}
+	}()
 	bz, err := ToBytes(input)
 	if err != nil {
 		panic(err)

--- a/mod/primitives/pkg/encoding/hex/bytes_test.go
+++ b/mod/primitives/pkg/encoding/hex/bytes_test.go
@@ -74,7 +74,7 @@ func TestEncodeAndDecodeBytes(t *testing.T) {
 			require.Equal(t, tt.input, decoded)
 
 			require.NotPanics(t, func() {
-				decoded = hex.MustToBytes(result)
+				decoded = hex.ToBytesSafe(result)
 			})
 			require.Equal(t, tt.input, decoded)
 		})

--- a/mod/primitives/pkg/net/jwt/jwt_test.go
+++ b/mod/primitives/pkg/net/jwt/jwt_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestNewFromHex(t *testing.T) {
 	wantValid := jwt.Secret(
-		hex.MustToBytes(
+		hex.ToBytesSafe(
 			"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 		),
 	)
@@ -91,7 +91,7 @@ func TestSecretString(t *testing.T) {
 		{
 			name: "mask secret correctly",
 			secret: jwt.Secret(
-				hex.MustToBytes(
+				hex.ToBytesSafe(
 					"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 				),
 			),

--- a/mod/state-transition/pkg/core/state_processor_genesis.go
+++ b/mod/state-transition/pkg/core/state_processor_genesis.go
@@ -104,7 +104,7 @@ func (sp *StateProcessor[
 	}
 
 	// Handle special case bartio genesis.
-	validatorsRoot := common.Root(hex.MustToBytes(spec.BartioValRoot))
+	validatorsRoot := common.Root(hex.ToBytesSafe(spec.BartioValRoot))
 	if sp.cs.DepositEth1ChainID() != spec.BartioChainID {
 		validators, err := st.GetValidators()
 		if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the hex conversion process by replacing the `MustToBytes` function with `ToBytesSafe`, preventing program crashes and allowing for safer error management.

- **New Features**
	- Enhanced overall robustness of the application by implementing safer hex string to byte conversions across various components, including state processing and execution handling.
	- Updated test suites to reflect the new error handling logic, ensuring consistent validation of hex string conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->