### PR TITLE
Fix invalid BLS key length error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/berachain/beacon-kit
 go 1.23.4
 
 replace (
-	github.com/cometbft/cometbft => github.com/cometbft/cometbft v1.0.1-0.20241218102856-585833e1cbc4
-	github.com/cometbft/cometbft/api => github.com/cometbft/cometbft/api v1.0.1-0.20241218102856-585833e1cbc4
+	github.com/cometbft/cometbft => github.com/cometbft/cometbft v1.0.1-0.20241219105415-e223c1220624
+	github.com/cometbft/cometbft/api => github.com/cometbft/cometbft/api v1.0.1-0.20241219105415-e223c1220624
 	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.52.0-rc.1
 
 	// The following are required to build with the latest version of the cosmos-sdk main branch:
@@ -48,6 +48,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
+	github.com/supranational/blst v0.3.13
 	github.com/umbracle/fastrlp v0.1.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/nilaway v0.0.0-20241010202415-ba14292918d8
@@ -417,7 +418,6 @@ require (
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/supranational/blst v0.3.13 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tdakkota/asciicheck v0.2.0 // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -239,12 +239,12 @@ github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwP
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
-github.com/cometbft/cometbft v1.0.1-0.20241218102856-585833e1cbc4 h1:Tbazu5VWROtyw7oKgcT1YAl4xQE23vPWuZepSNvaeXU=
-github.com/cometbft/cometbft v1.0.1-0.20241218102856-585833e1cbc4/go.mod h1:+hGB2I4vhCEwdceY35lf75XZZzMtm3VDOVt8hj7qkCs=
+github.com/cometbft/cometbft v1.0.1-0.20241219105415-e223c1220624 h1:kCxE9oU6j7/pDyi7jmvL91ZFqyA5xYCku+5wCtnmYoc=
+github.com/cometbft/cometbft v1.0.1-0.20241219105415-e223c1220624/go.mod h1:+hGB2I4vhCEwdceY35lf75XZZzMtm3VDOVt8hj7qkCs=
 github.com/cometbft/cometbft-db v1.0.1 h1:SylKuLseMLQKw3+i8y8KozZyJcQSL98qEe2CGMCGTYE=
 github.com/cometbft/cometbft-db v1.0.1/go.mod h1:EBrFs1GDRiTqrWXYi4v90Awf/gcdD5ExzdPbg4X8+mk=
-github.com/cometbft/cometbft/api v1.0.1-0.20241218102856-585833e1cbc4 h1:mtBmglh7gw/fFWFiSexyhjDknQEQYcMsIGrvkPQYEyo=
-github.com/cometbft/cometbft/api v1.0.1-0.20241218102856-585833e1cbc4/go.mod h1:EkQiqVSu/p2ebrZEnB2z6Re7r8XNe//M7ylR0qEwWm0=
+github.com/cometbft/cometbft/api v1.0.1-0.20241219105415-e223c1220624 h1:mBtsKJYa/JuvQjx81fdurEyteDWmkuKlsaHW1n+0Mek=
+github.com/cometbft/cometbft/api v1.0.1-0.20241219105415-e223c1220624/go.mod h1:EkQiqVSu/p2ebrZEnB2z6Re7r8XNe//M7ylR0qEwWm0=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.13.0 h1:VPULb/v6bbYELAPTDFINEVaMTTybV5GLxDdcjnS+4oc=


### PR DESCRIPTION
### Context
While `make start` duly compiled and ran` beacond`, there was an error when attaching an execution layer.  For example, running 1make start-reth` would return: 
```
Error: error during handshake: error on replay: encoding: invalid key length for bls12_381, got 48, want 96
```
This is an error returned by cometbft.

### Changes
This PR updates `go.mod` to use the latest cometbft version that addresses the above error. For details of the change in cometbft, see this PR https://github.com/cometbft/cometbft/pull/4692