### PR TITLE
fix: timeout_commit defaults to 0 in init

### DIFF
--- a/cli/commands/initialize/initialize.go
+++ b/cli/commands/initialize/initialize.go
@@ -102,7 +102,11 @@ func InitCmd(mm interface {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
 			config := client.GetConfigFromCmd(cmd)
-			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)
+			chainID, err := cmd.Flags().GetString(flags.FlagChainID)
+			if err != nil {
+				return errors.New("failed to parse FlagChainID")
+			}
+
 			switch {
 			case chainID != "":
 			case clientCtx.ChainID != "":
@@ -122,10 +126,14 @@ func InitCmd(mm interface {
 
 			// Get bip39 mnemonic
 			var mnemonic string
-			shouldRecover, _ := cmd.Flags().GetBool(FlagRecover)
+			shouldRecover, err := cmd.Flags().GetBool(FlagRecover)
+			if err != nil {
+				return errors.New("failed to parse FlagRecover")
+			}
 			if shouldRecover {
 				inBuf := bufio.NewReader(cmd.InOrStdin())
-				value, err := input.GetString("Enter your bip39 mnemonic", inBuf)
+				var value string
+				value, err = input.GetString("Enter your bip39 mnemonic", inBuf)
 				if err != nil {
 					return err
 				}
@@ -137,7 +145,10 @@ func InitCmd(mm interface {
 			}
 
 			// Get initial height
-			initHeight, _ := cmd.Flags().GetInt64(flags.FlagInitHeight)
+			initHeight, err := cmd.Flags().GetInt64(flags.FlagInitHeight)
+			if err != nil {
+				return errors.New("failed to parse FlagInitHeight")
+			}
 			if initHeight < 1 {
 				initHeight = 1
 			}
@@ -155,8 +166,14 @@ func InitCmd(mm interface {
 			config.Moniker = args[0]
 
 			genFile := config.GenesisFile()
-			overwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
-			defaultDenom, _ := cmd.Flags().GetString(FlagDefaultBondDenom)
+			overwrite, err := cmd.Flags().GetBool(FlagOverwrite)
+			if err != nil {
+				return errors.New("failed to parse FlagOverwrite")
+			}
+			defaultDenom, err := cmd.Flags().GetString(FlagDefaultBondDenom)
+			if err != nil {
+				return errors.New("failed to parse FlagDefaultBondDenom")
+			}
 
 			// use os.Stat to check if the file exists
 			_, err = os.Stat(genFile)

--- a/cli/commands/initialize/initialize.go
+++ b/cli/commands/initialize/initialize.go
@@ -18,6 +18,8 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
+// implementation taken from github.com/cosmos/cosmos-sdk/blob/main/x/genutil/client/cli/init.go
+// and modified to circumvent using default cometbft config which sets the timeout_commit to 0
 package initialize
 
 import (

--- a/cli/commands/initialize/initialize.go
+++ b/cli/commands/initialize/initialize.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2024, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package initialize
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/math/unsafe"
+	"github.com/berachain/beacon-kit/errors"
+	"github.com/berachain/beacon-kit/primitives/encoding/json"
+	cfg "github.com/cometbft/cometbft/config"
+	cmttypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/input"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	"github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/cosmos/go-bip39"
+	"github.com/spf13/cobra"
+)
+
+const (
+	// FlagOverwrite defines a flag to overwrite an existing genesis JSON file.
+	FlagOverwrite = "overwrite"
+
+	// FlagSeed defines a flag to initialize the private validator key from a specific seed.
+	FlagRecover = "recover"
+
+	// FlagDefaultBondDenom defines the default denom to use in the genesis file.
+	FlagDefaultBondDenom = "default-denom"
+
+	// FlagConsensusKeyAlgo defines the algorithm to use for the consensus signing key.
+	FlagConsensusKeyAlgo = "consensus-key-algo"
+)
+
+type printInfo struct {
+	Moniker    string          `json:"moniker" yaml:"moniker"`
+	ChainID    string          `json:"chain_id" yaml:"chain_id"`
+	NodeID     string          `json:"node_id" yaml:"node_id"`
+	GenTxsDir  string          `json:"gentxs_dir" yaml:"gentxs_dir"`
+	AppMessage json.RawMessage `json:"app_message" yaml:"app_message"`
+}
+
+func newPrintInfo(moniker, chainID, nodeID, genTxsDir string, appMessage json.RawMessage) printInfo {
+	return printInfo{
+		Moniker:    moniker,
+		ChainID:    chainID,
+		NodeID:     nodeID,
+		GenTxsDir:  genTxsDir,
+		AppMessage: appMessage,
+	}
+}
+
+func displayInfo(dst io.Writer, info printInfo) error {
+	out, err := json.MarshalIndent(info, "", " ")
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(dst, "%s\n", out)
+
+	return err
+}
+
+//nolint:funlen,gocognit,mnd // based on cosmossdk implementation
+func InitCmd(mm interface {
+	DefaultGenesis() map[string]json.RawMessage
+	ValidateGenesis(genesisData map[string]json.RawMessage) error
+}) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init <moniker>",
+		Short: "Initialize private validator, p2p, genesis, and application configuration files",
+		Long:  `Initialize validators's and node's configuration files.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+
+			config := client.GetConfigFromCmd(cmd)
+			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)
+			switch {
+			case chainID != "":
+			case clientCtx.ChainID != "":
+				chainID = clientCtx.ChainID
+			default:
+				chainID = fmt.Sprintf("test-chain-%v", unsafe.Str(6))
+			}
+			if config.RootDir == "" {
+				config.RootDir = clientCtx.HomeDir
+			}
+
+			// We should really cleanup how we generate the config, for example we should respect
+			// the defaults in builder.DefaultCometConfig instead  of the defaults from cometbft
+			if config.Consensus.TimeoutCommit == 0 {
+				config.Consensus.TimeoutCommit = 1000 * time.Millisecond
+			}
+
+			// Get bip39 mnemonic
+			var mnemonic string
+			shouldRecover, _ := cmd.Flags().GetBool(FlagRecover)
+			if shouldRecover {
+				inBuf := bufio.NewReader(cmd.InOrStdin())
+				value, err := input.GetString("Enter your bip39 mnemonic", inBuf)
+				if err != nil {
+					return err
+				}
+
+				mnemonic = value
+				if !bip39.IsMnemonicValid(mnemonic) {
+					return errors.New("invalid mnemonic")
+				}
+			}
+
+			// Get initial height
+			initHeight, _ := cmd.Flags().GetInt64(flags.FlagInitHeight)
+			if initHeight < 1 {
+				initHeight = 1
+			}
+
+			consensusKey, err := cmd.Flags().GetString(FlagConsensusKeyAlgo)
+			if err != nil {
+				return errorsmod.Wrap(err, "Failed to get consensus key algo")
+			}
+
+			nodeID, _, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic, consensusKey)
+			if err != nil {
+				return err
+			}
+
+			config.Moniker = args[0]
+
+			genFile := config.GenesisFile()
+			overwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
+			defaultDenom, _ := cmd.Flags().GetString(FlagDefaultBondDenom)
+
+			// use os.Stat to check if the file exists
+			_, err = os.Stat(genFile)
+			if !overwrite && !os.IsNotExist(err) {
+				return fmt.Errorf("genesis.json file already exists: %v", genFile)
+			}
+
+			// Overwrites the SDK default denom for side-effects
+			if defaultDenom != "" {
+				sdk.DefaultBondDenom = defaultDenom
+			}
+			appGenState := mm.DefaultGenesis()
+
+			appState, err := json.MarshalIndent(appGenState, "", " ")
+			if err != nil {
+				return errorsmod.Wrap(err, "Failed to marshal default genesis state")
+			}
+
+			appGenesis := &types.AppGenesis{}
+			if _, err = os.Stat(genFile); err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+			} else {
+				appGenesis, err = types.AppGenesisFromFile(genFile)
+				if err != nil {
+					return errorsmod.Wrap(err, "Failed to read genesis doc from file")
+				}
+			}
+
+			appGenesis.AppName = version.AppName
+			appGenesis.AppVersion = version.Version
+			appGenesis.ChainID = chainID
+			appGenesis.AppState = appState
+			appGenesis.InitialHeight = initHeight
+			appGenesis.Consensus = &types.ConsensusGenesis{
+				Validators: nil,
+				Params:     cmttypes.DefaultConsensusParams(),
+			}
+
+			appGenesis.Consensus.Params.Validator.PubKeyTypes = []string{consensusKey}
+
+			if err = genutil.ExportGenesisFile(appGenesis, genFile); err != nil {
+				return errorsmod.Wrap(err, "Failed to export genesis file")
+			}
+
+			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
+
+			cfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)
+			return displayInfo(cmd.ErrOrStderr(), toPrint)
+		},
+	}
+
+	cmd.Flags().BoolP(FlagOverwrite, "o", false, "overwrite the genesis.json file")
+	cmd.Flags().Bool(FlagRecover, false, "provide seed phrase to recover existing key instead of creating")
+	cmd.Flags().String(flags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
+	cmd.Flags().String(FlagDefaultBondDenom, "", "genesis file default denomination, if left blank default value is 'stake'")
+	cmd.Flags().Int64(flags.FlagInitHeight, 1, "specify the initial block height at genesis")
+	cmd.Flags().String(FlagConsensusKeyAlgo, "ed25519", "algorithm to use for the consensus key")
+
+	return cmd
+}

--- a/cli/commands/setup.go
+++ b/cli/commands/setup.go
@@ -24,6 +24,7 @@ import (
 	"github.com/berachain/beacon-kit/chain-spec/chain"
 	"github.com/berachain/beacon-kit/cli/commands/deposit"
 	"github.com/berachain/beacon-kit/cli/commands/genesis"
+	"github.com/berachain/beacon-kit/cli/commands/initialize"
 	"github.com/berachain/beacon-kit/cli/commands/jwt"
 	"github.com/berachain/beacon-kit/cli/commands/server"
 	servertypes "github.com/berachain/beacon-kit/cli/commands/server/types"
@@ -33,7 +34,6 @@ import (
 	"github.com/berachain/beacon-kit/log"
 	"github.com/berachain/beacon-kit/node-core/types"
 	"github.com/cosmos/cosmos-sdk/version"
-	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 )
 
 // DefaultRootCommandSetup sets up the default commands for the root command.
@@ -51,7 +51,7 @@ func DefaultRootCommandSetup[
 		// `comet`
 		cmtcli.Commands(appCreator),
 		// `init`
-		genutilcli.InitCmd(mm),
+		initialize.InitCmd(mm),
 		// `genesis`
 		genesis.Commands(chainSpec),
 		// `deposit`

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,9 @@ require (
 	cosmossdk.io/collections v1.0.0-rc.1
 	cosmossdk.io/core v1.0.0-alpha.6
 	cosmossdk.io/depinject v1.1.0
+	cosmossdk.io/errors v1.0.1
 	cosmossdk.io/log v1.5.0
+	cosmossdk.io/math v1.4.0
 	cosmossdk.io/store v1.10.0-rc.1.0.20241218084712-ca559989da43
 	github.com/bazelbuild/buildtools v0.0.0-20241129155226-a0444eb13952
 	github.com/bufbuild/buf v1.47.2
@@ -23,6 +25,7 @@ require (
 	github.com/cometbft/cometbft/api v1.0.1-0.20241220100824-07c737de00ff
 	github.com/cosmos/cosmos-db v1.1.0
 	github.com/cosmos/cosmos-sdk v0.53.0
+	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gosec/v2 v2.0.0-20230124142343-bf28a33fadf2
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -86,8 +89,6 @@ require (
 	connectrpc.com/otelconnect v0.7.1 // indirect
 	cosmossdk.io/api v0.8.0-rc.3 // indirect
 	cosmossdk.io/core/testing v0.0.1 // indirect
-	cosmossdk.io/errors v1.0.1 // indirect
-	cosmossdk.io/math v1.4.0 // indirect
 	cosmossdk.io/schema v1.0.0 // indirect
 	cosmossdk.io/x/bank v0.0.0-20241218110910-47409028a73d // indirect
 	cosmossdk.io/x/staking v0.0.0-20241218110910-47409028a73d // indirect
@@ -166,7 +167,6 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5 // indirect
-	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/gogoproto v1.7.0 // indirect
 	github.com/cosmos/iavl v1.3.4 // indirect


### PR DESCRIPTION
Now that we have upgraded `cosmossdk`/`cometbft` dependencies it becomes clear that we should improve the way we generate our config files.

In newest `cometbft` version it set the default `timeout_commit` to 0 seconds instead of 1s it was before which which causes us to produce blocks every 30-50us.

To address this quickly I implemented the `InitCmd` in our repo instead of using its implementation in `cosmossdk`. Its almost the same except I check if `timeout_commit` is 0 and if so set it to 1000ms. It would be better to read the config from file but it seems it has special encoding by viper so not easy to unmarshal (I may post an update or new PR as a followup)

But we should definitely fix the underlying issue of not using proper defaults specific to our application.