### PR TITLE
chore(docs) incorrect usage of `slices.Collect` function

### DIFF
--- a/beacon/blockchain/deposit.go
+++ b/beacon/blockchain/deposit.go
@@ -102,7 +102,7 @@ func (s *Service[
 			return
 		case <-ticker.C:
 			s.failedBlocksMu.RLock()
-			failedBlks := slices.Collect(maps.Keys(s.failedBlocks))
+			failedBlks := maps.Keys(s.failedBlocks)
 			s.failedBlocksMu.RUnlock()
 			if len(failedBlks) == 0 {
 				continue


### PR DESCRIPTION
The `maps.Keys` function returns a slice of the map's keys, so the additional call to `slices.Collect` is redundant and will result in a compilation error: `undefined: slices.Collect`. To obtain the list of keys, it is sufficient to use only `maps.Keys.`