### PR TITLE
fix(state-transition): Correctly enforce deposits length to avoid panics

### DIFF
--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -32,17 +32,14 @@ import (
 	"github.com/berachain/beacon-kit/state-transition/core/state"
 )
 
-// processOperations processes the operations and ensures they match the
-// local state.
+// processOperations processes the operations and ensures they match the local state.
 func (sp *StateProcessor[_]) processOperations(
 	ctx context.Context, st *state.StateDB, blk *ctypes.BeaconBlock,
 ) error {
-	// Verify that outstanding deposits are processed
-	// up to the maximum number of deposits
-
-	// Unlike Eth 2.0 specs we don't check that
-	// len(body.deposits) ==  min(MAX_DEPOSITS,
-	// state.eth1_data.deposit_count - state.eth1_deposit_index)
+	// Verify that outstanding deposits are processed up to the maximum number of deposits.
+	//
+	// Unlike Eth 2.0 specs we don't check the following:
+	// `len(body.deposits) ==  min(MAX_DEPOSITS, state.eth1_data.deposit_count - state.eth1_deposit_index)`.
 	// Instead we directly compare block deposits with store ones.
 	deposits := blk.GetBody().GetDeposits()
 	if uint64(len(deposits)) > sp.cs.MaxDepositsPerBlock() {
@@ -51,16 +48,19 @@ func (sp *StateProcessor[_]) processOperations(
 			sp.cs.MaxDepositsPerBlock(), len(deposits),
 		)
 	}
+
 	if err := sp.validateNonGenesisDeposits(
 		ctx, st, deposits, blk.GetBody().GetEth1Data().DepositRoot,
 	); err != nil {
 		return err
 	}
+
 	for _, dep := range deposits {
 		if err := sp.processDeposit(st, dep); err != nil {
 			return err
 		}
 	}
+
 	return st.SetEth1Data(blk.GetBody().Eth1Data)
 }
 

--- a/state-transition/core/validation_deposits.go
+++ b/state-transition/core/validation_deposits.go
@@ -78,12 +78,8 @@ func (sp *StateProcessor[_]) validateNonGenesisDeposits(
 		return err
 	}
 
-	var (
-		localDeposits            ctypes.Deposits
-		blkDepositsLen           = uint64(len(blkDeposits))
-		expectedLocalDepositsLen = blkDepositsLen + depositIndex
-	)
-	localDeposits, err = sp.ds.GetDepositsByIndex(ctx, 0, expectedLocalDepositsLen)
+	expectedLocalDepositsLen := depositIndex + uint64(len(blkDeposits))
+	localDeposits, err := sp.ds.GetDepositsByIndex(ctx, 0, expectedLocalDepositsLen)
 	if err != nil {
 		return err
 	}

--- a/state-transition/core/validation_deposits.go
+++ b/state-transition/core/validation_deposits.go
@@ -84,7 +84,7 @@ func (sp *StateProcessor[_]) validateNonGenesisDeposits(
 		return err
 	}
 
-	// First verify that the local store's deposit count matches the block's deposit count.
+	// First verify that the local store returned all the expected deposits
 	if uint64(len(localDeposits)) != expectedLocalDepositsLen {
 		return errors.Wrapf(ErrDepositsLengthMismatch,
 			"local deposit count: %d, expected deposit count: %d",

--- a/state-transition/core/validation_deposits.go
+++ b/state-transition/core/validation_deposits.go
@@ -78,13 +78,25 @@ func (sp *StateProcessor[_]) validateNonGenesisDeposits(
 		return err
 	}
 
-	var localDeposits ctypes.Deposits
-	localDeposits, err = sp.ds.GetDepositsByIndex(ctx, 0, depositIndex+uint64(len(blkDeposits)))
+	var (
+		localDeposits            ctypes.Deposits
+		blkDepositsLen           = uint64(len(blkDeposits))
+		expectedLocalDepositsLen = blkDepositsLen + depositIndex
+	)
+	localDeposits, err = sp.ds.GetDepositsByIndex(ctx, 0, expectedLocalDepositsLen)
 	if err != nil {
 		return err
 	}
 
-	// First check that the block's deposits 1) have contiguous indices and 2) match the local
+	// First verify that the local store's deposit count matches the block's deposit count.
+	if uint64(len(localDeposits)) != expectedLocalDepositsLen {
+		return errors.Wrapf(ErrDepositsLengthMismatch,
+			"local deposit count: %d, expected deposit count: %d",
+			len(localDeposits), expectedLocalDepositsLen,
+		)
+	}
+
+	// Then check that the block's deposits 1) have contiguous indices and 2) match the local
 	// view of the block's deposits.
 	for i, blkDeposit := range blkDeposits {
 		blkDepositIndex := blkDeposit.GetIndex().Unwrap()
@@ -103,7 +115,7 @@ func (sp *StateProcessor[_]) validateNonGenesisDeposits(
 		}
 	}
 
-	// Then check that the historical deposits root matches locally what's on the beacon block.
+	// Finally check that the historical deposits root matches locally what's on the beacon block.
 	if !localDeposits.HashTreeRoot().Equals(blkDepositRoot) {
 		return ErrDepositsRootMismatch
 	}


### PR DESCRIPTION
We didn't have a length check before. If a verifying node did not have up-to-date the latest deposits that are included in block, we would panic in their process proposal (OR finalize block). This PR fixes by erroring to REJECT the proposal in this case.