### PR TITLE
Fix inconsistent quoting in TOML template

### DIFF
--- a/config/template/template.go
+++ b/config/template/template.go
@@ -65,7 +65,7 @@ implementation = "{{.BeaconKit.KZG.Implementation}}"
 
 [beacon-kit.payload-builder]
 # Enabled determines if the local payload builder is enabled.
-enabled = {{ .BeaconKit.PayloadBuilder.Enabled }}
+enabled = "{{ .BeaconKit.PayloadBuilder.Enabled }}"
 
 # Post bellatrix, this address will receive the transaction fees produced by any blocks
 # from this node.


### PR DESCRIPTION
Summary
This PR addresses a minor inconsistency in the TOML template by ensuring all variables are consistently enclosed in quotes. Specifically, the enabled field under [beacon-kit.payload-builder] was previously unquoted, while other fields in the template followed a quoted format.

Changes
Updated the following line: ```toml enabled = {{ .BeaconKit.PayloadBuilder.Enabled }} to: enabled = "{{ .BeaconKit.PayloadBuilder.Enabled }}" Why This Change?
-Improves template consistency.
-Enhances readability for developers and users.
Impact
This is a non-breaking change and does not affect functionality. It solely improves template formatting.