### PR TITLE
chain-spec: Add validations for epoch and blob parameters

### DIFF
--- a/chain-spec/chain/errors.go
+++ b/chain-spec/chain/errors.go
@@ -35,4 +35,25 @@ var (
 	ErrInvalidValidatorSetCap = errors.New(
 		"validator set cap must be less than the validator registry limit",
 	)
+
+	// ErrInvalidMinEpochsToInactivityPenalty is returned when the minimum epochs
+	// to inactivity penalty is zero.
+	ErrInvalidMinEpochsToInactivityPenalty = errors.New(
+		"minimum epochs to inactivity penalty must be greater than zero",
+	)
+
+	// ErrInvalidSlotsPerEpoch is returned when slots per epoch is zero.
+	ErrInvalidSlotsPerEpoch = errors.New(
+		"slots per epoch must be greater than zero",
+	)
+
+	// ErrInvalidFieldElementsPerBlob is returned when field elements per blob is zero.
+	ErrInvalidFieldElementsPerBlob = errors.New(
+		"field elements per blob must be greater than zero",
+	)
+
+	// ErrInvalidBytesPerBlob is returned when bytes per blob is zero.
+	ErrInvalidBytesPerBlob = errors.New(
+		"bytes per blob must be greater than zero",
+	)
 )


### PR DESCRIPTION
Description:
Add validation checks for critical chain parameters in the chain specification validator:
- Ensure MinEpochsToInactivityPenalty is greater than zero
- Ensure SlotsPerEpoch is greater than zero
- Ensure FieldElementsPerBlob is greater than zero
- Ensure BytesPerBlob is greater than zero

These validations help prevent invalid chain configurations that could cause issues
during chain operation. The changes improve the robustness of the chain specification
validation by ensuring these fundamental parameters have valid values.