### PR TITLE
Improvements to signal handling

### DIFF
--- a/node-core/node/node.go
+++ b/node-core/node/node.go
@@ -38,6 +38,9 @@ import (
 // Compile-time assertion that node implements the NodeI interface.
 var _ types.Node = (*node)(nil)
 
+// if the node does not shutdown within a very reasonable time (5min) then we force exit.
+const shutdownTimeout = 5 * time.Minute
+
 // node is the hard-type representation of the beacon-kit node.
 type node struct {
 	// logger is the node's logger.
@@ -88,8 +91,6 @@ func (n *node) Start(
 	go func() {
 		sig := <-sigc
 
-		// if the node does not shutdown within a very reasonable time (5min) then we force exit
-		const shutdownTimeout = 5 * time.Minute
 		timeout := time.AfterFunc(shutdownTimeout, func() {
 			n.logger.Error("Shutdown timeout exceeded, forcing exit", "timeout", shutdownTimeout.String())
 			os.Exit(1)

--- a/node-core/services/registry/registry.go
+++ b/node-core/services/registry/registry.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync"
 
 	"cosmossdk.io/store"
 	cometbft "github.com/berachain/beacon-kit/consensus/cometbft/service"
@@ -60,8 +59,6 @@ type Registry struct {
 	servicesStarted map[string]struct{}
 	// serviceTypes is an ordered slice of registered service types.
 	serviceTypes []string
-	// mutex makes calls to StartAll and StopAll thread-safe.
-	mutex sync.Mutex
 }
 
 // NewRegistry starts a registry instance for convenience.
@@ -82,9 +79,6 @@ func NewRegistry(logger log.Logger, opts ...RegistryOption) *Registry {
 
 // StartAll initialized each service in order of registration.
 func (s *Registry) StartAll(ctx context.Context) error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	// start all services
 	s.logger.Info("Starting services", "num", len(s.serviceTypes))
 	for _, typeName := range s.serviceTypes {
@@ -106,9 +100,6 @@ func (s *Registry) StartAll(ctx context.Context) error {
 }
 
 func (s *Registry) StopAll() {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	// stop all services in reverse order they were started
 	s.logger.Info("Stopping services", "num", len(s.serviceTypes))
 	for i := len(s.serviceTypes) - 1; i >= 0; i-- {


### PR DESCRIPTION
This PR makes the following improvements to signal handling, where during graceful shutdown we now:
- Only stop services which we called `Start()` on.
- Fixes critical section issue where we can call `StopAll` twice during shutdown if signal was received while in the middle of Startup.
- Simplifies the signal handling to use a simple blocking channel instead of `errgroup`. 
- Force kill if not shutdown within 5 minutes. Currently our kubernetes pods have timeout to 30seconds before they send it SIGKILL but we are targeting to increase this to 5 minutes ([see task](https://github.com/berachain/infra/issues/875)).

**Test plan**

Node fails in `StartAll` only Stops already started services

```
2025-02-11T14:41:00Z INFO Starting services num=8
2025-02-11T14:41:00Z INFO Starting service type=shutdown
2025-02-11T14:41:00Z INFO Starting service type=validator
2025-02-11T14:41:00Z INFO Starting service type=node-api-server
2025-02-11T14:41:00Z ERRR Shutdown initiated error=failed to start services: some error with service
2025-02-11T14:41:00Z INFO Stopping services num=8
2025-02-11T14:41:00Z INFO Service not started type=beacond
2025-02-11T14:41:00Z INFO Service not started type=blockchain
2025-02-11T14:41:00Z INFO Service not started type=engine-client
2025-02-11T14:41:00Z INFO Service not started type=telemetry
2025-02-11T14:41:00Z INFO Service not started type=reporting
2025-02-11T14:41:00Z INFO Service not started type=node-api-server
2025-02-11T14:41:00Z INFO Stopping service type=validator
2025-02-11T14:41:00Z INFO Stopping service type=shutdown
2025-02-11T14:41:00Z INFO Stopping shutdown service service=shutdown
2025-02-11T14:41:00Z INFO Node shutdown completed duration=36.897µs
```

Shutting down node with CTRL+C

```
2025-02-11T14:41:53Z ERRR Shutdown initiated error=shutdown initiated by signal: interrupt
2025-02-11T14:41:53Z INFO Stopping services num=8
2025-02-11T14:41:53Z INFO Stopping service type=beacond
2025-02-11T14:41:53Z INFO Stopping CometBFT Node
2025-02-11T14:41:53Z INFO Stopping Node service impl=Node
2025-02-11T14:41:53Z INFO Stopping service type=blockchain
2025-02-11T14:41:53Z INFO Stopping blockchain service service=blockchain
2025-02-11T14:41:53Z INFO Stopping service type=engine-client
2025-02-11T14:41:53Z INFO Stopping service type=telemetry
2025-02-11T14:41:53Z INFO Stopping service type=reporting
2025-02-11T14:41:53Z INFO Stopping service type=node-api-server
2025-02-11T14:41:53Z INFO Stopping service type=validator
2025-02-11T14:41:53Z INFO Stopping service type=shutdown
2025-02-11T14:41:53Z INFO Stopping shutdown service service=shutdown
2025-02-11T14:41:53Z INFO Node shutdown completed duration=9.560043ms
```

Shutting down node when it does not exit within a reasonable time (manually lowered from 5mins to 5secs with sleep to simulate syncing to disk):

```
2025-02-11T14:43:05Z ERRR Shutdown initiated error=shutdown initiated by signal: interrupt
2025-02-11T14:43:05Z INFO Stopping services num=8
2025-02-11T14:43:05Z INFO Stopping service type=beacond
2025-02-11T14:43:05Z INFO Stopping blockchain service service=blockchain
2025-02-11T14:43:05Z INFO Stopping service type=engine-client
2025-02-11T14:43:05Z INFO Stopping service type=telemetry
2025-02-11T14:43:05Z INFO Stopping service type=reporting
2025-02-11T14:43:05Z INFO Stopping service type=node-api-server
2025-02-11T14:43:05Z INFO Stopping service type=validator
2025-02-11T14:43:05Z INFO Stopping service type=shutdown
2025-02-11T14:43:05Z INFO Stopping shutdown service service=shutdown
2025-02-11T14:43:13Z ERRR Shutdown timeout exceeded, forcing exit timeout=5s
```
