### PR TITLE
fix: Fix incorrect value in test_DepositNative() function

### DIFF
--- a/contracts/test/staking/DepositContract.t.sol
+++ b/contracts/test/staking/DepositContract.t.sol
@@ -149,7 +149,7 @@ contract DepositContractTest is SoladyTest, StdCheats {
         vm.prank(depositor);
         vm.expectEmit(true, true, true, true);
         emit IDepositContract.Deposit(
-            VALIDATOR_PUBKEY, STAKING_CREDENTIALS, 32 gwei, _create96Byte(), 0
+            VALIDATOR_PUBKEY, STAKING_CREDENTIALS, 32 ether, _create96Byte(), 0
         );
         depositContract.deposit{ value: 32 ether }(
             VALIDATOR_PUBKEY, STAKING_CREDENTIALS, _create96Byte(), depositor


### PR DESCRIPTION
I noticed a typo in the `test_DepositNative()` function where `32 gwei` was used instead of `32 ether`. This inconsistency could lead to incorrect test logic since the code above uses `32 ether` for the deposit. I’ve corrected the value to `32 ether` to match the intended behavior.  

**Changes:**  
- Replaced `32 gwei` with `32 ether` in the `emit IDepositContract.Deposit()` call.  
