### PR TITLE
fix(state-transition): restore state sync over boonet

### DIFF
--- a/config/spec/special_cases.go
+++ b/config/spec/special_cases.go
@@ -20,6 +20,8 @@
 
 package spec
 
+import "math"
+
 // Special cased Bartio for some ad-hoc handling due to the way
 // some bugs were handled on Bartio. To be removed.
 const (
@@ -34,4 +36,6 @@ const (
 	BoonetFork1Height uint64 = 69420
 
 	BoonetFork2Height uint64 = 1722000
+
+	BoonetFork3Height uint64 = math.MaxUint64
 )

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -386,7 +386,7 @@ func (sp *StateProcessor[
 			return nil, err
 		}
 	case sp.cs.DepositEth1ChainID() == spec.BoonetEth1ChainID &&
-		slot != 0 && slot < math.U64(spec.BoonetFork3Height):
+		slot < math.U64(spec.BoonetFork3Height):
 		// We cannot simply drop hollowProcessRewardsAndPenalties because
 		// appHash accounts for the list of operations carried out
 		// over the state even if the operations does not affect the state

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -84,7 +84,7 @@ func (sp *StateProcessor[
 		// We keep it for backward compatibility.
 		depositIndex++
 	case sp.cs.DepositEth1ChainID() == spec.BoonetEth1ChainID &&
-		slot < math.U64(spec.BoonetFork2Height):
+		slot != 0 && slot < math.U64(spec.BoonetFork2Height):
 		// Boonet pre fork2 has a bug which makes DepositEth1ChainID point to
 		// next deposit index, not latest processed deposit index.
 		// We keep it for backward compatibility.


### PR DESCRIPTION
Sync is currently broken on Boonet. Bysecting I found:

- https://github.com/berachain/beacon-kit/pull/2158 broke syncing this but making a non-backward compatible change to `MaxValidatorsPerWithdrawalsSweep
- https://github.com/berachain/beacon-kit/pull/2194 fixes syncing  again
- https://github.com/berachain/beacon-kit/pull/2202 broke syncing again

The latest PR breaks sync because if mistakenly changes the indexes for genesis deposits, and only those
These indexes are part of the beacon state that is hashed into blocks. So state sync was broken because:
- Genesis state is subtly modified
- Block 1, already finalized and downloaded from a peer, fails verification because `AppHash` reported by the block does not match the `AppHash` generated by the local state.

The fix is to preserve the way we set indexes over genesis

MOREOVER

We need to properly drop uselass BeaconState ops to preserve appHash