### PR TITLE
Fix Typo in `README.md`

### DIFF
--- a/state-transition/core/README.md
+++ b/state-transition/core/README.md
@@ -12,7 +12,7 @@ We list below a few relevant facts.
 
 ## `Balance` and `EffectiveBalance`
 
-BeaconKit distingishes a validator `Balance` and a validator `EffectiveBalance`.
+BeaconKit distinguishes a validator `Balance` and a validator `EffectiveBalance`.
 
 - `Balance` is updated slot by slot, when a deposit in made over the deposit contract and events are subsequently processed by BeaconKit.
 - `Balance` can increase only in multiples of `MinDepositAmount`, which is specified in the deposit contract. There is no cap on the `Balance`.


### PR DESCRIPTION
# Pull Request Title
Fix Typo in `README.md`

## Description
This pull request addresses a typo in the `README.md` file within the `state-transition/core` directory to improve clarity and professionalism in the documentation.

### Changes Made:
- **File Modified:** `state-transition/core/README.md`
- **Summary of Changes:**
  - Line 12: Corrected "distingishes" to "distinguishes."

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] Documentation updated for clarity and professionalism.
- [x] Verified adherence to the project's [Contributing Guidelines](link-to-guidelines).

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Documentation typo fix only)

## Additional Notes
This update only modifies the documentation and does not impact any functional aspects of the codebase.

---

**Allow edits by maintainers:** [x]
<!-- Check this box to allow maintainers to modify the pull request if needed. -->
