### PR TITLE
fix(consensus): explicitly check consensus txs count

### DIFF
--- a/beacon/blockchain/errors.go
+++ b/beacon/blockchain/errors.go
@@ -23,6 +23,7 @@ package blockchain
 import "github.com/berachain/beacon-kit/errors"
 
 var (
+	ErrTooManyConsensusTxs = errors.New("too many consensus txs")
 	// ErrNilBlk is an error for when the beacon block is nil.
 	ErrNilBlk = errors.New("nil beacon block")
 	// ErrNilBlob is an error for when the BlobSidecars is nil.

--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -49,12 +49,22 @@ const (
 	// BlobSidecarsTxIndex represents the index of the blob sidecar transaction.
 	// It follows the beacon block transaction in the tx list.
 	BlobSidecarsTxIndex
+
+	// A Consensus block has at most two transactions (block and blob).
+	MaxConsensusTxsCount = 2
 )
 
 func (s *Service) ProcessProposal(
 	ctx sdk.Context,
 	req *cmtabci.ProcessProposalRequest,
 ) error {
+	if countTx := len(req.Txs); countTx > MaxConsensusTxsCount {
+		return fmt.Errorf("max expected %d, got %d: %w",
+			MaxConsensusTxsCount, countTx,
+			ErrTooManyConsensusTxs,
+		)
+	}
+
 	// Decode signed block and sidecars.
 	signedBlk, sidecars, err := encoding.
 		ExtractBlobsAndBlockFromRequest(


### PR DESCRIPTION
We only allow two "transactions" to be included into a consensus block: a block and a blob.
This PR explicitly marks as invalid blocks containing more than 2 transactions