### PR TITLE
chore(engine): Remove Unused Errors and Functions

### DIFF
--- a/consensus-types/types/payload_requests.go
+++ b/consensus-types/types/payload_requests.go
@@ -115,7 +115,7 @@ func (n *NewPayloadRequest) HasValidVersionedAndBlockHashes() error {
 		gethprimitives.NewStackTrie(nil),
 	)
 
-	// Verify that the payload is telling the truth about it's block hash.
+	// Verify that the payload is telling the truth about its block hash.
 	//#nosec:G103 // its okay.
 	if block := gethprimitives.NewBlockWithHeader(
 		&gethprimitives.Header{

--- a/engine-primitives/errors/errors.go
+++ b/engine-primitives/errors/errors.go
@@ -68,13 +68,8 @@ var (
 
 	// ErrInvalidPayloadStatus indicates an invalid payload status.
 	ErrInvalidPayloadStatus = errors.New(
-		"payload status is INVALID")
-
-	// ErrInvalidBlockHashPayloadStatus indicates a failure in validating the
-	// block hash for the payload.
-	ErrInvalidBlockHashPayloadStatus = errors.New(
-		"payload status is INVALID_BLOCK_HASH")
-
+		"payload status is INVALID",
+	)
 	// ErrNilForkchoiceResponse indicates a nil forkchoice response.
 	ErrNilForkchoiceResponse = errors.New(
 		"nil forkchoice response",

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -112,14 +112,7 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 
 	// If we get invalid payload status, we will need to find a valid
 	// ancestor block and force a recovery.
-	//
-	// These two cases are semantically the same:
-	// https://github.com/ethereum/execution-apis/issues/270
-	case errors.IsAny(
-		err,
-		engineerrors.ErrInvalidPayloadStatus,
-		engineerrors.ErrInvalidBlockHashPayloadStatus,
-	):
+	case errors.Is(err, engineerrors.ErrInvalidPayloadStatus):
 		ee.metrics.markForkchoiceUpdateInvalid(req.State, err)
 		return payloadID, latestValidHash, ErrBadBlockProduced
 
@@ -203,12 +196,7 @@ func (ee *Engine) VerifyAndNotifyNewPayload(
 		)
 
 	// These two cases are semantically the same:
-	// https://github.com/ethereum/execution-apis/issues/270
-	case errors.IsAny(
-		err,
-		engineerrors.ErrInvalidPayloadStatus,
-		engineerrors.ErrInvalidBlockHashPayloadStatus,
-	):
+	case errors.Is(err, engineerrors.ErrInvalidPayloadStatus):
 		ee.metrics.markNewPayloadInvalidPayloadStatus(
 			req.ExecutionPayload.GetBlockHash(),
 			req.Optimistic,

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -58,19 +58,6 @@ func New(
 	}
 }
 
-// Start spawns any goroutines required by the service.
-func (ee *Engine) Start(
-	ctx context.Context,
-) error {
-	go func() {
-		// TODO: handle better
-		if err := ee.ec.Start(ctx); err != nil {
-			panic(err)
-		}
-	}()
-	return nil
-}
-
 // GetPayload returns the payload and blobs bundle for the given slot.
 func (ee *Engine) GetPayload(
 	ctx context.Context,
@@ -195,7 +182,6 @@ func (ee *Engine) VerifyAndNotifyNewPayload(
 			req.Optimistic,
 		)
 
-	// These two cases are semantically the same:
 	case errors.Is(err, engineerrors.ErrInvalidPayloadStatus):
 		ee.metrics.markNewPayloadInvalidPayloadStatus(
 			req.ExecutionPayload.GetBlockHash(),


### PR DESCRIPTION
INVALID_BLOCK_HASH error is never returned from the execution client. It is also beaconkit wrapped type that is never actually created and as such can never occur. 

Engine.Start is also never called and hence removed