### PR TITLE
chore(state-transition): allow validators with non-eth1 withdrawal creds to stake

### DIFF
--- a/cli/commands/jwt/jwt.go
+++ b/cli/commands/jwt/jwt.go
@@ -57,13 +57,13 @@ func Commands() *cobra.Command {
 }
 
 // NewGenerateJWTCommand creates a new command for generating a JWT secret.
+//
+//nolint:lll // reads better if long description is one line
 func NewGenerateJWTCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generates a new JWT authentication secret",
-		Long: `This command generates a new JWT authentication secret and
-writes it to a file. If no output file path is specified, it uses the default
-file name "jwt.hex" in the current directory.`,
+		Long:  `This command generates a new JWT authentication secret and writes it to a file. If no output file path is specified, it uses the default file name "jwt.hex" in the current directory.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Get the file path from the command flags.
 			outputPath, err := getFilePath(cmd, FlagOutputPath)
@@ -80,13 +80,13 @@ file name "jwt.hex" in the current directory.`,
 }
 
 // NewValidateJWTCommand creates a new command for validating a JWT secret.
+//
+//nolint:lll // reads better if long description is one line
 func NewValidateJWTCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validates a JWT secret conforms to Engine-RPC requirements",
-		Long: `This command validates a JWT secret by checking if the JWT secret
-is formatted properly. If no output file path is specified, it uses the default
-file name "jwt.hex" in the current directory.`,
+		Long:  `This command validates a JWT secret by checking if the JWT secret is formatted properly. If no output file path is specified, it uses the default file name "jwt.hex" in the current directory.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Get the file path from the command flags.
 			inputPath, err := getFilePath(cmd, FlagInputPath)

--- a/state-transition/core/metrics.go
+++ b/state-transition/core/metrics.go
@@ -48,8 +48,12 @@ func (s *stateProcessorMetrics) gaugeTimestamps(
 	s.sink.SetGauge("beacon_kit.state.payload_consensus_timestamp_diff", diff)
 }
 
-func (s *stateProcessorMetrics) incrementDepositsIgnored() {
-	s.sink.IncrementCounter("beacon_kit.state.deposits_ignored")
+func (s *stateProcessorMetrics) incrementValidatorNotWithdrawable() {
+	s.sink.IncrementCounter("beacon_kit.state.validator_not_withdrawable")
+}
+
+func (s *stateProcessorMetrics) incrementDepositStakeLost() {
+	s.sink.IncrementCounter("beacon_kit.state.deposit_stake_lost")
 }
 
 func (s *stateProcessorMetrics) gaugeBlockGasUsed(

--- a/state-transition/core/state_processor_staking_test.go
+++ b/state-transition/core/state_processor_staking_test.go
@@ -1133,3 +1133,75 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 	_, err = sp.Transition(ctx, st, blk)
 	require.NoError(t, err)
 }
+
+func TestValidatorNotWithdrawable(t *testing.T) {
+	cs := setupChain(t, components.BetnetChainSpecType)
+	sp, st, ds, ctx := setupState(t, cs)
+
+	var (
+		belowActiveBalance = math.Gwei(cs.EjectionBalance())
+		maxBalance         = math.Gwei(cs.MaxEffectiveBalance())
+		validCredentials   = types.NewCredentialsFromExecutionAddress(common.ExecutionAddress{})
+	)
+
+	// Setup initial state with one validator
+	var (
+		genDeposits = types.Deposits{
+			{
+				Pubkey:      [48]byte{0x00},
+				Credentials: validCredentials,
+				Amount:      maxBalance,
+				Index:       0,
+			},
+		}
+		genPayloadHeader = new(types.ExecutionPayloadHeader).Empty()
+		genVersion       = version.FromUint32[common.Version](version.Deneb)
+	)
+	require.NoError(t, ds.EnqueueDeposits(ctx, genDeposits))
+	_, err := sp.InitializePreminedBeaconStateFromEth1(
+		st, genDeposits, genPayloadHeader, genVersion,
+	)
+	require.NoError(t, err)
+
+	// Create the block deposit with a non-ETH1 withdrawal credentials. This stake should not
+	// be lost.
+	invalidCredentials := types.WithdrawalCredentials(validCredentials[:])
+	invalidCredentials[1] = 0x01
+	blockDeposits := types.Deposits{
+		{
+			Pubkey:      [48]byte{0x01},
+			Credentials: invalidCredentials,
+			Amount:      belowActiveBalance,
+			Index:       1,
+		},
+	}
+
+	depRoot := append(genDeposits, blockDeposits...).HashTreeRoot()
+	blk := buildNextBlock(
+		t,
+		st,
+		&types.BeaconBlockBody{
+			ExecutionPayload: &types.ExecutionPayload{
+				Timestamp:    10,
+				ExtraData:    []byte("testing"),
+				Transactions: [][]byte{},
+				Withdrawals: []*engineprimitives.Withdrawal{
+					st.EVMInflationWithdrawal(),
+				},
+				BaseFeePerGas: math.NewU256(0),
+			},
+			Eth1Data: types.NewEth1Data(depRoot),
+			Deposits: blockDeposits,
+		},
+	)
+	require.NoError(t, ds.EnqueueDeposits(ctx, blockDeposits))
+
+	// Run transition.
+	_, err = sp.Transition(ctx, st, blk)
+	require.NoError(t, err)
+
+	// Check that validator 0x01 is part of beacon state with below active balance.
+	validator, err := st.ValidatorByIndex(1)
+	require.NoError(t, err)
+	require.Equal(t, belowActiveBalance, validator.EffectiveBalance)
+}


### PR DESCRIPTION
These validators are now allowed to stake, but will never be able to withdraw their stake. Consistent with [spec](https://ethereum.github.io/consensus-specs/specs/phase0/beacon-chain/#__codelineno-111-1). 