### PR TITLE
fix(state-transition): fix deposit signature verification

### DIFF
--- a/mod/state-transition/pkg/core/state_processor_staking.go
+++ b/mod/state-transition/pkg/core/state_processor_staking.go
@@ -134,7 +134,14 @@ func (sp *StateProcessor[
 		sp.cs.DomainTypeDeposit(),
 		sp.signer.VerifySignature,
 	); err != nil {
-		return err
+		// Ignore deposits that fail the signature check.
+		sp.logger.Info(
+			"failed deposit signature verification",
+			"deposit_index", dep.GetIndex(),
+			"error", err,
+		)
+
+		return nil
 	}
 
 	// Add the validator to the registry.


### PR DESCRIPTION
Skip invalid deposits without failing the whole block