### PR TITLE
fix(blockchain): bugfix failing inclusion proofs and add test case

### DIFF
--- a/consensus-types/types/body.go
+++ b/consensus-types/types/body.go
@@ -28,6 +28,7 @@ package types
 import (
 	"github.com/berachain/beacon-kit/chain-spec/chain"
 	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/constants"
 	"github.com/berachain/beacon-kit/primitives/crypto"
 	"github.com/berachain/beacon-kit/primitives/eip4844"
 	"github.com/berachain/beacon-kit/primitives/math"
@@ -106,7 +107,7 @@ func KZGCommitmentInclusionProofDepth(
 	switch cs.ActiveForkVersionForSlot(slot) {
 	case version.Deneb:
 		sum := uint64(log.ILog2Floor(uint64(KZGMerkleIndexDeneb))) +
-			uint64(log.ILog2Ceil(cs.MaxBlobCommitmentsPerBlock())) + 1
+			uint64(log.ILog2Ceil(cs.MaxBlobCommitmentsPerBlock()))
 		if sum > maxUint8 {
 			return 0, ErrInclusionProofDepthExceeded
 		}
@@ -159,12 +160,12 @@ func (b *BeaconBlockBody) DefineSSZ(codec *ssz.Codec) {
 	ssz.DefineStaticBytes(codec, &b.RandaoReveal)
 	ssz.DefineStaticObject(codec, &b.Eth1Data)
 	ssz.DefineStaticBytes(codec, &b.Graffiti)
-	ssz.DefineSliceOfStaticObjectsOffset(codec, &b.Deposits, 16)
+	ssz.DefineSliceOfStaticObjectsOffset(codec, &b.Deposits, constants.MaxDeposits)
 	ssz.DefineDynamicObjectOffset(codec, &b.ExecutionPayload)
 	ssz.DefineSliceOfStaticBytesOffset(codec, &b.BlobKzgCommitments, 16)
 
 	// Define the dynamic data (fields)
-	ssz.DefineSliceOfStaticObjectsContent(codec, &b.Deposits, 16)
+	ssz.DefineSliceOfStaticObjectsContent(codec, &b.Deposits, constants.MaxDeposits)
 	ssz.DefineDynamicObjectContent(codec, &b.ExecutionPayload)
 	ssz.DefineSliceOfStaticBytesContent(codec, &b.BlobKzgCommitments, 16)
 }


### PR DESCRIPTION
There was a discrepancy in the `HashTreeRoot()` of `Deposits` when calculated by the `BeaconBlockBody.HashTreeRoot()` vs when independently computed via `Deposits.HashTreeRoot()`. This discrepancy arose because the `BeaconBlockBody` defines the SSZ serialization of `Deposits` separately from the actual `Deposits`:
- `BeaconBlockBody.Deposits` SSZ defined at [consensus-types/types/body.go#L162](https://github.com/berachain/beacon-kit/blob/1e1a86965f542bc9cab8af5064aac6e1913ab900/consensus-types/types/body.go#L162)
- `Deposits` SSZ defined at [consensus-types/types/deposits.go#L44](https://github.com/berachain/beacon-kit/blob/1e1a86965f542bc9cab8af5064aac6e1913ab900/consensus-types/types/deposits.go#L44)

The `maxItems` for `Deposits` was updated in one spot without getting updated in the other. This led to a discrepancy in the merkle tree proofs, resulting in the inclusion proof mismatch.

This PR fixes that issue and adds a unit test that validates that inclusion proofs work.