### PR TITLE
fix: typos in documentation files

### DIFF
--- a/kurtosis/src/networks/kurtosis-devnet/README.md
+++ b/kurtosis/src/networks/kurtosis-devnet/README.md
@@ -1,4 +1,4 @@
 # kurtosis-devnet
 
-This contains all of the required files to spin up a `kurtosis-devnet`
+This contains all the required files to spin up a `kurtosis-devnet``
 on your local machine.

--- a/kurtosis/src/nodes/execution/execution.star
+++ b/kurtosis/src/nodes/execution/execution.star
@@ -37,7 +37,7 @@ def get_default_service_config(node_struct, node_module):
     # Check if the node_struct.el_image has erigon keyword in it
     # For otterscan, we need erigon RPC URL to connect to. By default, kurtosis assigns random public port to the service.
     # We need to assign a specific port to the service to connect to the RPC URL.
-    # Note : public port is not supported on kubenernetes
+    # Note : public port is not supported on kubernetes
     if "erigon" in node_struct.el_image:
         # Update common parameters with erigon-specific ones
         common_params["public_ports"] = {"eth-json-rpc": port_spec_lib.get_port_spec_template(PUBLIC_RPC_PORT_NUM, shared_utils.TCP_PROTOCOL)}

--- a/node-core/node/node.go
+++ b/node-core/node/node.go
@@ -83,7 +83,7 @@ func (n *node) Start(
 		return err
 	}
 
-	// Stopp each service allowing them the exit gracefully.
+	// Stop each service allowing them the exit gracefully.
 	if err = n.registry.StopAll(); err != nil {
 		return err
 	}

--- a/primitives/encoding/ssz/db/node.go
+++ b/primitives/encoding/ssz/db/node.go
@@ -27,7 +27,7 @@ import (
 
 // TODO: Figure out what the best way to do our DB types is?
 // Should this even be a DB package, should we just have a tree that
-// is completely decoupled fromt he DB?
+// is completely decoupled from the DB?
 // Putting this here for now just to make the deps nicely structured
 // but long term we need to figure out the play.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `kubenernetes` to `kubernetes`
Corrected `Stopp` to `Stop`
Corrected `fromt he` to `from the`

Please review the changes and let me know if any additional changes are needed.

