### PR TITLE
fix: update Twitter URL to x.com format ,fix: correct typos in state processor documentation,fix: correct typo in smart contract deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _The project is still heavily under construction, see the [disclaimer below](#st
 [![CI status](https://github.com/berachain/beacon-kit/workflows/pipeline/badge.svg)](https://github.com/berachain/beacon-kit/actions/workflows/pipeline.yml)
 [![CodeCov](https://codecov.io/gh/berachain/beacon-kit/graph/badge.svg?token=0l5iJ3ZbzV)](https://codecov.io/gh/berachain/beacon-kit)
 [![Telegram Chat](https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fbeacon_kit)](https://t.me/beacon_kit)
-[![X Follow](https://img.shields.io/twitter/follow/berachain)](https://x.com/berachain)
+[![X Follow](https://img.shields.io/x/follow/berachain)](https://x.com/berachain)
 [![Discord](https://img.shields.io/discord/924442927399313448?label=discord)](https://discord.gg/berachain)
 
 </div>

--- a/state-transition/core/README.md
+++ b/state-transition/core/README.md
@@ -12,14 +12,14 @@ We list below a few relevant facts.
 
 ## `Balance` and `EffectiveBalance`
 
-BeaconKit distingishes a validator `Balance` and a validator `EffectiveBalance`.
+BeaconKit distinguishes a validator `Balance` and a validator `EffectiveBalance`.
 
-- `Balance` is updated slot by slot, when a deposit in made over the deposit contract and events are subsequently processed by BeaconKit.
+- `Balance` is updated slot by slot, when a deposit is made over the deposit contract and events are subsequently processed by BeaconKit.
 - `Balance` can increase only in multiples of `MinDepositAmount`, which is specified in the deposit contract. There is no cap on the `Balance`.
 - `EffectiveBalance` is updated at the turn of every epoch.
 - `EffectiveBalance` is enforced to be a multiple of `EffectiveBalanceIncrement`
 - `EffectiveBalance` is capped at `MaxEffectiveBalance`. Any `Balance` in excess of `MaxEffectiveBalance` is automatically withdrawn.
-- `EffectiveBalance` is aligned to `Balance`, within the constrains listed above, and accounting for hysteresys, at the turn of every epoch, via [`processEffectiveBalanceUpdates`](./state_processor.go#L491)
+- `EffectiveBalance` is aligned to `Balance`, within the constrains listed above, and accounting for hysteresis, at the turn of every epoch, via [`processEffectiveBalanceUpdates`](./state_processor.go#L491)
 
 ## Validator lifecycle
 
@@ -29,13 +29,13 @@ Say a deposit is made at slot `S`, epoch `N`, that creates a validator.
 
 The funds deposited will be locked and the validator will stay inactive until the a minimum staking balance is hit. The minimum staking balance is set to `EjectionBalance + EffectiveBalanceIncrement` to account for hysteresys. However if the active validator set has already reached the `ValidatorSetCap`, a new prospective validator must deposit more funds than the effective balance of the active validator with the lowest stake.
 
-So let's assumed that `S`, epoch `N`, is the slot where finally the validator `Balance` equals the minimum required for staking (one or multiple deposits may have been done to get there). Then:
+So let's assume that `S`, epoch `N`, is the slot where finally the validator `Balance` equals the minimum required for staking (one or multiple deposits may have been done to get there). Then:
 
 - The validator is marked as `EligibleForActivationQueue` as soon as epoch `N+1` starts. This is guaranteed since there is no cap on the activation queue size.
 - The validator is marked as active as soon as epoch `N+2` starts. However
-  - if the size of validator set goes beyond the `ValidatorSetCap` enough validators with the lowest stake are marked for eviction, to make the cap be fullfilled. Validators are sorted by increasing `EffectiveBalance` and ties are broken ordering their pub keys alphabetically.
+  - if the size of validator set goes beyond the `ValidatorSetCap` enough validators with the lowest stake are marked for eviction, to make the cap be fulfilled. Validators are sorted by increasing `EffectiveBalance` and ties are broken ordering their pub keys alphabetically.
 - BeaconKit does not currently support voluntary withdrawals, nor slashing or inactivity leaks. Therefore a validator keeps validating indefinitely.
   - The only case in which a validator may be evicted from the validator set (and its funds returned) is when `ValidatorSetCap` is hit and a validator with greater priority is added (i.e. with larger `EffectiveBalance` or equal `EffectiveBalance` and larger PubKey in alphabetical order).
 - Once a validator is marked as active, `CometBFT` consensus will reach it out for block proposals, validations and voting. The higher a validator `EffectiveBalance`, the higher its voting power the frequency it is polled for block proposal.
 
-Now say the validator is marked for exit (currently only as a result of the validator cap being hit), at epoch `M`. Then its funds will be fully withdrawned at epoch `M+1`, since again BeaconKit does not currently enforce a cap on validators churn.
+Now say the validator is marked for exit (currently only as a result of the validator cap being hit), at epoch `M`. Then its funds will be fully withdrawn at epoch `M+1`, since again BeaconKit does not currently enforce a cap on validators churn.

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -23,15 +23,15 @@ make test-e2e
 ```
 If required, add tests under testing/e2e folder.
 
-This will automatically build your beacond docker image from the local source
+This will automatically build your beacon docker image from the local source
 code, and spin up a Kurtosis network based on the config file in
 `testing/e2e/config/defaults.go`.
 
 ## Configuration
-In case you want to configure(change) the validator set, consider doing changes in `defaultValidators`.
+In case you want to configure (change) the validator set, consider doing changes in `defaultValidators`.
 The user can specify the number of replicas they want per type.
 
-All the default configuration are listed in `testing/e2e/config/defaults.go`
+All the default configurations are listed in `testing/e2e/config/defaults.go`
 
 Note: Currently the chainID for this local network is 80087, which is our dev network configuration (this is fixed in the kurtosis env setup and will be made configurable in a future version). To make changes to the 80087 chain spec used, modify parameters [here](https://github.com/berachain/beacon-kit/blob/main/config/spec/devnet.go#L40).
 

--- a/testing/forge-script/README.md
+++ b/testing/forge-script/README.md
@@ -18,11 +18,11 @@
 
 ## There could be different cases -
 
-- **Contract directory does not use git submodules**
+- **Contract directory does not uses git submodules*
 
-    If the contract directory does not use git submodules, provide the path up to the contracts in the `repository` and leave `contracts_path` as an empty string.
+    If the contract directory does not uses git submodules, provide the path up to the contracts in the `repository` and leave `contracts_path` as an empty string.
 
-- **Contract directory use git submodules**
+- **Contract directory uses git submodules**
 
     If the contract directory uses git submodules, then we need to clone the whole repository to get the submodules. In that case, we need to provide the `repository` at the root level and `contracts_path` where the contracts are present.
 


### PR DESCRIPTION
fix: update Twitter URL to x.com format
- Updated the Twitter URL from https://twitter.com/ to https://x.com/ to reflect the platform's rebranding.

fix: correct typos in state processor documentation
- "distingishes" -> "distinguishes"
- "in made" -> "is made"
- "hysteresys" -> "hysteresis"
- "assumed" -> "assume"
- "fullfilled" -> "fulfilled"
- "withdrawned" -> "withdrawn"

fix: correct typo in smart contract deployment documentation
- "use git submodules" -> "uses git submodules"
