### PR TITLE
feat(state-transition): make validators epochs handling close to Eth2.0 specs

### DIFF
--- a/consensus-types/types/validator.go
+++ b/consensus-types/types/validator.go
@@ -246,9 +246,7 @@ func (v Validator) IsActive(epoch math.Epoch) bool {
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#is_eligible_for_activation_queue
 //
 //nolint:lll
-func (v Validator) IsEligibleForActivation(
-	finalizedEpoch math.Epoch,
-) bool {
+func (v Validator) IsEligibleForActivation(finalizedEpoch math.Epoch) bool {
 	return v.ActivationEligibilityEpoch <= finalizedEpoch &&
 		v.ActivationEpoch == math.Epoch(constants.FarFutureEpoch)
 }
@@ -335,6 +333,14 @@ func (v *Validator) SetActivationEligibilityEpoch(e math.Epoch) {
 
 func (v *Validator) GetActivationEligibilityEpoch() math.Epoch {
 	return v.ActivationEligibilityEpoch
+}
+
+func (v *Validator) SetActivationEpoch(e math.Epoch) {
+	v.ActivationEpoch = e
+}
+
+func (v *Validator) GetActivationEpoch() math.Epoch {
+	return v.ActivationEpoch
 }
 
 // GetWithdrawalCredentials returns the withdrawal credentials of the validator.

--- a/consensus-types/types/validator.go
+++ b/consensus-types/types/validator.go
@@ -253,17 +253,13 @@ func (v Validator) IsEligibleForActivation(
 		v.ActivationEpoch == math.Epoch(constants.FarFutureEpoch)
 }
 
-// IsEligibleForActivationQueue as defined in the Ethereum 2.0 Spec
+// IsEligibleForActivationQueue is defined slightly differently from Ethereum 2.0 Spec
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#is_eligible_for_activation_queue
 //
 //nolint:lll
-func (v Validator) IsEligibleForActivationQueue(
-	maxEffectiveBalance math.Gwei,
-) bool {
-	return v.ActivationEligibilityEpoch == math.Epoch(
-		constants.FarFutureEpoch,
-	) &&
-		v.EffectiveBalance == maxEffectiveBalance
+func (v Validator) IsEligibleForActivationQueue(threshold math.Gwei) bool {
+	return v.ActivationEligibilityEpoch == math.Epoch(constants.FarFutureEpoch) &&
+		v.EffectiveBalance >= threshold
 }
 
 // IsSlashable as defined in the Ethereum 2.0 Spec
@@ -296,9 +292,7 @@ func (v Validator) IsFullyWithdrawable(
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#is_partially_withdrawable_validator
 //
 //nolint:lll
-func (v Validator) IsPartiallyWithdrawable(
-	balance, maxEffectiveBalance math.Gwei,
-) bool {
+func (v Validator) IsPartiallyWithdrawable(balance, maxEffectiveBalance math.Gwei) bool {
 	hasExcessBalance := balance > maxEffectiveBalance
 	return v.HasEth1WithdrawalCredentials() &&
 		v.HasMaxEffectiveBalance(maxEffectiveBalance) && hasExcessBalance
@@ -333,6 +327,14 @@ func (v *Validator) SetWithdrawableEpoch(e math.Epoch) {
 // GetWithdrawableEpoch returns the epoch when the validator can withdraw.
 func (v Validator) GetWithdrawableEpoch() math.Epoch {
 	return v.WithdrawableEpoch
+}
+
+func (v *Validator) SetActivationEligibilityEpoch(e math.Epoch) {
+	v.ActivationEligibilityEpoch = e
+}
+
+func (v *Validator) GetActivationEligibilityEpoch() math.Epoch {
+	return v.ActivationEligibilityEpoch
 }
 
 // GetWithdrawalCredentials returns the withdrawal credentials of the validator.

--- a/consensus-types/types/validator.go
+++ b/consensus-types/types/validator.go
@@ -317,16 +317,6 @@ func (v *Validator) SetEffectiveBalance(balance math.Gwei) {
 	v.EffectiveBalance = balance
 }
 
-// SetWithdrawableEpoch sets the epoch when the validator can withdraw.
-func (v *Validator) SetWithdrawableEpoch(e math.Epoch) {
-	v.WithdrawableEpoch = e
-}
-
-// GetWithdrawableEpoch returns the epoch when the validator can withdraw.
-func (v Validator) GetWithdrawableEpoch() math.Epoch {
-	return v.WithdrawableEpoch
-}
-
 func (v *Validator) SetActivationEligibilityEpoch(e math.Epoch) {
 	v.ActivationEligibilityEpoch = e
 }
@@ -341,6 +331,22 @@ func (v *Validator) SetActivationEpoch(e math.Epoch) {
 
 func (v *Validator) GetActivationEpoch() math.Epoch {
 	return v.ActivationEpoch
+}
+
+func (v *Validator) SetExitEpoch(e math.Epoch) {
+	v.ExitEpoch = e
+}
+
+func (v Validator) GetExitEpoch() math.Epoch {
+	return v.ExitEpoch
+}
+
+func (v *Validator) SetWithdrawableEpoch(e math.Epoch) {
+	v.WithdrawableEpoch = e
+}
+
+func (v Validator) GetWithdrawableEpoch() math.Epoch {
+	return v.WithdrawableEpoch
 }
 
 // GetWithdrawalCredentials returns the withdrawal credentials of the validator.

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -398,6 +398,9 @@ func (sp *StateProcessor[
 		// no real need to perform hollowProcessRewardsAndPenalties
 	}
 
+	if err = sp.processRegistryUpdates(st); err != nil {
+		return nil, err
+	}
 	if err = sp.processEffectiveBalanceUpdates(st); err != nil {
 		return nil, err
 	}

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -364,6 +364,8 @@ func (sp *StateProcessor[
 		return nil, err
 	}
 
+	// track validators set before updating it, to be able to
+	// inform consensus of the validators set changes
 	currentEpoch := sp.cs.SlotToEpoch(slot)
 	currentActiveVals, err := sp.getActiveVals(st, currentEpoch)
 	if err != nil {
@@ -385,10 +387,14 @@ func (sp *StateProcessor[
 	if err = sp.processRandaoMixesReset(st); err != nil {
 		return nil, err
 	}
+
+	// only after we have fully updated validators, we enforce
+	// a cap on the validators set
 	if err = sp.processValidatorSetCap(st); err != nil {
 		return nil, err
 	}
 
+	// finally compute diffs in validator set to duly update consensus
 	nextEpoch := currentEpoch + 1
 	nextActiveVals, err := sp.getActiveVals(st, nextEpoch)
 	if err != nil {

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -30,7 +30,6 @@ import (
 	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/log"
 	"github.com/berachain/beacon-kit/primitives/common"
-	"github.com/berachain/beacon-kit/primitives/constants"
 	"github.com/berachain/beacon-kit/primitives/crypto"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/transition"
@@ -375,39 +374,19 @@ func (sp *StateProcessor[
 ]) processEpoch(
 	st BeaconStateT,
 ) (transition.ValidatorUpdates, error) {
-	slot, err := st.GetSlot()
-	if err != nil {
+	if err := sp.processRewardsAndPenalties(st); err != nil {
 		return nil, err
 	}
-
-	switch {
-	case sp.cs.DepositEth1ChainID() == spec.BartioChainID:
-		if err = sp.hollowProcessRewardsAndPenalties(st); err != nil {
-			return nil, err
-		}
-	case sp.cs.DepositEth1ChainID() == spec.BoonetEth1ChainID &&
-		slot < math.U64(spec.BoonetFork3Height):
-		// We cannot simply drop hollowProcessRewardsAndPenalties because
-		// appHash accounts for the list of operations carried out
-		// over the state even if the operations does not affect the state
-		// (rewards and penalties are always zero at this stage of beaconKit)
-		if err = sp.hollowProcessRewardsAndPenalties(st); err != nil {
-			return nil, err
-		}
-	default:
-		// no real need to perform hollowProcessRewardsAndPenalties
-	}
-
-	if err = sp.processRegistryUpdates(st); err != nil {
+	if err := sp.processRegistryUpdates(st); err != nil {
 		return nil, err
 	}
-	if err = sp.processEffectiveBalanceUpdates(st); err != nil {
+	if err := sp.processEffectiveBalanceUpdates(st); err != nil {
 		return nil, err
 	}
-	if err = sp.processSlashingsReset(st); err != nil {
+	if err := sp.processSlashingsReset(st); err != nil {
 		return nil, err
 	}
-	if err = sp.processRandaoMixesReset(st); err != nil {
+	if err := sp.processRandaoMixesReset(st); err != nil {
 		return nil, err
 	}
 	return sp.processValidatorsSetUpdates(st)
@@ -493,40 +472,6 @@ func (sp *StateProcessor[
 		bodyRoot,
 	)
 	return st.SetLatestBlockHeader(lbh)
-}
-
-func (sp *StateProcessor[
-	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
-]) hollowProcessRewardsAndPenalties(st BeaconStateT) error {
-	slot, err := st.GetSlot()
-	if err != nil {
-		return err
-	}
-
-	if sp.cs.SlotToEpoch(slot) == math.U64(constants.GenesisEpoch) {
-		return nil
-	}
-
-	// this has been simplified to make clear that
-	// we are not really doing anything here
-	valCount, err := st.GetTotalValidators()
-	if err != nil {
-		return err
-	}
-
-	for i := range valCount {
-		// Increase the balance of the validator.
-		if err = st.IncreaseBalance(math.ValidatorIndex(i), 0); err != nil {
-			return err
-		}
-
-		// Decrease the balance of the validator.
-		if err = st.DecreaseBalance(math.ValidatorIndex(i), 0); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // processEffectiveBalanceUpdates as defined in the Ethereum 2.0 specification.

--- a/state-transition/core/state_processor_genesis.go
+++ b/state-transition/core/state_processor_genesis.go
@@ -120,6 +120,7 @@ func (sp *StateProcessor[
 		var idx math.ValidatorIndex
 		for _, val := range vals {
 			val.SetActivationEligibilityEpoch(0)
+			val.SetActivationEpoch(0)
 			idx, err = st.ValidatorIndexByPubkey(val.GetPubkey())
 			if err != nil {
 				return nil, err

--- a/state-transition/core/state_processor_genesis_test.go
+++ b/state-transition/core/state_processor_genesis_test.go
@@ -145,12 +145,18 @@ func checkValidatorNonBartio(
 ) {
 	t.Helper()
 
-	// checks on validators common to all networks
-	commonChecksValidators(t, cs, bs, dep)
-
-	// checks on validators for any network but Bartio
 	idx, err := bs.ValidatorIndexByPubkey(dep.Pubkey)
 	require.NoError(t, err)
+
+	val, err := bs.ValidatorByIndex(idx)
+	require.NoError(t, err)
+	require.Equal(t, dep.Pubkey, val.Pubkey)
+
+	// checks on validators common to all networks
+	commonChecksValidators(t, cs, val, dep)
+
+	// checks on validators for any network but Bartio
+	require.Equal(t, math.Epoch(0), val.GetActivationEligibilityEpoch())
 
 	valBal, err := bs.GetBalance(idx)
 	require.NoError(t, err)
@@ -268,15 +274,17 @@ func checkValidatorBartio(
 ) {
 	t.Helper()
 
-	// checks on validators common to all networks
-	commonChecksValidators(t, cs, bs, dep)
-
-	// Bartio specific checks on validators
 	idx, err := bs.ValidatorIndexByPubkey(dep.Pubkey)
 	require.NoError(t, err)
+
 	val, err := bs.ValidatorByIndex(idx)
 	require.NoError(t, err)
+	require.Equal(t, dep.Pubkey, val.Pubkey)
 
+	// checks on validators common to all networks
+	commonChecksValidators(t, cs, val, dep)
+
+	// Bartio specific checks on validators
 	valBal, err := bs.GetBalance(idx)
 	require.NoError(t, err)
 	require.Equal(t, val.EffectiveBalance, valBal)
@@ -291,16 +299,10 @@ func commonChecksValidators(
 		math.Slot,
 		any,
 	],
-	bs *TestBeaconStateT,
+	val *types.Validator,
 	dep *types.Deposit,
 ) {
 	t.Helper()
-
-	idx, err := bs.ValidatorIndexByPubkey(dep.Pubkey)
-	require.NoError(t, err)
-
-	val, err := bs.ValidatorByIndex(idx)
-	require.NoError(t, err)
 	require.Equal(t, dep.Pubkey, val.Pubkey)
 
 	var (

--- a/state-transition/core/state_processor_genesis_test.go
+++ b/state-transition/core/state_processor_genesis_test.go
@@ -157,6 +157,7 @@ func checkValidatorNonBartio(
 
 	// checks on validators for any network but Bartio
 	require.Equal(t, math.Epoch(0), val.GetActivationEligibilityEpoch())
+	require.Equal(t, math.Epoch(0), val.GetActivationEpoch())
 
 	valBal, err := bs.GetBalance(idx)
 	require.NoError(t, err)
@@ -283,6 +284,17 @@ func checkValidatorBartio(
 
 	// checks on validators common to all networks
 	commonChecksValidators(t, cs, val, dep)
+
+	require.Equal(
+		t,
+		math.Epoch(constants.FarFutureEpoch),
+		val.GetActivationEligibilityEpoch(),
+	)
+	require.Equal(
+		t,
+		math.Epoch(constants.FarFutureEpoch),
+		val.GetActivationEpoch(),
+	)
 
 	// Bartio specific checks on validators
 	valBal, err := bs.GetBalance(idx)

--- a/state-transition/core/state_processor_rewards_penalties.go
+++ b/state-transition/core/state_processor_rewards_penalties.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package core
+
+import (
+	"github.com/berachain/beacon-kit/config/spec"
+	"github.com/berachain/beacon-kit/primitives/constants"
+	"github.com/berachain/beacon-kit/primitives/math"
+)
+
+func (sp *StateProcessor[
+	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
+]) processRewardsAndPenalties(st BeaconStateT) error {
+	slot, err := st.GetSlot()
+	if err != nil {
+		return err
+	}
+
+	// processRewardsAndPenalties does not really do anything right now.
+	// However we cannot simply drop it because appHash accounts
+	// for the list of operations carried out over the state
+	// even if the operations does not affect the final state
+	// (rewards and penalties are always zero at this stage of beaconKit)
+
+	switch {
+	case sp.cs.DepositEth1ChainID() == spec.BartioChainID:
+		// go head doing the processing, eve
+	case sp.cs.DepositEth1ChainID() == spec.BoonetEth1ChainID &&
+		slot < math.U64(spec.BoonetFork3Height):
+	default:
+		// no real need to perform hollowProcessRewardsAndPenalties
+		return nil
+	}
+
+	if sp.cs.SlotToEpoch(slot) == math.U64(constants.GenesisEpoch) {
+		return nil
+	}
+
+	// this has been simplified to make clear that
+	// we are not really doing anything here
+	valCount, err := st.GetTotalValidators()
+	if err != nil {
+		return err
+	}
+
+	for i := range valCount {
+		// Increase the balance of the validator.
+		if err = st.IncreaseBalance(math.ValidatorIndex(i), 0); err != nil {
+			return err
+		}
+
+		// Decrease the balance of the validator.
+		if err = st.DecreaseBalance(math.ValidatorIndex(i), 0); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/state-transition/core/state_processor_rewards_penalties.go
+++ b/state-transition/core/state_processor_rewards_penalties.go
@@ -42,9 +42,10 @@ func (sp *StateProcessor[
 
 	switch {
 	case sp.cs.DepositEth1ChainID() == spec.BartioChainID:
-		// go head doing the processing, eve
+		// go head doing the processing
 	case sp.cs.DepositEth1ChainID() == spec.BoonetEth1ChainID &&
 		slot < math.U64(spec.BoonetFork3Height):
+		// go head doing the processing
 	default:
 		// no real need to perform hollowProcessRewardsAndPenalties
 		return nil

--- a/state-transition/core/state_processor_slashing.go
+++ b/state-transition/core/state_processor_slashing.go
@@ -21,6 +21,7 @@
 package core
 
 import (
+	"github.com/berachain/beacon-kit/config/spec"
 	"github.com/berachain/beacon-kit/primitives/math"
 )
 
@@ -33,108 +34,28 @@ func (sp *StateProcessor[
 ]) processSlashingsReset(
 	st BeaconStateT,
 ) error {
-	// Get the current epoch.
+	// processSlashingsReset does not really do anything right now.
+	// However we cannot simply drop it because appHash accounts
+	// for the list of operations carried out over the state
+	// even if the operations does not affect the final state
+	// (currently no slashing on beaconKit)
+
 	slot, err := st.GetSlot()
 	if err != nil {
 		return err
+	}
+
+	switch {
+	case sp.cs.DepositEth1ChainID() == spec.BartioChainID:
+		// go head doing the processing
+	case sp.cs.DepositEth1ChainID() == spec.BoonetEth1ChainID &&
+		slot < math.U64(spec.BoonetFork3Height):
+		// go head doing the processing
+	default:
+		// no real need to perform slashing reset
+		return nil
 	}
 
 	index := (sp.cs.SlotToEpoch(slot).Unwrap() + 1) % sp.cs.EpochsPerSlashingsVector()
 	return st.UpdateSlashingAtIndex(index, 0)
-}
-
-// processProposerSlashing as defined in the Ethereum 2.0 specification.
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#proposer-slashings
-//
-//nolint:lll,unused // will be used later
-func (sp *StateProcessor[
-	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
-]) processProposerSlashing(
-	_ BeaconStateT,
-	// ps ProposerSlashing,
-) error {
-	return nil
-}
-
-// processSlashings as defined in the Ethereum 2.0 specification.
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#slashings
-//
-// processSlashings processes the slashings and ensures they match the local
-// state.
-//
-//nolint:lll,unused // will be used later
-func (sp *StateProcessor[
-	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, _, _, _, _, _,
-]) processSlashings(
-	st BeaconStateT,
-) error {
-	totalBalance, err := st.GetTotalActiveBalances(sp.cs.SlotsPerEpoch())
-	if err != nil {
-		return err
-	}
-
-	totalSlashings, err := st.GetTotalSlashing()
-	if err != nil {
-		return err
-	}
-
-	adjustedTotalSlashingBalance := min(
-		totalSlashings.Unwrap()*sp.cs.ProportionalSlashingMultiplier(),
-		totalBalance.Unwrap(),
-	)
-
-	vals, err := st.GetValidators()
-	if err != nil {
-		return err
-	}
-
-	// Get the current slot.
-	slot, err := st.GetSlot()
-	if err != nil {
-		return err
-	}
-
-	//nolint:mnd // this is in the spec
-	slashableEpoch := (sp.cs.SlotToEpoch(slot).Unwrap() + sp.cs.EpochsPerSlashingsVector()) / 2
-
-	// Iterate through the validators and slash if needed.
-	for _, val := range vals {
-		if val.IsSlashed() &&
-			(slashableEpoch == val.GetWithdrawableEpoch().Unwrap()) {
-			if err = sp.processSlash(
-				st, val,
-				adjustedTotalSlashingBalance,
-				totalBalance.Unwrap(),
-			); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// processSlash handles the logic for slashing a validator.
-//
-//nolint:unused // will be used later
-func (sp *StateProcessor[
-	_, _, _, BeaconStateT, _, _, _, _, _, _, _, _, ValidatorT, _, _, _, _,
-]) processSlash(
-	st BeaconStateT,
-	val ValidatorT,
-	adjustedTotalSlashingBalance uint64,
-	totalBalance uint64,
-) error {
-	// Calculate the penalty.
-	increment := sp.cs.EffectiveBalanceIncrement()
-	balDivIncrement := val.GetEffectiveBalance().Unwrap() / increment
-	penaltyNumerator := balDivIncrement * adjustedTotalSlashingBalance
-	penalty := penaltyNumerator / totalBalance * increment
-
-	// Get the val index and decrease the balance of the validator.
-	idx, err := st.ValidatorIndexByPubkey(val.GetPubkey())
-	if err != nil {
-		return err
-	}
-
-	return st.DecreaseBalance(idx, math.Gwei(penalty))
 }

--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -116,8 +116,8 @@ func (sp *StateProcessor[
 	// validators this epoch and we withdraw them next epoch
 	for li := range uint64(len(nextEpochVals)) - sp.cs.ValidatorSetCap() {
 		valToEject := nextEpochVals[li]
-		valToEject.SetExitEpoch(currEpoch)
-		valToEject.SetWithdrawableEpoch(nextEpoch)
+		valToEject.SetExitEpoch(nextEpoch)
+		valToEject.SetWithdrawableEpoch(nextEpoch + 1)
 		idx, err = st.ValidatorIndexByPubkey(valToEject.GetPubkey())
 		if err != nil {
 			return fmt.Errorf("registry update, failed loading validator index: %w", err)

--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/berachain/beacon-kit/config/spec"
 	"github.com/berachain/beacon-kit/primitives/bytes"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/transition"
@@ -214,10 +215,21 @@ func (sp *StateProcessor[
 	if err != nil {
 		return nil, err
 	}
+
 	activeVals := make([]ValidatorT, 0, len(vals))
-	for _, val := range vals {
-		if val.IsActive(epoch) {
-			activeVals = append(activeVals, val)
+	if sp.cs.DepositEth1ChainID() == spec.BartioChainID {
+		// Bartio does not properly handle validators epochs, so
+		// we have an ad-hoc definition of active validator there
+		for _, val := range vals {
+			if val.GetEffectiveBalance() > math.U64(sp.cs.EjectionBalance()) {
+				activeVals = append(activeVals, val)
+			}
+		}
+	} else {
+		for _, val := range vals {
+			if val.IsActive(epoch) {
+				activeVals = append(activeVals, val)
+			}
 		}
 	}
 

--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -79,9 +79,9 @@ func (sp *StateProcessor[
 	}
 
 	// Enforce the validator set cap by:
-	// 1- retrieve validators active next epoch
-	// 2- sort them by stake
-	// 3- drop enough validators to fulfill the cap
+	// 1- retrieving validators active next epoch
+	// 2- sorting them by stake
+	// 3- dropping enough validators to fulfill the cap
 	nextEpochVals, err := sp.nextEpochValidatorSet(st)
 	if err != nil {
 		return fmt.Errorf("registry update, failed retrieving next epoch vals: %w", err)
@@ -112,7 +112,7 @@ func (sp *StateProcessor[
 		}
 	})
 
-	// We do not currently have a cap on validator churn, so we stop
+	// We do not currently have a cap on validators churn, so we stop
 	// validators this epoch and we withdraw them next epoch
 	for li := range uint64(len(nextEpochVals)) - sp.cs.ValidatorSetCap() {
 		valToEject := nextEpochVals[li]

--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -247,6 +247,9 @@ func (sp *StateProcessor[
 		if val.GetEffectiveBalance() <= math.U64(sp.cs.EjectionBalance()) {
 			continue
 		}
+		if val.GetActivationEligibilityEpoch() == nextEpoch {
+			continue
+		}
 		if val.GetWithdrawableEpoch() == nextEpoch {
 			continue
 		}

--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -166,6 +166,7 @@ func (sp *StateProcessor[
 
 // Note: validatorSetsDiffs does not need to be a StateProcessor method
 // but it helps simplifying generic instantiation.
+// TODO: Turn this into a free function
 func (*StateProcessor[
 	_, _, _, _, _, _, _, _, _, _, _, _, ValidatorT, _, _, _, _,
 ]) validatorSetsDiffs(

--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -146,7 +146,7 @@ func (sp *StateProcessor[
 	})
 
 	// We do not currently have a cap on validators churn, so we stop
-	// validators this epoch and we withdraw them next epoch
+	// validators next epoch and we withdraw them the epoch after
 	var idx math.ValidatorIndex
 	for li := range uint64(len(nextEpochVals)) - sp.cs.ValidatorSetCap() {
 		valToEject := nextEpochVals[li]
@@ -154,10 +154,10 @@ func (sp *StateProcessor[
 		valToEject.SetWithdrawableEpoch(nextEpoch + 1)
 		idx, err = st.ValidatorIndexByPubkey(valToEject.GetPubkey())
 		if err != nil {
-			return fmt.Errorf("registry update, failed loading validator index: %w", err)
+			return fmt.Errorf("validators cap, failed loading validator index: %w", err)
 		}
 		if err = st.UpdateValidatorAtIndex(idx, valToEject); err != nil {
-			return fmt.Errorf("registry update, failed ejecting validator idx %d: %w", li, err)
+			return fmt.Errorf("validator cap, failed ejecting validator idx %d: %w", li, err)
 		}
 	}
 

--- a/state-transition/core/types.go
+++ b/state-transition/core/types.go
@@ -242,6 +242,8 @@ type Validator[
 	) ValidatorT
 	// IsSlashed returns true if the validator is slashed.
 	IsSlashed() bool
+
+	IsEligibleForActivationQueue(threshold math.Gwei) bool
 	// GetPubkey returns the public key of the validator.
 	GetPubkey() crypto.BLSPubkey
 	// GetEffectiveBalance returns the effective balance of the validator in
@@ -253,6 +255,9 @@ type Validator[
 	GetWithdrawableEpoch() math.Epoch
 	// SetWithdrawableEpoch sets the epoch when the validator can withdraw.
 	SetWithdrawableEpoch(math.Epoch)
+
+	GetActivationEligibilityEpoch() math.Epoch
+	SetActivationEligibilityEpoch(math.Epoch)
 }
 
 type Validators interface {

--- a/state-transition/core/types.go
+++ b/state-transition/core/types.go
@@ -244,6 +244,8 @@ type Validator[
 	IsSlashed() bool
 
 	IsEligibleForActivationQueue(threshold math.Gwei) bool
+	IsEligibleForActivation(finalizedEpoch math.Epoch) bool
+
 	// GetPubkey returns the public key of the validator.
 	GetPubkey() crypto.BLSPubkey
 	// GetEffectiveBalance returns the effective balance of the validator in
@@ -258,6 +260,9 @@ type Validator[
 
 	GetActivationEligibilityEpoch() math.Epoch
 	SetActivationEligibilityEpoch(math.Epoch)
+
+	GetActivationEpoch() math.Epoch
+	SetActivationEpoch(math.Epoch)
 }
 
 type Validators interface {

--- a/state-transition/core/types.go
+++ b/state-transition/core/types.go
@@ -253,16 +253,18 @@ type Validator[
 	GetEffectiveBalance() math.Gwei
 	// SetEffectiveBalance sets the effective balance of the validator in Gwei.
 	SetEffectiveBalance(math.Gwei)
-	// GetWithdrawableEpoch returns the epoch when the validator can withdraw.
-	GetWithdrawableEpoch() math.Epoch
-	// SetWithdrawableEpoch sets the epoch when the validator can withdraw.
-	SetWithdrawableEpoch(math.Epoch)
 
 	GetActivationEligibilityEpoch() math.Epoch
 	SetActivationEligibilityEpoch(math.Epoch)
 
 	GetActivationEpoch() math.Epoch
 	SetActivationEpoch(math.Epoch)
+
+	GetExitEpoch() math.Epoch
+	SetExitEpoch(e math.Epoch)
+
+	GetWithdrawableEpoch() math.Epoch
+	SetWithdrawableEpoch(math.Epoch)
 }
 
 type Validators interface {

--- a/state-transition/core/types.go
+++ b/state-transition/core/types.go
@@ -245,6 +245,7 @@ type Validator[
 
 	IsEligibleForActivationQueue(threshold math.Gwei) bool
 	IsEligibleForActivation(finalizedEpoch math.Epoch) bool
+	IsActive(epoch math.Epoch) bool
 
 	// GetPubkey returns the public key of the validator.
 	GetPubkey() crypto.BLSPubkey


### PR DESCRIPTION
- [x] Correctly handle validators epochs
- [x] Implement `processRegistryUpdate`, moving validators cap handling there 
- [x] Drop useless processing (duly guarded by hard fork) 
- [x] Improve diff calculations to use validators epochs only (wherever possible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validator management with new methods for eligibility and activation checks.
	- Introduced a mechanism to enforce a cap on the validator set.
	- Added functionality for processing rewards and penalties within the state processor.

- **Bug Fixes**
	- Improved error handling and validation checks for validator activation and epochs.

- **Documentation**
	- Updated comments and annotations for better clarity and future maintenance.

- **Tests**
	- Refactored test cases to improve clarity and ensure robust validation of validator state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->