### PR TITLE
Build errors now show correct file names

### DIFF
--- a/scripts/build/build.mk
+++ b/scripts/build/build.mk
@@ -86,7 +86,7 @@ build: BUILD_ARGS=-o $(OUT_DIR)/$(TESTAPP) ## build `beacond`
 
 $(BUILD_TARGETS): $(OUT_DIR)/
 	@echo "Building ${TESTAPP_CMD_DIR}"
-	@cd ${CURRENT_DIR}/$(TESTAPP_CMD_DIR) && go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./.
+	@go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) $(TESTAPP_CMD_DIR)/*.go
 
 $(OUT_DIR)/:
 	mkdir -p $(OUT_DIR)/


### PR DESCRIPTION
We were running `go build` from inside cmd/beacond so any build errors show a relative path from that directory which is not clickable to view in the editor.

Instead we should build from root project directory and give it the path to the package to build.