### PR TITLE
lower test iterations to address slow sidecar test

### DIFF
--- a/testing/quick/compare_test.go
+++ b/testing/quick/compare_test.go
@@ -40,7 +40,6 @@ import (
 )
 
 var (
-	c    = quick.Config{MaxCount: 5_000}
 	hFn  = ztree.GetHashFn()
 	spec = zspec.Mainnet
 )
@@ -92,7 +91,7 @@ func TestExecutionPayloadHashTreeRootZrnt(t *testing.T) {
 		return bytes.Equal(typeRoot[:], containerRoot[:]) &&
 			bytes.Equal(typeRoot[:], zRoot[:])
 	}
-	if err := quick.Check(f, &c); err != nil {
+	if err := quick.Check(f, &quick.Config{MaxCount: 5_000}); err != nil {
 		t.Error(err)
 	}
 }
@@ -148,7 +147,8 @@ func TestBlobSidecarTreeRootPrysm(t *testing.T) {
 
 		return bytes.Equal(prysmRoot[:], beaconRoot[:])
 	}
-	if err := quick.Check(f, &c); err != nil {
+
+	if err := quick.Check(f, &quick.Config{MaxCount: 2_500}); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
The `test-unit-cover` test takes over 9minutes to run on our CI which is double the next longest CI task (test-e2e). This lowers the maximum iterations in the blob sidecar test so it should take approximately the same time as the test-e2e