### PR TITLE
fix: Optimize Consensus Configuration and Merkle Tree Benchmarks

### DIFF
--- a/testing/networks/80084/config.toml
+++ b/testing/networks/80084/config.toml
@@ -467,11 +467,8 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-# Set to 0 if you want to make progress as soon as the node has all the precommits.
-timeout_commit = "500ms"
-
-# Deprecated: set `timeout_commit` to 0 instead.
-skip_timeout_commit = false
+# Set to 0 to make progress as soon as the node has all the precommits.
+timeout_commit = "0"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart


### PR DESCRIPTION
1. Consensus Configuration:
   - Removed deprecated `skip_timeout_commit`
   - Set `timeout_commit = "0"` for faster block progress

2. Merkle Tree Tests:
   - Added helper function for test data generation
   - Added benchmarks for different tree sizes (Small/Medium/Large)