### PR TITLE
Enable nilaway on CI and remove build tags from linters

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -63,6 +63,7 @@ jobs:
           - "lint"
           - "slither"
           - "gosec"
+          - "nilaway"
           - "markdownlint"
           - "generate-check"
           - "tidy-sync-check"

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
-	github.com/supranational/blst v0.3.13
 	github.com/umbracle/fastrlp v0.1.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/nilaway v0.0.0-20241010202415-ba14292918d8
@@ -418,6 +417,7 @@ require (
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/supranational/blst v0.3.13 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tdakkota/asciicheck v0.2.0 // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -15,14 +15,14 @@ lint: ## run all configured linters
 # TODO: Remove GODEBUG override once: https://github.com/golang/go/issues/68877 is resolved.
 golangci:
 	@echo "--> Running linter on all modules"
-	(GODEBUG=gotypesalias=0 go run github.com/golangci/golangci-lint/cmd/golangci-lint --build-tags bls12381 run --config $(ROOT_DIR)/.golangci.yaml --timeout=10m --concurrency 8) || exit 1;
+	(GODEBUG=gotypesalias=0 go run github.com/golangci/golangci-lint/cmd/golangci-lint run --config $(ROOT_DIR)/.golangci.yaml --timeout=10m --concurrency 8) || exit 1;
 	@printf "All modules complete\n"
 
 
 # TODO: Remove GODEBUG override once: https://github.com/golang/go/issues/68877 is resolved.
 golangci-fix:
 	@echo "--> Running linter with fixes on all modules"
-	(GODEBUG=gotypesalias=0 go run github.com/golangci/golangci-lint/cmd/golangci-lint --build-tags bls12381 run --config $(ROOT_DIR)/.golangci.yaml --timeout=10m --fix --concurrency 8) || exit 1;
+	(GODEBUG=gotypesalias=0 go run github.com/golangci/golangci-lint/cmd/golangci-lint run --config $(ROOT_DIR)/.golangci.yaml --timeout=10m --fix --concurrency 8) || exit 1;
 	@printf "All modules complete\n"
 
 #################
@@ -53,7 +53,7 @@ license-fix:
 
 nilaway:
 	@echo "--> Running nilaway"
-	(go run go.uber.org/nilaway/cmd/nilaway --tags bls12381 -exclude-errors-in-files "geth-primitives/deposit/" -v ./...) || exit 1;
+	(go run go.uber.org/nilaway/cmd/nilaway -exclude-errors-in-files "geth-primitives/deposit/" -v ./...) || exit 1;
 	@printf "Nilaway check complete\n"
 
 #################
@@ -62,7 +62,7 @@ nilaway:
 
 gosec:
 	@echo "--> Running gosec"
-	@go run github.com/cosmos/gosec/v2/cmd/gosec -tags bls12381 -exclude-dir node-core/components/signer  -exclude G702 ./...
+	@go run github.com/cosmos/gosec/v2/cmd/gosec -exclude G702 ./...
 
 #################
 #    slither    #

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -258,26 +258,26 @@ test:
 test-unit: ## run golang unit tests
 	@echo "Running unit tests..."
 	@go list -f '{{.Dir}}/...' -m | xargs \
-		go test --tags bls12381 -race
+		go test -race
 
 test-unit-cover: ## run golang unit tests with coverage
 	@echo "Running unit tests with coverage..."
 	@go list -f '{{.Dir}}/...' -m | xargs \
-		go test --tags bls12381 -race -coverprofile=test-unit-cover.txt
+		go test -race -coverprofile=test-unit-cover.txt
 
 test-unit-bench: ## run golang unit benchmarks
 	@echo "Running unit tests with benchmarks..."
 	@go list -f '{{.Dir}}/...' -m | xargs \
-		go test --tags bls12381 -bench=. -run=^$ -benchmem
+		go test -bench=. -run=^$ -benchmem
 
 # On MacOS, if there is a linking issue on the fuzz tests,
 # use the old linker with flags -ldflags=-extldflags=-Wl,-ld_classic
 test-unit-fuzz: ## run fuzz tests
 	@echo "Running fuzz tests with coverage..."
-	go test --tags bls12381 -run ^FuzzPayloadIDCacheBasic -fuzztime=${SHORT_FUZZ_TIME} github.com/berachain/beacon-kit/payload/cache
-	go test --tags bls12381 -run ^FuzzPayloadIDInvalidInput -fuzztime=${SHORT_FUZZ_TIME} github.com/berachain/beacon-kit/payload/cache
-	go test --tags bls12381 -run ^FuzzPayloadIDCacheConcurrency -fuzztime=${SHORT_FUZZ_TIME} github.com/berachain/beacon-kit/payload/cache
-	go test --tags bls12381 -run ^FuzzHashTreeRoot -fuzztime=${MEDIUM_FUZZ_TIME} github.com/berachain/beacon-kit/primitives/merkle
+	go test -run ^FuzzPayloadIDCacheBasic -fuzztime=${SHORT_FUZZ_TIME} github.com/berachain/beacon-kit/payload/cache
+	go test -run ^FuzzPayloadIDInvalidInput -fuzztime=${SHORT_FUZZ_TIME} github.com/berachain/beacon-kit/payload/cache
+	go test -run ^FuzzPayloadIDCacheConcurrency -fuzztime=${SHORT_FUZZ_TIME} github.com/berachain/beacon-kit/payload/cache
+	go test -run ^FuzzHashTreeRoot -fuzztime=${MEDIUM_FUZZ_TIME} github.com/berachain/beacon-kit/primitives/merkle
 
 test-e2e: ## run e2e tests
 	@$(MAKE) build-docker VERSION=kurtosis-local test-e2e-no-build


### PR DESCRIPTION
This enables nilaway which we had to disable yesterday due to it not supporting build tags. Now that https://github.com/berachain/beacon-kit/pull/2309 is merged which changes the method signature of  `NewPrivateKeyFromBytes` in `key_bls12381` to be inline with other implementations we can enable it again