### PR TITLE
Fix incorrect method call on a nil pointer

### DIFF
--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -168,7 +168,7 @@ func (s *Service[_]) getEmptyBeaconBlockForSlot(
 		return blk, err
 	}
 
-	return blk.NewWithVersion(
+	return ctypes.NewBeaconBlockWithVersion(
 		requestedSlot,
 		proposerIndex,
 		parentBlockRoot,


### PR DESCRIPTION
In line 171, the `NewWithVersion` method is called on the variable `blk`, which is declared as a pointer to `ctypes.BeaconBlock` and initially set to nil `(var blk *ctypes.BeaconBlock)`. Attempting to call a method on a `nil `pointer will cause a runtime panic.

***The program will crash when attempting to call a method on a nil pointer, which will disrupt the functionality of the entire system.***