### PR TITLE
Fix typos and spelling errors

### DIFF
--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -55,7 +55,7 @@ func (s *Service[_]) BuildBlockAndSidecars(
 
 	// The goal here is to acquire a payload whose parent is the previously
 	// finalized block, such that, if this payload is accepted, it will be
-	// the next finalized block in the chain. A byproduct of this design
+	// the next finalized block in the chain. A by-product of this design
 	// is that we get the nice property of lazily propagating the finalized
 	// and safe block hashes to the execution client.
 	st := s.sb.StateFromContext(ctx)

--- a/chain-spec/chain/data.go
+++ b/chain-spec/chain/data.go
@@ -66,7 +66,7 @@ type SpecData[
 
 	// Signature domains.
 	//
-	// DomainDomainTypeProposerProposer is the domain for beacon proposer
+	// DomainTypeProposer is the domain for beacon proposer
 	// signatures.
 	DomainTypeProposer DomainTypeT `mapstructure:"domain-type-beacon-proposer"`
 	// DomainTypeAttester is the domain for beacon attester signatures.

--- a/cmd/beacond/defaults.go
+++ b/cmd/beacond/defaults.go
@@ -27,7 +27,7 @@ import (
 func DefaultComponents() []any {
 	c := []any{
 		components.ProvideAttributesFactory[*Logger],
-		components.ProvideAvailibilityStore[*Logger],
+		components.ProvideAvailabilityStore[*Logger],
 		components.ProvideDepositContract,
 		components.ProvideBlockStore[*Logger],
 		components.ProvideBlsSigner,


### PR DESCRIPTION
This pull request fixes the following errors in the documentation:

"byproduct" -> "by-product"
"DomainDomainTypeProposerProposer" -> "DomainTypeProposer"
"ProvideAvailibilityStore" -> "ProvideAvailabilityStore"
Thank you for your work, and I hope my pull request proves useful!