### PR TITLE
Fix Typo in `README.md`

### DIFF
--- a/state-transition/core/README.md
+++ b/state-transition/core/README.md
@@ -12,7 +12,7 @@ We list below a few relevant facts.
 
 ## `Balance` and `EffectiveBalance`
 
-BeaconKit distingishes a validator `Balance` and a validator `EffectiveBalance`.
+BeaconKit distinguishes a validator `Balance` and a validator `EffectiveBalance`.
 
 - `Balance` is updated slot by slot, when a deposit in made over the deposit contract and events are subsequently processed by BeaconKit.
 - `Balance` can increase only in multiples of `MinDepositAmount`, which is specified in the deposit contract. There is no cap on the `Balance`.


### PR DESCRIPTION
# Pull Request Title: Fix Typo in `README.md` - "distingishes" to "distinguishes"

## Summary:
This pull request resolves a minor typo in the `README.md` file located in the `state-transition/core` directory. The correction improves the documentation's clarity and professionalism by fixing a misspelling.

## Changes Made:
- Corrected the typo **"distingishes"** to **"distinguishes"** in the context of describing `Balance` and `EffectiveBalance` in BeaconKit.

## Files Changed:
- `state-transition/core/README.md`

## Testing:
- This is a documentation-only update, requiring no functional testing.

## Additional Notes:
- Clear and accurate documentation is critical for ensuring that users and contributors can understand the codebase effectively. 
- This fix aligns with the project's standards for high-quality documentation.

---

Thank you for reviewing this contribution!
