### PR TITLE
Fix - Permission error in E2E Testing

### DIFF
--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -70,11 +70,11 @@ gosec:
 
 slither:
 	docker run \
-	-t \
+	-t --user 1001:118 \
 	--platform linux/amd64 \
 	-v ./contracts:/contracts:rw \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "whoami && ls -ltrh / && chmod -R 777 /contracts && ls -ltrh /contracts && cd /contracts/ && slither ./."
+	/bin/bash -c "whoami && ls -ltrh / && ls -ltrh /contracts && cd /contracts/ && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/tmp/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "cd /tmp/contracts && slither ./."
+	/bin/bash -c "chown -R 1001:1001 /tmp/contracts && cd /tmp/contracts && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -72,7 +72,7 @@ slither:
 	docker run \
 	-t \
 	--platform linux/amd64 \
-	-v ./contracts:/contracts \
+	-v ./contracts:/tmp/contracts \
 	trailofbits/eth-security-toolbox:edge \
 	/bin/bash -c "cd /contracts && slither ./."
 

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -75,7 +75,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/contracts:rw \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "whoami && ls -ltrh / && ls -ltrh /contracts && cd /contracts/ && slither ./."
+	/bin/bash -c "cd /contracts/ && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -70,11 +70,11 @@ gosec:
 
 slither:
 	docker run \
-	-t \
+	-t --user 1001:ethsec \
 	--platform linux/amd64 \
-	-v ./contracts:/tmp/contracts \
+	-v ./contracts:/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "whoami && ls -ltrh /tmp && cd /tmp/contracts && slither ./."
+	/bin/bash -c "ls -ltrh /tmp && cd /contracts && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/tmp/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "cd /contracts && slither ./."
+	/bin/bash -c "cd /tmp/contracts && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/contracts:rw \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "ls -ltrh / && ls -ltrh /contracts && cd /contracts/ && slither ./."
+	/bin/bash -c "whoami ls -ltrh / && chmod -R 777 /contracts && ls -ltrh /contracts && cd /contracts/ && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "ls -ltrh / && chmod -R u+rw,g+rw,o+rw /contracts && ls -ltrh /contracts && cd /contracts && slither ./."
+	/bin/bash -c "cp -r /contracts ~/ && cd ~/contracts/ && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "ls -ltrh /tmp && cd /contracts && slither ./."
+	/bin/bash -c "ls -ltrh /contracts && cd /contracts && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "ls -ltrh /contracts && cd /contracts && slither ./."
+	/bin/bash -c "ls -ltrh / && chmod -R /contracts && ls -ltrh /contracts && cd /contracts && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -70,11 +70,11 @@ gosec:
 
 slither:
 	docker run \
-	-t --user 1001:ethsec \
+	-t \
 	--platform linux/amd64 \
-	-v ./contracts:/contracts \
+	-v ./contracts:/contracts:rw \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "cp -r /contracts ~/ && cd ~/contracts/ && slither ./."
+	/bin/bash -c "ls -ltrh / && ls -ltrh /contracts && cd /contracts/ && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/contracts:rw \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "whoami ls -ltrh / && chmod -R 777 /contracts && ls -ltrh /contracts && cd /contracts/ && slither ./."
+	/bin/bash -c "whoami && ls -ltrh / && chmod -R 777 /contracts && ls -ltrh /contracts && cd /contracts/ && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "ls -ltrh / && chmod -R /contracts && ls -ltrh /contracts && cd /contracts && slither ./."
+	/bin/bash -c "ls -ltrh / && chmod -R +rw /contracts && ls -ltrh /contracts && cd /contracts && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/tmp/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "chown -R 1001:1001 /tmp/contracts && cd /tmp/contracts && slither ./."
+	/bin/bash -c "whoami && ls -ltrh /tmp && cd /tmp/contracts && slither ./."
 
 #################
 # markdown-lint #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -69,8 +69,9 @@ gosec:
 #################
 
 slither:
+	chmod -R o+rw ./contracts
 	docker run \
-	-t --user 1001:118 \
+	-t \
 	--platform linux/amd64 \
 	-v ./contracts:/contracts:rw \
 	trailofbits/eth-security-toolbox:edge \

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -74,7 +74,7 @@ slither:
 	--platform linux/amd64 \
 	-v ./contracts:/contracts \
 	trailofbits/eth-security-toolbox:edge \
-	/bin/bash -c "ls -ltrh / && chmod -R +rw /contracts && ls -ltrh /contracts && cd /contracts && slither ./."
+	/bin/bash -c "ls -ltrh / && chmod -R u+rw,g+rw,o+rw /contracts && ls -ltrh /contracts && cd /contracts && slither ./."
 
 #################
 # markdown-lint #


### PR DESCRIPTION
Fixes permission error in E2E testing related to [slither](https://github.com/berachain/beacon-kit/actions/runs/12298901005/job/34323402213). This occurs due to restrictions with the docker UID.
PR grants read+write perms to other users in the directory.