### PR TITLE
Remove uses of context.Background()

### DIFF
--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -123,7 +123,7 @@ func (s *Service) ProcessProposal(
 		// the currently active fork). ProcessProposal should only
 		// keep the state changes as candidates (which is what we do in
 		// VerifyIncomingBlock).
-		err = s.VerifyIncomingBlobSidecars(sidecars, blk.GetHeader(), blk.GetBody().GetBlobKzgCommitments())
+		err = s.VerifyIncomingBlobSidecars(ctx, sidecars, blk.GetHeader(), blk.GetBody().GetBlobKzgCommitments())
 		if err != nil {
 			s.logger.Error("failed to verify incoming blob sidecars", "error", err)
 			return err
@@ -168,6 +168,7 @@ func (s *Service) VerifyIncomingBlockSignature(
 // VerifyIncomingBlobSidecars verifies the BlobSidecars of an incoming
 // proposal and logs the process.
 func (s *Service) VerifyIncomingBlobSidecars(
+	ctx context.Context,
 	sidecars datypes.BlobSidecars,
 	blkHeader *ctypes.BeaconBlockHeader,
 	kzgCommitments eip4844.KZGCommitments[common.ExecutionHash],
@@ -175,7 +176,7 @@ func (s *Service) VerifyIncomingBlobSidecars(
 	s.logger.Info("Received incoming blob sidecars")
 
 	// Verify the blobs and ensure they match the local state.
-	err := s.blobProcessor.VerifySidecars(sidecars, blkHeader, kzgCommitments)
+	err := s.blobProcessor.VerifySidecars(ctx, sidecars, blkHeader, kzgCommitments)
 	if err != nil {
 		s.logger.Error(
 			"rejecting incoming blob sidecars",

--- a/da/blob/processor.go
+++ b/da/blob/processor.go
@@ -21,6 +21,7 @@
 package blob
 
 import (
+	"context"
 	"time"
 
 	"github.com/berachain/beacon-kit/chain"
@@ -66,6 +67,7 @@ func NewProcessor(
 
 // VerifySidecars verifies the blobs and ensures they match the local state.
 func (sp *Processor) VerifySidecars(
+	ctx context.Context,
 	sidecars datypes.BlobSidecars,
 	blkHeader *ctypes.BeaconBlockHeader,
 	kzgCommitments eip4844.KZGCommitments[common.ExecutionHash],
@@ -81,6 +83,7 @@ func (sp *Processor) VerifySidecars(
 
 	// Verify the blobs and ensure they match the local state.
 	return sp.verifier.verifySidecars(
+		ctx,
 		sidecars,
 		blkHeader,
 		kzgCommitments,

--- a/da/blob/verifier.go
+++ b/da/blob/verifier.go
@@ -62,6 +62,7 @@ func newVerifier(
 // verifySidecars verifies the blobs for both inclusion as well
 // as the KZG proofs.
 func (bv *verifier) verifySidecars(
+	ctx context.Context,
 	sidecars datypes.BlobSidecars,
 	blkHeader *ctypes.BeaconBlockHeader,
 	kzgCommitments eip4844.KZGCommitments[common.ExecutionHash],
@@ -71,7 +72,7 @@ func (bv *verifier) verifySidecars(
 		bv.proofVerifier.GetImplementation(),
 	)
 
-	g, _ := errgroup.WithContext(context.Background())
+	g, _ := errgroup.WithContext(ctx)
 
 	// Create lookup table for each blob sidecar commitment.
 	blobSidecarCommitments := make(map[eip4844.KZGCommitment]struct{})

--- a/da/da/types.go
+++ b/da/da/types.go
@@ -21,6 +21,8 @@
 package da
 
 import (
+	"context"
+
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
 	dastore "github.com/berachain/beacon-kit/da/store"
 	datypes "github.com/berachain/beacon-kit/da/types"
@@ -38,6 +40,7 @@ type BlobProcessor interface {
 	) error
 	// VerifySidecars verifies the blobs and ensures they match the local state.
 	VerifySidecars(
+		ctx context.Context,
 		sidecars datypes.BlobSidecars,
 		blkHeader *ctypes.BeaconBlockHeader,
 		kzgCommitments eip4844.KZGCommitments[common.ExecutionHash],

--- a/node-core/components/interfaces.go
+++ b/node-core/components/interfaces.go
@@ -183,6 +183,7 @@ type (
 		// VerifySidecars verifies the blobs and ensures they match the local
 		// state.
 		VerifySidecars(
+			ctx context.Context,
 			sidecars datypes.BlobSidecars,
 			blkHeader *ctypes.BeaconBlockHeader,
 			kzgCommitments eip4844.KZGCommitments[common.ExecutionHash],

--- a/state-transition/core/state_processor_payload.go
+++ b/state-transition/core/state_processor_payload.go
@@ -38,7 +38,7 @@ func (sp *StateProcessor[ContextT]) processExecutionPayload(
 		body    = blk.GetBody()
 		payload = body.GetExecutionPayload()
 		header  *ctypes.ExecutionPayloadHeader
-		g, gCtx = errgroup.WithContext(context.Background())
+		g, gCtx = errgroup.WithContext(ctx)
 	)
 
 	payloadTimestamp := payload.GetTimestamp().Unwrap()


### PR DESCRIPTION
We should only use this in top-level code like in main and tests and such as context.Background is not cancellable 