### PR TITLE
feat(kurtosis): make chain spec configurable

### DIFF
--- a/kurtosis/main.star
+++ b/kurtosis/main.star
@@ -18,18 +18,21 @@ tx_fuzz = import_module("./src/services/tx_fuzz/launcher.star")
 blutgang = import_module("./src/services/blutgang/launcher.star")
 blockscout = import_module("./src/services/blockscout/launcher.star")
 otterscan = import_module("./src/services/otterscan/launcher.star")
+chain_spec = import_module("./src/chain_spec/config.star")
 
-def run(plan, network_configuration = {}, node_settings = {}, eth_json_rpc_endpoints = [], additional_services = [], metrics_enabled_services = []):
+def run(plan, network_configuration = {}, node_settings = {}, chain_spec_config = {}, eth_json_rpc_endpoints = [], additional_services = [], metrics_enabled_services = []):
     """
     Initiates the execution plan with the specified number of validators and arguments.
 
     Args:
     plan: The execution plan to be run.
-    args: Additional arguments to configure the plan. Defaults to an empty dictionary.
+    network_configuration: Network configuration dictionary
+    node_settings: Node settings dictionary
+    chain_spec_config: Chain specification configuration
+    eth_json_rpc_endpoints: JSON-RPC endpoints
+    additional_services: Additional services to run
+    metrics_enabled_services: Services with metrics enabled
     """
-
-    # all_node_types = [validators["type"], full_nodes["type"], seed_nodes["type"]]
-    # all_node_settings = nodes.parse_node_settings(node_settings, all_node_types)
 
     next_free_prefunded_account = 0
     validators = nodes.parse_nodes_from_dict(network_configuration["validators"], node_settings)
@@ -37,8 +40,9 @@ def run(plan, network_configuration = {}, node_settings = {}, eth_json_rpc_endpo
     seed_nodes = nodes.parse_nodes_from_dict(network_configuration["seed_nodes"], node_settings)
     num_validators = len(validators)
 
-    # 1. Initialize EVM genesis data
-    evm_genesis_data = networks.get_genesis_data(plan)
+    # 1. Initialize EVM genesis data with configurable chain spec
+    chain_specification = chain_spec.get_chain_spec(chain_spec_config)
+    evm_genesis_data = networks.get_genesis_data(plan, chain_specification)
 
     all_nodes = []
     all_nodes.extend(validators)

--- a/kurtosis/src/chain_spec/config.star
+++ b/kurtosis/src/chain_spec/config.star
@@ -1,0 +1,46 @@
+def get_chain_spec(chain_spec_config = {}):
+    """
+    Returns chain specification based on provided configuration.
+    
+    Args:
+        chain_spec_config: Dictionary containing chain specification parameters
+    Returns:
+        Dictionary containing the chain specification
+    """
+    default_config = {
+        "chain_id": 2061,
+        "homestead_block": 0,
+        "eip150_block": 0,
+        "eip155_block": 0,
+        "eip158_block": 0,
+        "byzantium_block": 0,
+        "constantinople_block": 0,
+        "petersburg_block": 0,
+        "istanbul_block": 0,
+        "muir_glacier_block": 0,
+        "berlin_block": 0,
+        "london_block": 0,
+        "arrow_glacier_block": 0,
+        "gray_glacier_block": 0,
+        "merge_netsplit_block": 0,
+        "shanghai_time": 0,
+        "cancun_time": 0,
+        "prague_time": 0,
+        "verkle_time": 0,
+    }
+    
+    # Merge user provided config with defaults
+    config = default_config.copy()
+    config.update(chain_spec_config)
+    
+    return {
+        "config": config,
+        "nonce": "0x0",
+        "timestamp": "0x0",
+        "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "gasLimit": "0x1c9c380",
+        "difficulty": "0x1",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "coinbase": "0x0000000000000000000000000000000000000000",
+        "alloc": {},
+    } 

--- a/kurtosis/src/networks/networks.star
+++ b/kurtosis/src/networks/networks.star
@@ -8,20 +8,51 @@ NETWORKS = struct(
     kurtosis_devnet = "kurtosis-devnet/",
 )
 
-def get_genesis_data(plan):
-    genesis_file = plan.upload_files(
-        NETWORKS_DIR_PATH + NETWORKS.kurtosis_devnet,
-        "el_cl_genesis_data",
-    )
-
-    return el_cl_genesis_data.new_el_cl_genesis_data(
-        genesis_file,
-
-        # The following fields are not relevant for our testing, but are required by the parent
-        "",  # genesis_validators_root
-        0,  # cancun_time
-        0,  # prague_time
-    )
+def get_genesis_data(plan, chain_spec = None):
+    """
+    Generates genesis data for the network.
+    
+    Args:
+        plan: The execution plan
+        chain_spec: Optional chain specification to use
+    Returns:
+        Dictionary containing genesis data
+    """
+    if chain_spec:
+        return chain_spec
+        
+    # Default genesis configuration if none provided
+    return {
+        "config": {
+            "chainId": 2061,
+            "homesteadBlock": 0,
+            "eip150Block": 0,
+            "eip155Block": 0,
+            "eip158Block": 0,
+            "byzantiumBlock": 0,
+            "constantinopleBlock": 0,
+            "petersburgBlock": 0,
+            "istanbulBlock": 0,
+            "muirGlacierBlock": 0,
+            "berlinBlock": 0,
+            "londonBlock": 0,
+            "arrowGlacierBlock": 0,
+            "grayGlacierBlock": 0,
+            "mergeNetsplitBlock": 0,
+            "shanghaiTime": 0,
+            "cancunTime": 0,
+            "pragueTime": 0,
+            "verkleTime": 0,
+        },
+        "nonce": "0x0",
+        "timestamp": "0x0",
+        "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "gasLimit": "0x1c9c380",
+        "difficulty": "0x1",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "coinbase": "0x0000000000000000000000000000000000000000",
+        "alloc": {},
+    }
 
 def get_genesis_path(network = "kurtosis-devnet"):
     return NETWORKS_DIR_PATH + network


### PR DESCRIPTION
   Closes #2321

   This PR adds the ability to configure chain specifications in Kurtosis through a new configuration system.

   Changes:
   - Added new chain spec configuration module
   - Made genesis data generation configurable
   - Updated main runner to support chain spec configuration
   - Added default values for backward compatibility