### PR TITLE
fix(initchain): Enforce stricter handling on InitChain Requests

### DIFF
--- a/consensus/cometbft/service/init_chain.go
+++ b/consensus/cometbft/service/init_chain.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sourcegraph/conc/iter"
 )
 
-//nolint:gocognit // its fine.
 func (s *Service[LoggerT]) initChain(
 	ctx context.Context,
 	req *cmtabci.InitChainRequest,

--- a/consensus/cometbft/service/init_chain.go
+++ b/consensus/cometbft/service/init_chain.go
@@ -45,7 +45,7 @@ func (s *Service[LoggerT]) initChain(
 	}
 
 	// Enforce that request validators is zero. This is because Berachain derives the validators directly from
-	// deposits in the genesis file and disregards the validators in genesis file.
+	// deposits in the genesis file and disregards the validators in genesis file, which is what Comet uses.
 	if len(req.Validators) != 0 {
 		return nil, errors.New("expected no validators in initChain request")
 	}

--- a/consensus/cometbft/service/init_chain.go
+++ b/consensus/cometbft/service/init_chain.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
 	cmtabci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -46,7 +45,7 @@ func (s *Service[LoggerT]) initChain(
 	// Enforce that request validators is zero. This is because Berachain derives the validators directly from
 	// deposits in the genesis file and disregards the validators in genesis file, which is what Comet uses.
 	if len(req.Validators) != 0 {
-		return nil, errors.New("expected no validators in initChain request")
+		return nil, fmt.Errorf("expected no validators in initChain request but got %d", len(req.Validators))
 	}
 
 	var genesisState map[string]json.RawMessage


### PR DESCRIPTION
The original code for handling `[]ValidatorUpdate` was [copied](https://github.com/cosmos/cosmos-sdk/blob/e9b16a4eae13d5851eb12dd6eda77913c2951826/baseapp/abci.go#L116)  from CosmosSDK. In our case, the `ValidatorUpdate` list is ALWAYS expected to be 0 in initChain as we derive the validator set from the deposits directly in InitChain, which is the source of truth.

Therefore, we can remove the additional handling if the `len([]ValidatorUpdate) > 0` and simply enforce that it is always zero length, reducing confusion around its purpose 