### PR TITLE
Fix Typo in `README.md`

### DIFF
--- a/state-transition/core/README.md
+++ b/state-transition/core/README.md
@@ -33,7 +33,7 @@ So let's assumed that `S`, epoch `N`, is the slot where finally the validator `B
 
 - The validator is marked as `EligibleForActivationQueue` as soon as epoch `N+1` starts. This is guaranteed since there is no cap on the activation queue size.
 - The validator is marked as active as soon as epoch `N+2` starts. However
-  - if the size of validator set goes beyond the `ValidatorSetCap` enough validators with the lowest stake are marked for eviction, to make the cap be fullfilled. Validators are sorted by increasing `EffectiveBalance` and ties are broken ordering their pub keys alphabetically.
+  - if the size of validator set goes beyond the `ValidatorSetCap` enough validators with the lowest stake are marked for eviction, to make the cap be fulfilled. Validators are sorted by increasing `EffectiveBalance` and ties are broken ordering their pub keys alphabetically.
 - BeaconKit does not currently support voluntary withdrawals, nor slashing or inactivity leaks. Therefore a validator keeps validating indefinitely.
   - The only case in which a validator may be evicted from the validator set (and its funds returned) is when `ValidatorSetCap` is hit and a validator with greater priority is added (i.e. with larger `EffectiveBalance` or equal `EffectiveBalance` and larger PubKey in alphabetical order).
 - Once a validator is marked as active, `CometBFT` consensus will reach it out for block proposals, validations and voting. The higher a validator `EffectiveBalance`, the higher its voting power the frequency it is polled for block proposal.


### PR DESCRIPTION
# Fix Typo in `README.md`

## Description
This pull request resolves a typo in the `README.md` file within the `state-transition/core` directory.  
- Corrected the spelling of "fullfilled" to "fulfilled" in the explanation of the validator eviction process.

### Changes Made:
- **File Modified:** `state-transition/core/README.md`
- **Summary of Changes:**
  - Line 33: Corrected "fullfilled" to "fulfilled."

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] Code comments updated for clarity and professionalism.
- [x] Verified adherence to the project's [GitHub Community Guidelines](link-to-guidelines).

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment typo fix only)

## Additional Notes
This update is a non-functional change and is strictly related to improving the clarity and accuracy of the documentation.

---

**Allow edits by maintainers:** [x]  
<!-- Check this box to allow maintainers to modify the pull requ
