### PR TITLE
fix: Fix supportsInterface function visibility to comply with ERC-165…

### DIFF
--- a/contracts/src/staking/IERC165.sol
+++ b/contracts/src/staking/IERC165.sol
@@ -11,6 +11,6 @@ interface ERC165 {
     ///  `interfaceId` is not 0xffffffff, `false` otherwise
     function supportsInterface(bytes4 interfaceId)
         external
-        pure
+        view
         returns (bool);
 }


### PR DESCRIPTION
I noticed that the `supportsInterface` function was incorrectly declared as `pure` instead of `view`.
According to the ERC-165 specification, this function should be `view` since it may read the contract's state (e.g., checking supported interfaces) but does not modify it.

This change ensures compliance with the standard.  
