### PR TITLE
fix: correct iteration logic for constants.MaxBytesPerTx and constants.MaxTxsPerPayload

### DIFF
--- a/engine-primitives/engine-primitives/transactions_test.go
+++ b/engine-primitives/engine-primitives/transactions_test.go
@@ -72,7 +72,7 @@ var prysmConsistencyTests = []struct {
 		name: "max bytes per tx",
 		txs: func() [][]byte {
 			var tx []byte
-			for i := 0; i < int(constants.MaxBytesPerTx); i++ { // int dönüşümü eklendi
+			for i := 0; i < int(constants.MaxBytesPerTx); i++ {
 				tx = append(tx, byte(i))
 			}
 			return [][]byte{tx}
@@ -96,7 +96,7 @@ var prysmConsistencyTests = []struct {
 		name: "max txs",
 		txs: func() [][]byte {
 			var txs [][]byte
-			for i := 0; i < int(constants.MaxTxsPerPayload); i++ { // int dönüşümü eklendi
+			for i := 0; i < int(constants.MaxTxsPerPayload); i++ {
 				txs = append(txs, []byte{0x01})
 			}
 			return txs

--- a/engine-primitives/engine-primitives/transactions_test.go
+++ b/engine-primitives/engine-primitives/transactions_test.go
@@ -72,7 +72,7 @@ var prysmConsistencyTests = []struct {
 		name: "max bytes per tx",
 		txs: func() [][]byte {
 			var tx []byte
-			for i := range constants.MaxBytesPerTx {
+			for i := 0; i < constants.MaxBytesPerTx; i++ {
 				tx = append(tx, byte(i))
 			}
 			return [][]byte{tx}
@@ -96,7 +96,7 @@ var prysmConsistencyTests = []struct {
 		name: "max txs",
 		txs: func() [][]byte {
 			var txs [][]byte
-			for range int(constants.MaxTxsPerPayload) {
+			for i := 0; i < constants.MaxTxsPerPayload; i++ {
 				txs = append(txs, []byte{0x01})
 			}
 			return txs

--- a/engine-primitives/engine-primitives/transactions_test.go
+++ b/engine-primitives/engine-primitives/transactions_test.go
@@ -72,7 +72,7 @@ var prysmConsistencyTests = []struct {
 		name: "max bytes per tx",
 		txs: func() [][]byte {
 			var tx []byte
-			for i := 0; i < constants.MaxBytesPerTx; i++ {
+			for i := 0; i < int(constants.MaxBytesPerTx); i++ { // int dönüşümü eklendi
 				tx = append(tx, byte(i))
 			}
 			return [][]byte{tx}
@@ -96,7 +96,7 @@ var prysmConsistencyTests = []struct {
 		name: "max txs",
 		txs: func() [][]byte {
 			var txs [][]byte
-			for i := 0; i < constants.MaxTxsPerPayload; i++ {
+			for i := 0; i < int(constants.MaxTxsPerPayload); i++ { // int dönüşümü eklendi
 				txs = append(txs, []byte{0x01})
 			}
 			return txs


### PR DESCRIPTION
### Problem:
The constants `constants.MaxBytesPerTx` and `constants.MaxTxsPerPayload` were previously treated as iterable types with a `range` loop, but they are of type `uint64`. This caused incorrect usage of the `range` keyword, which is incompatible with integer types.

### Solution:
The iteration logic for both constants was corrected by replacing the `range` loop with an explicit integer-based loop using `for i := 0; i < ...; i++`. This ensures proper handling of the uint64 values.

### Test:
To confirm the type of these constants, the following test was performed:

1. A simple Go program was written to print the types of `constants.MaxBytesPerTx` and `constants.MaxTxsPerPayload`.
2. The test revealed that both constants are of type `uint64`.

I have also attached a screenshot of the test I performed below:
![Test Output]
![Berachain hata bulma](https://github.com/user-attachments/assets/57fe70c9-2a67-4c9a-a7be-b20e6c10cc90)


---

This fix ensures compatibility with Go standards and eliminates potential logical issues in the iteration logic.

