### PR TITLE
Fix Typos

### DIFF
--- a/kurtosis/src/nodes/execution/execution.star
+++ b/kurtosis/src/nodes/execution/execution.star
@@ -37,7 +37,7 @@ def get_default_service_config(node_struct, node_module):
     # Check if the node_struct.el_image has erigon keyword in it
     # For otterscan, we need erigon RPC URL to connect to. By default, kurtosis assigns random public port to the service.
     # We need to assign a specific port to the service to connect to the RPC URL.
-    # Note : public port is not supported on kubenernetes
+    # Note : public port is not supported on kubernetes
     if "erigon" in node_struct.el_image:
         # Update common parameters with erigon-specific ones
         common_params["public_ports"] = {"eth-json-rpc": port_spec_lib.get_port_spec_template(PUBLIC_RPC_PORT_NUM, shared_utils.TCP_PROTOCOL)}

--- a/node-core/node/node.go
+++ b/node-core/node/node.go
@@ -83,7 +83,7 @@ func (n *node) Start(
 		return err
 	}
 
-	// Stopp each service allowing them the exit gracefully.
+	// Stop each service allowing them the exit gracefully.
 	if err = n.registry.StopAll(); err != nil {
 		return err
 	}


### PR DESCRIPTION
# Pull Request: Fix Typos

## Description
This pull request fixes minor typos in the following files:
- **`kurtosis/src/nodes/execution/execution.star`**: Corrected "kubenernetes" to "kubernetes".
- **`node-core/node/node.go`**: Corrected "Stopp" to "Stop".

These changes ensure better readability and maintain the quality of the documentation and comments.

## Changes
- **File:** `execution.star`
  - Original: `# Note : public port is not supported on kubenernetes`
  - Updated: `# Note : public port is not supported on kubernetes`
- **File:** `node.go`
  - Original: `// Stopp each service allowing them the exit gracefully.`
  - Updated: `// Stop each service allowing them the exit gracefully.`

## Motivation and Context
The corrections address typographical errors that could lead to confusion for contributors and users working with the codebase.

## Checklist
- [x] I have reviewed the changes to ensure correctness.
- [x] I have updated documentation/comments where applicable.
- [x] My changes do not introduce new warnings or errors.

## Notes
- No functional changes were made; this pull request is limited to comment and documentation updates.
- Edits were verified for accuracy and relevance.

Thank you for reviewing this pull request. Feedback and suggestions are always welcome!
