### PR TITLE
.golangci.yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,7 +92,7 @@ linters-settings:
   gocritic:
     # Settings passed to gocritic.
     # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
+    # The list of supported checkers can be find in https://go-critic.github.io/overview .
     settings:
       captLocal:
         # Whether to restrict checker to params only.


### PR DESCRIPTION
### Fix spacing issue in a comment for better link navigation

#### Description
- Added a space after the period in the comment to ensure the link (`https://go-critic.github.io/overview`) is properly clickable in rendered views.

#### Changes
- Adjusted the comment:  
  `# The list of supported checkers can be find in https://go-critic.github.io/overview.`  
  →  
  `# The list of supported checkers can be find in https://go-critic.github.io/overview .`

#### Impact
- Improves the usability of the link in the comment.

---
