### PR TITLE
fix: Fix package import path for engineprimitives

### DIFF
--- a/beacon/blockchain/execution_engine.go
+++ b/beacon/blockchain/execution_engine.go
@@ -24,7 +24,7 @@ import (
 	"context"
 
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
-	engineprimitives "github.com/berachain/beacon-kit/engine-primitives/engine-primitives"
+	engineprimitives "github.com/berachain/beacon-kit/engine-primitives"
 	statedb "github.com/berachain/beacon-kit/state-transition/core/state"
 )
 


### PR DESCRIPTION

I noticed a small issue with the import path for the `engineprimitives` package. The current path duplicates the package name, which seems unintended. I’ve updated it to the correct path:  

```go
engineprimitives "github.com/berachain/beacon-kit/engine-primitives"
```  

This should resolve any potential confusion or errors related to the package naming. 