### PR TITLE
chore(boonet): min stake upgrade on boonet fork 4

### DIFF
--- a/chain-spec/chain/chain_spec.go
+++ b/chain-spec/chain/chain_spec.go
@@ -39,7 +39,7 @@ type Spec[
 	MaxEffectiveBalance(isPostUpgrade bool) uint64
 
 	// EjectionBalance returns the balance below which a validator is ejected.
-	EjectionBalance() uint64
+	EjectionBalance(isPostUpgrade bool) uint64
 
 	// EffectiveBalanceIncrement returns the increment of balance used in reward
 	// calculations.
@@ -285,8 +285,12 @@ func (c chainSpec[
 // EjectionBalance returns the balance below which a validator is ejected.
 func (c chainSpec[
 	DomainTypeT, EpochT, ExecutionAddressT, SlotT, CometBFTConfigT,
-]) EjectionBalance() uint64 {
-	return c.Data.EjectionBalance
+]) EjectionBalance(isPostUpgrade bool) uint64 {
+	if isPostUpgrade {
+		return c.Data.EjectionBalancePostUpgrade
+	}
+
+	return c.Data.EjectionBalancePreUpgrade
 }
 
 // EffectiveBalanceIncrement returns the increment of effective balance.

--- a/chain-spec/chain/chain_spec.go
+++ b/chain-spec/chain/chain_spec.go
@@ -43,7 +43,7 @@ type Spec[
 
 	// EffectiveBalanceIncrement returns the increment of balance used in reward
 	// calculations.
-	EffectiveBalanceIncrement() uint64
+	EffectiveBalanceIncrement(isPostUpgrade bool) uint64
 
 	// HysteresisQuotient returns the quotient used in effective balance
 	// calculations to create hysteresis. This provides resistance to small
@@ -296,8 +296,12 @@ func (c chainSpec[
 // EffectiveBalanceIncrement returns the increment of effective balance.
 func (c chainSpec[
 	DomainTypeT, EpochT, ExecutionAddressT, SlotT, CometBFTConfigT,
-]) EffectiveBalanceIncrement() uint64 {
-	return c.Data.EffectiveBalanceIncrement
+]) EffectiveBalanceIncrement(isPostUpgrade bool) uint64 {
+	if isPostUpgrade {
+		return c.Data.EffectiveBalanceIncrementPostUpgrade
+	}
+
+	return c.Data.EffectiveBalanceIncrementPreUpgrade
 }
 
 func (c chainSpec[

--- a/chain-spec/chain/data.go
+++ b/chain-spec/chain/data.go
@@ -45,8 +45,12 @@ type SpecData[
 	// EjectionBalancePostUpgrade is the balance at which a validator is ejected
 	// after the upgrade.
 	EjectionBalancePostUpgrade uint64 `mapstructure:"ejection-balance-post-upgrade"`
-	// EffectiveBalanceIncrement is the effective balance increment.
-	EffectiveBalanceIncrement uint64 `mapstructure:"effective-balance-increment"`
+	// EffectiveBalanceIncrementPreUpgrade is the effective balance increment
+	// before the upgrade.
+	EffectiveBalanceIncrementPreUpgrade uint64 `mapstructure:"effective-balance-increment-pre-upgrade"`
+	// EffectiveBalanceIncrementPostUpgrade is the effective balance increment
+	// after the upgrade.
+	EffectiveBalanceIncrementPostUpgrade uint64 `mapstructure:"effective-balance-increment-post-upgrade"`
 
 	// HysteresisQuotient is the quotient used in effective balance calculations
 	HysteresisQuotient uint64 `mapstructure:"hysteresis-quotient"`

--- a/chain-spec/chain/data.go
+++ b/chain-spec/chain/data.go
@@ -39,8 +39,12 @@ type SpecData[
 	// MaxEffectiveBalancePostUpgrade is the maximum effective balance allowed
 	// for a validator after the upgrade.
 	MaxEffectiveBalancePostUpgrade uint64 `mapstructure:"max-effective-balance-post-upgrade"`
-	// EjectionBalance is the balance at which a validator is ejected.
-	EjectionBalance uint64 `mapstructure:"ejection-balance"`
+	// EjectionBalancePreUpgrade is the balance at which a validator is ejected
+	// before the upgrade.
+	EjectionBalancePreUpgrade uint64 `mapstructure:"ejection-balance-pre-upgrade"`
+	// EjectionBalancePostUpgrade is the balance at which a validator is ejected
+	// after the upgrade.
+	EjectionBalancePostUpgrade uint64 `mapstructure:"ejection-balance-post-upgrade"`
 	// EffectiveBalanceIncrement is the effective balance increment.
 	EffectiveBalanceIncrement uint64 `mapstructure:"effective-balance-increment"`
 

--- a/cli/commands/genesis/root.go
+++ b/cli/commands/genesis/root.go
@@ -75,7 +75,7 @@ func GetGenesisValidatorRootCmd(cs common.ChainSpec) *cobra.Command {
 					deposit.Pubkey,
 					types.WithdrawalCredentials(deposit.Credentials),
 					deposit.Amount,
-					math.Gwei(cs.EffectiveBalanceIncrement()),
+					math.Gwei(cs.EffectiveBalanceIncrement(false)),
 					math.Gwei(cs.MaxEffectiveBalance(false)),
 				)
 			}

--- a/config/spec/base.go
+++ b/config/spec/base.go
@@ -58,7 +58,8 @@ func BaseSpec() chain.SpecData[
 		MinDepositAmount:               1e9,
 		MaxEffectiveBalancePreUpgrade:  32e9,
 		MaxEffectiveBalancePostUpgrade: 32e9,
-		EjectionBalance:                16e9,
+		EjectionBalancePreUpgrade:      16e9,
+		EjectionBalancePostUpgrade:     16e9,
 		EffectiveBalanceIncrement:      1e9,
 
 		HysteresisQuotient:           4,

--- a/config/spec/base.go
+++ b/config/spec/base.go
@@ -55,12 +55,13 @@ func BaseSpec() chain.SpecData[
 		any,
 	]{
 		// Gwei value constants.
-		MinDepositAmount:               1e9,
-		MaxEffectiveBalancePreUpgrade:  32e9,
-		MaxEffectiveBalancePostUpgrade: 32e9,
-		EjectionBalancePreUpgrade:      16e9,
-		EjectionBalancePostUpgrade:     16e9,
-		EffectiveBalanceIncrement:      1e9,
+		MinDepositAmount:                     1e9,
+		MaxEffectiveBalancePreUpgrade:        32e9,
+		MaxEffectiveBalancePostUpgrade:       32e9,
+		EjectionBalancePreUpgrade:            16e9,
+		EjectionBalancePostUpgrade:           16e9,
+		EffectiveBalanceIncrementPreUpgrade:  1e9,
+		EffectiveBalanceIncrementPostUpgrade: 1e9,
 
 		HysteresisQuotient:           4,
 		HysteresisDownwardMultiplier: 1,

--- a/config/spec/boonet.go
+++ b/config/spec/boonet.go
@@ -52,19 +52,24 @@ func BoonetChainSpec() (chain.Spec[
 
 	// MaxValidatorsPerWithdrawalsSweep is 43 because we expect at least 46
 	// validators in the total validators set. We choose a prime number smaller
-	// than the minimum amount of total validators possible.
+	// than the minimum amount of total validators possible. Effective post boonet
+	// fork 2.
 	boonetSpec.MaxValidatorsPerWithdrawalsSweepPostUpgrade = 43
 
-	// MaxEffectiveBalancePostUpgrade is 5 million BERA after the boonet
-	// upgrade.
+	// MaxEffectiveBalancePostUpgrade is 5 million BERA after boonet fork 3.
 	//
 	//nolint:mnd // ok.
 	boonetSpec.MaxEffectiveBalancePostUpgrade = 5_000_000 * 1e9
 
-	// Ejection balance is 250 thousand BERA after the boonet upgrade.
+	// Ejection balance is 250 thousand BERA after boonet fork 4.
 	//
 	//nolint:mnd // ok.
 	boonetSpec.EjectionBalancePostUpgrade = 250_000 * 1e9
+
+	// Effective balance increment is 10 thousand BERA after boonet fork 4.
+	//
+	//nolint:mnd // ok.
+	boonetSpec.EffectiveBalanceIncrementPostUpgrade = 10_000 * 1e9
 
 	return chain.NewChainSpec(boonetSpec)
 }

--- a/config/spec/boonet.go
+++ b/config/spec/boonet.go
@@ -52,7 +52,8 @@ func BoonetChainSpec() (chain.Spec[
 
 	// MaxValidatorsPerWithdrawalsSweep is 43 because we expect at least 46
 	// validators in the total validators set. We choose a prime number smaller
-	// than the minimum amount of total validators possible. Effective post boonet
+	// than the minimum amount of total validators possible. Effective post
+	// boonet
 	// fork 2.
 	boonetSpec.MaxValidatorsPerWithdrawalsSweepPostUpgrade = 43
 

--- a/config/spec/boonet.go
+++ b/config/spec/boonet.go
@@ -61,5 +61,10 @@ func BoonetChainSpec() (chain.Spec[
 	//nolint:mnd // ok.
 	boonetSpec.MaxEffectiveBalancePostUpgrade = 5_000_000 * 1e9
 
+	// Ejection balance is 250 thousand BERA after the boonet upgrade.
+	//
+	//nolint:mnd // ok.
+	boonetSpec.EjectionBalancePostUpgrade = 250_000 * 1e9
+
 	return chain.NewChainSpec(boonetSpec)
 }

--- a/config/spec/special_cases.go
+++ b/config/spec/special_cases.go
@@ -35,4 +35,6 @@ const (
 	BoonetFork2Height uint64 = 1722000
 
 	BoonetFork3Height uint64 = 2230000
+
+	BoonetFork4Height uint64 = 3982000
 )

--- a/state-transition/core/state/upgrade.go
+++ b/state-transition/core/state/upgrade.go
@@ -25,9 +25,9 @@ import (
 	"github.com/berachain/beacon-kit/primitives/math"
 )
 
-// IsPostFork2 returns true if the chain is post-upgrade (Fork2 on Boonet).
-//
 // TODO: Jank. Refactor into better fork version management.
+
+// IsPostFork2 returns true if the chain is post-upgrade (Fork2 on Boonet).
 func IsPostFork2(chainID uint64, slot math.Slot) bool {
 	switch chainID {
 	case spec.BartioChainID:
@@ -44,14 +44,28 @@ func IsPostFork2(chainID uint64, slot math.Slot) bool {
 }
 
 // IsPostFork3 returns true if the chain is post-upgrade (Fork3 on Boonet).
-//
-// TODO: Jank. Refactor into better fork version management.
 func IsPostFork3(chainID uint64, slot math.Slot) bool {
 	switch chainID {
 	case spec.BartioChainID:
 		return false
 	case spec.BoonetEth1ChainID:
 		if slot < math.U64(spec.BoonetFork3Height) {
+			return false
+		}
+
+		return true
+	default:
+		return true
+	}
+}
+
+// IsPostFork4 returns true if the chain is post-upgrade (Fork4 on Boonet).
+func IsPostFork4(chainID uint64, slot math.Slot) bool {
+	switch chainID {
+	case spec.BartioChainID:
+		return false
+	case spec.BoonetEth1ChainID:
+		if slot < math.U64(spec.BoonetFork4Height) {
 			return false
 		}
 

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -489,7 +489,8 @@ func (sp *StateProcessor[
 	}
 
 	var (
-		hysteresisIncrement = sp.cs.EffectiveBalanceIncrement() / sp.cs.HysteresisQuotient()
+		isPostFork4         = state.IsPostFork4(sp.cs.DepositEth1ChainID(), slot)
+		hysteresisIncrement = sp.cs.EffectiveBalanceIncrement(isPostFork4) / sp.cs.HysteresisQuotient()
 		downwardThreshold   = math.Gwei(
 			hysteresisIncrement * sp.cs.HysteresisDownwardMultiplier(),
 		)
@@ -516,7 +517,7 @@ func (sp *StateProcessor[
 			val.GetEffectiveBalance()+upwardThreshold < balance {
 			updatedBalance := ctypes.ComputeEffectiveBalance(
 				balance,
-				math.U64(sp.cs.EffectiveBalanceIncrement()),
+				math.U64(sp.cs.EffectiveBalanceIncrement(isPostFork4)),
 				math.U64(sp.cs.MaxEffectiveBalance(
 					state.IsPostFork3(sp.cs.DepositEth1ChainID(), slot),
 				)),

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -489,9 +489,14 @@ func (sp *StateProcessor[
 	}
 
 	var (
-		isPostFork4         = state.IsPostFork4(sp.cs.DepositEth1ChainID(), slot)
-		hysteresisIncrement = sp.cs.EffectiveBalanceIncrement(isPostFork4) / sp.cs.HysteresisQuotient()
-		downwardThreshold   = math.Gwei(
+		isPostFork4 = state.IsPostFork4(
+			sp.cs.DepositEth1ChainID(),
+			slot,
+		)
+		hysteresisIncrement = sp.cs.EffectiveBalanceIncrement(
+			isPostFork4,
+		) / sp.cs.HysteresisQuotient()
+		downwardThreshold = math.Gwei(
 			hysteresisIncrement * sp.cs.HysteresisDownwardMultiplier(),
 		)
 		upwardThreshold = math.Gwei(

--- a/state-transition/core/state_processor_genesis.go
+++ b/state-transition/core/state_processor_genesis.go
@@ -179,7 +179,7 @@ func (sp *StateProcessor[
 			)
 		}
 		minEffectiveBalance := math.Gwei(
-			sp.cs.EjectionBalance() + sp.cs.EffectiveBalanceIncrement(),
+			sp.cs.EjectionBalance(false) + sp.cs.EffectiveBalanceIncrement(),
 		)
 
 		var idx math.ValidatorIndex

--- a/state-transition/core/state_processor_genesis.go
+++ b/state-transition/core/state_processor_genesis.go
@@ -179,7 +179,7 @@ func (sp *StateProcessor[
 			)
 		}
 		minEffectiveBalance := math.Gwei(
-			sp.cs.EjectionBalance(false) + sp.cs.EffectiveBalanceIncrement(),
+			sp.cs.EjectionBalance(false) + sp.cs.EffectiveBalanceIncrement(false),
 		)
 
 		var idx math.ValidatorIndex

--- a/state-transition/core/state_processor_genesis.go
+++ b/state-transition/core/state_processor_genesis.go
@@ -179,7 +179,11 @@ func (sp *StateProcessor[
 			)
 		}
 		minEffectiveBalance := math.Gwei(
-			sp.cs.EjectionBalance(false) + sp.cs.EffectiveBalanceIncrement(false),
+			sp.cs.EjectionBalance(
+				false,
+			) + sp.cs.EffectiveBalanceIncrement(
+				false,
+			),
 		)
 
 		var idx math.ValidatorIndex

--- a/state-transition/core/state_processor_genesis_test.go
+++ b/state-transition/core/state_processor_genesis_test.go
@@ -39,7 +39,7 @@ func TestInitialize(t *testing.T) {
 
 	var (
 		maxBalance = math.Gwei(cs.MaxEffectiveBalance(false))
-		increment  = math.Gwei(cs.EffectiveBalanceIncrement())
+		increment  = math.Gwei(cs.EffectiveBalanceIncrement(false))
 		minBalance = math.Gwei(cs.EjectionBalance(false))
 	)
 
@@ -194,7 +194,7 @@ func TestInitializeBartio(t *testing.T) {
 
 	var (
 		maxBalance = math.Gwei(cs.MaxEffectiveBalance(false))
-		increment  = math.Gwei(cs.EffectiveBalanceIncrement())
+		increment  = math.Gwei(cs.EffectiveBalanceIncrement(false))
 		minBalance = math.Gwei(cs.EjectionBalance(false))
 	)
 
@@ -367,7 +367,7 @@ func commonChecksValidators(
 
 	var (
 		maxBalance = math.Gwei(cs.MaxEffectiveBalance(false))
-		increment  = math.Gwei(cs.EffectiveBalanceIncrement())
+		increment  = math.Gwei(cs.EffectiveBalanceIncrement(false))
 		minBalance = math.Gwei(cs.EjectionBalance(false))
 	)
 	switch {

--- a/state-transition/core/state_processor_genesis_test.go
+++ b/state-transition/core/state_processor_genesis_test.go
@@ -40,7 +40,7 @@ func TestInitialize(t *testing.T) {
 	var (
 		maxBalance = math.Gwei(cs.MaxEffectiveBalance(false))
 		increment  = math.Gwei(cs.EffectiveBalanceIncrement())
-		minBalance = math.Gwei(cs.EjectionBalance())
+		minBalance = math.Gwei(cs.EjectionBalance(false))
 	)
 
 	// create test inputs
@@ -195,7 +195,7 @@ func TestInitializeBartio(t *testing.T) {
 	var (
 		maxBalance = math.Gwei(cs.MaxEffectiveBalance(false))
 		increment  = math.Gwei(cs.EffectiveBalanceIncrement())
-		minBalance = math.Gwei(cs.EjectionBalance())
+		minBalance = math.Gwei(cs.EjectionBalance(false))
 	)
 
 	var (
@@ -368,7 +368,7 @@ func commonChecksValidators(
 	var (
 		maxBalance = math.Gwei(cs.MaxEffectiveBalance(false))
 		increment  = math.Gwei(cs.EffectiveBalanceIncrement())
-		minBalance = math.Gwei(cs.EjectionBalance())
+		minBalance = math.Gwei(cs.EjectionBalance(false))
 	)
 	switch {
 	case dep.Amount >= maxBalance:

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -139,7 +139,7 @@ func (sp *StateProcessor[
 
 		updatedBalance := types.ComputeEffectiveBalance(
 			val.GetEffectiveBalance()+dep.GetAmount(),
-			math.Gwei(sp.cs.EffectiveBalanceIncrement()),
+			math.Gwei(sp.cs.EffectiveBalanceIncrement(false)),
 			math.Gwei(sp.cs.MaxEffectiveBalance(false)),
 		)
 		val.SetEffectiveBalance(updatedBalance)
@@ -234,7 +234,9 @@ func (sp *StateProcessor[
 		dep.GetPubkey(),
 		dep.GetWithdrawalCredentials(),
 		dep.GetAmount(),
-		math.Gwei(sp.cs.EffectiveBalanceIncrement()),
+		math.Gwei(sp.cs.EffectiveBalanceIncrement(
+			state.IsPostFork4(sp.cs.DepositEth1ChainID(), slot),
+		)),
 		math.Gwei(sp.cs.MaxEffectiveBalance(
 			state.IsPostFork3(sp.cs.DepositEth1ChainID(), slot),
 		)),

--- a/state-transition/core/state_processor_staking_test.go
+++ b/state-transition/core/state_processor_staking_test.go
@@ -47,7 +47,7 @@ func TestTransitionUpdateValidators(t *testing.T) {
 	var (
 		maxBalance       = math.Gwei(cs.MaxEffectiveBalance(false))
 		increment        = math.Gwei(cs.EffectiveBalanceIncrement())
-		minBalance       = math.Gwei(cs.EjectionBalance())
+		minBalance       = math.Gwei(cs.EjectionBalance(false))
 		emptyCredentials = types.NewCredentialsFromExecutionAddress(
 			common.ExecutionAddress{},
 		)
@@ -196,7 +196,7 @@ func TestTransitionCreateValidator(t *testing.T) {
 	var (
 		maxBalance       = math.Gwei(cs.MaxEffectiveBalance(false))
 		increment        = math.Gwei(cs.EffectiveBalanceIncrement())
-		minBalance       = math.Gwei(cs.EjectionBalance())
+		minBalance       = math.Gwei(cs.EjectionBalance(false))
 		emptyAddress     = common.ExecutionAddress{}
 		emptyCredentials = types.NewCredentialsFromExecutionAddress(
 			emptyAddress,
@@ -621,7 +621,7 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 
 	var (
 		maxBalance      = math.Gwei(cs.MaxEffectiveBalance(false))
-		ejectionBalance = math.Gwei(cs.EjectionBalance())
+		ejectionBalance = math.Gwei(cs.EjectionBalance(false))
 		minBalance      = ejectionBalance + math.Gwei(
 			cs.EffectiveBalanceIncrement(),
 		)
@@ -849,7 +849,7 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 
 	var (
 		maxBalance      = math.Gwei(cs.MaxEffectiveBalance(false))
-		ejectionBalance = math.Gwei(cs.EjectionBalance())
+		ejectionBalance = math.Gwei(cs.EjectionBalance(false))
 		minBalance      = ejectionBalance + math.Gwei(
 			cs.EffectiveBalanceIncrement(),
 		)

--- a/state-transition/core/state_processor_staking_test.go
+++ b/state-transition/core/state_processor_staking_test.go
@@ -46,7 +46,7 @@ func TestTransitionUpdateValidators(t *testing.T) {
 
 	var (
 		maxBalance       = math.Gwei(cs.MaxEffectiveBalance(false))
-		increment        = math.Gwei(cs.EffectiveBalanceIncrement())
+		increment        = math.Gwei(cs.EffectiveBalanceIncrement(false))
 		minBalance       = math.Gwei(cs.EjectionBalance(false))
 		emptyCredentials = types.NewCredentialsFromExecutionAddress(
 			common.ExecutionAddress{},
@@ -195,7 +195,7 @@ func TestTransitionCreateValidator(t *testing.T) {
 
 	var (
 		maxBalance       = math.Gwei(cs.MaxEffectiveBalance(false))
-		increment        = math.Gwei(cs.EffectiveBalanceIncrement())
+		increment        = math.Gwei(cs.EffectiveBalanceIncrement(false))
 		minBalance       = math.Gwei(cs.EjectionBalance(false))
 		emptyAddress     = common.ExecutionAddress{}
 		emptyCredentials = types.NewCredentialsFromExecutionAddress(
@@ -390,7 +390,7 @@ func TestTransitionWithdrawals(t *testing.T) {
 
 	var (
 		maxBalance   = math.Gwei(cs.MaxEffectiveBalance(false))
-		minBalance   = math.Gwei(cs.EffectiveBalanceIncrement())
+		minBalance   = math.Gwei(cs.EffectiveBalanceIncrement(false))
 		credentials0 = types.NewCredentialsFromExecutionAddress(
 			common.ExecutionAddress{},
 		)
@@ -483,7 +483,7 @@ func TestTransitionMaxWithdrawals(t *testing.T) {
 
 	var (
 		maxBalance   = math.Gwei(cs.MaxEffectiveBalance(false))
-		minBalance   = math.Gwei(cs.EffectiveBalanceIncrement())
+		minBalance   = math.Gwei(cs.EffectiveBalanceIncrement(false))
 		address0     = common.ExecutionAddress{}
 		credentials0 = types.NewCredentialsFromExecutionAddress(address0)
 		address1     = common.ExecutionAddress{0x01}
@@ -623,7 +623,7 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 		maxBalance      = math.Gwei(cs.MaxEffectiveBalance(false))
 		ejectionBalance = math.Gwei(cs.EjectionBalance(false))
 		minBalance      = ejectionBalance + math.Gwei(
-			cs.EffectiveBalanceIncrement(),
+			cs.EffectiveBalanceIncrement(false),
 		)
 		rndSeed = 2024 // seed used to generate unique random value
 	)
@@ -851,7 +851,7 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 		maxBalance      = math.Gwei(cs.MaxEffectiveBalance(false))
 		ejectionBalance = math.Gwei(cs.EjectionBalance(false))
 		minBalance      = ejectionBalance + math.Gwei(
-			cs.EffectiveBalanceIncrement(),
+			cs.EffectiveBalanceIncrement(false),
 		)
 		rndSeed = 2024 // seed used to generate unique random value
 	)

--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -65,7 +65,11 @@ func (sp *StateProcessor[
 
 	isPostUpgrade := state.IsPostFork4(sp.cs.DepositEth1ChainID(), slot)
 	minEffectiveBalance := math.Gwei(
-		sp.cs.EjectionBalance(isPostUpgrade) + sp.cs.EffectiveBalanceIncrement(isPostUpgrade),
+		sp.cs.EjectionBalance(
+			isPostUpgrade,
+		) + sp.cs.EffectiveBalanceIncrement(
+			isPostUpgrade,
+		),
 	)
 
 	// We do not currently have a cap on validator churn,
@@ -258,7 +262,9 @@ func (sp *StateProcessor[
 	}
 
 	ejectionBalance := math.U64(
-		sp.cs.EjectionBalance(state.IsPostFork4(sp.cs.DepositEth1ChainID(), slot)),
+		sp.cs.EjectionBalance(
+			state.IsPostFork4(sp.cs.DepositEth1ChainID(), slot),
+		),
 	)
 
 	activeVals := make([]ValidatorT, 0, len(vals))

--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -63,9 +63,9 @@ func (sp *StateProcessor[
 	currEpoch := sp.cs.SlotToEpoch(slot)
 	nextEpoch := currEpoch + 1
 
+	isPostUpgrade := state.IsPostFork4(sp.cs.DepositEth1ChainID(), slot)
 	minEffectiveBalance := math.Gwei(
-		sp.cs.EjectionBalance(state.IsPostFork4(sp.cs.DepositEth1ChainID(), slot)) +
-			sp.cs.EffectiveBalanceIncrement(),
+		sp.cs.EjectionBalance(isPostUpgrade) + sp.cs.EffectiveBalanceIncrement(isPostUpgrade),
 	)
 
 	// We do not currently have a cap on validator churn,


### PR DESCRIPTION
`boonet` branch is currently synced with `v0.6.1`. After merging this PR, future releases for the boonet network can be cut off of the `boonet` branch. 

Effective changes are to validator set processing:
- The min stake (or `EjectionBalance`) is now set to 250k BERA 
- The `EffectiveBalanceIncrement` (not the same as minimum deposit amount on the execution layer deposit contract) is now set to 10k BERA