### PR TITLE
Remove service-name prefix

### DIFF
--- a/testing/networks/example/app.toml
+++ b/testing/networks/example/app.toml
@@ -73,7 +73,7 @@ app-db-backend = "pebbledb"
 [telemetry]
 
 # Prefixed with keys to separate services.
-service-name = "beacond_node"
+service-name = ""
 
 # Enabled enables the application telemetry functionality. When enabled,
 # an in-memory sink is also enabled by default. Operators may also enabled


### PR DESCRIPTION
This was causing our beaconkit metrics to not show up properly in our dashboards as they were prefixed causing them to be filtered out. See  https://berachain.slack.com/archives/C07JWRBH2TT/p1737214129859619