### PR TITLE
chore(types): Set version

### DIFF
--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -66,12 +66,11 @@ func (s *Service) ProcessProposal(
 	}
 
 	// Decode signed block and sidecars.
-	signedBlk, sidecars, err := encoding.
-		ExtractBlobsAndBlockFromRequest(
-			req,
-			BeaconBlockTxIndex,
-			BlobSidecarsTxIndex,
-			s.chainSpec.ActiveForkVersionForSlot(math.Slot(req.Height))) // #nosec G115
+	signedBlk, sidecars, err := encoding.ExtractBlobsAndBlockFromRequest(
+		req,
+		BeaconBlockTxIndex,
+		BlobSidecarsTxIndex,
+		s.chainSpec.ActiveForkVersionForSlot(math.Slot(req.Height))) // #nosec G115
 	if err != nil {
 		return err
 	}

--- a/chain/helpers.go
+++ b/chain/helpers.go
@@ -34,7 +34,8 @@ func (s spec) ActiveForkVersionForSlot(slot math.Slot) uint32 {
 func (s spec) ActiveForkVersionForEpoch(epoch math.Epoch) uint32 {
 	if epoch >= s.ElectraForkEpoch() {
 		return version.Electra
-	} else if epoch >= s.Deneb1ForkEpoch() {
+	}
+	if epoch >= s.Deneb1ForkEpoch() {
 		return version.Deneb1
 	}
 	return version.Deneb

--- a/cli/commands/genesis/payload.go
+++ b/cli/commands/genesis/payload.go
@@ -183,6 +183,7 @@ func executableDataToExecutionPayloadHeader(
 			WithdrawalsRoot: withdrawals.HashTreeRoot(),
 			BlobGasUsed:     math.U64(blobGasUsed),
 			ExcessBlobGas:   math.U64(excessBlobGas),
+			EphVersion:      forkVersion,
 		}
 	default:
 		return nil, types.ErrForkVersionNotSupported

--- a/consensus-types/types/block.go
+++ b/consensus-types/types/block.go
@@ -33,6 +33,9 @@ import (
 // BeaconBlock represents a block in the beacon chain during
 // the Deneb fork.
 type BeaconBlock struct {
+	// version is the version of the beacon block.
+	version uint32
+
 	// Slot represents the position of the block in the chain.
 	Slot math.Slot `json:"slot"`
 	// ProposerIndex is the index of the validator who proposed the block.
@@ -41,14 +44,15 @@ type BeaconBlock struct {
 	ParentRoot common.Root `json:"parent_root"`
 	// StateRoot is the hash of the state at the block.
 	StateRoot common.Root `json:"state_root"`
-	// Body is the body of the BeaconBlock, containing the block's
-	// operations.
+	// Body is the body of the BeaconBlock, containing the block's operations.
 	Body *BeaconBlockBody `json:"body"`
 }
 
 // Empty creates an empty beacon block.
-func (*BeaconBlock) Empty() *BeaconBlock {
-	return &BeaconBlock{}
+func (*BeaconBlock) Empty(forkVersion uint32) *BeaconBlock {
+	return &BeaconBlock{
+		version: forkVersion,
+	}
 }
 
 // NewBeaconBlockWithVersion assembles a new beacon block from the given.
@@ -61,6 +65,7 @@ func NewBeaconBlockWithVersion(
 	switch forkVersion {
 	case version.Deneb, version.Deneb1:
 		return &BeaconBlock{
+			version:       forkVersion,
 			Slot:          slot,
 			ProposerIndex: proposerIndex,
 			ParentRoot:    parentBlockRoot,
@@ -147,7 +152,7 @@ func (b *BeaconBlock) GetStateRoot() common.Root {
 
 // Version identifies the version of the BeaconBlock.
 func (b *BeaconBlock) Version() uint32 {
-	return version.Deneb
+	return b.version
 }
 
 // SetStateRoot sets the state root of the BeaconBlock.

--- a/consensus-types/types/block.go
+++ b/consensus-types/types/block.go
@@ -49,9 +49,10 @@ type BeaconBlock struct {
 }
 
 // Empty creates an empty beacon block.
-func (*BeaconBlock) Empty(forkVersion uint32) *BeaconBlock {
+func (*BeaconBlock) Empty() *BeaconBlock {
 	return &BeaconBlock{
-		version: forkVersion,
+		// By default, we return a Deneb block to maintain compatibility.
+		version: version.Deneb,
 	}
 }
 

--- a/consensus-types/types/block.go
+++ b/consensus-types/types/block.go
@@ -33,9 +33,6 @@ import (
 // BeaconBlock represents a block in the beacon chain during
 // the Deneb fork.
 type BeaconBlock struct {
-	// version is the version of the beacon block.
-	version uint32
-
 	// Slot represents the position of the block in the chain.
 	Slot math.Slot `json:"slot"`
 	// ProposerIndex is the index of the validator who proposed the block.
@@ -46,12 +43,16 @@ type BeaconBlock struct {
 	StateRoot common.Root `json:"state_root"`
 	// Body is the body of the BeaconBlock, containing the block's operations.
 	Body *BeaconBlockBody `json:"body"`
+
+	// version is the version of the beacon block.
+	// version must be not serialized
+	version uint32
 }
 
 // Empty creates an empty beacon block.
 func (*BeaconBlock) Empty() *BeaconBlock {
 	return &BeaconBlock{
-		// By default, we set the version to Deneb to maintain compatibility.
+		// By default, we set the version to Deneb to maintain backward-compatibility.
 		version: version.Deneb,
 	}
 }
@@ -66,12 +67,12 @@ func NewBeaconBlockWithVersion(
 	switch forkVersion {
 	case version.Deneb, version.Deneb1:
 		return &BeaconBlock{
-			version:       forkVersion,
 			Slot:          slot,
 			ProposerIndex: proposerIndex,
 			ParentRoot:    parentBlockRoot,
 			StateRoot:     common.Root{},
 			Body:          &BeaconBlockBody{},
+			version:       forkVersion,
 		}, nil
 	default:
 		// we return block here to appease nilaway

--- a/consensus-types/types/block.go
+++ b/consensus-types/types/block.go
@@ -47,7 +47,7 @@ type BeaconBlock struct {
 	// BbVersion is the BbVersion of the beacon block.
 	// BbVersion must be not serialized but it's exported
 	// to allow unit tests using reflect on beacon block.
-	BbVersion uint32
+	BbVersion uint32 `json:"-"`
 }
 
 // Empty creates an empty beacon block.

--- a/consensus-types/types/block.go
+++ b/consensus-types/types/block.go
@@ -51,7 +51,7 @@ type BeaconBlock struct {
 // Empty creates an empty beacon block.
 func (*BeaconBlock) Empty() *BeaconBlock {
 	return &BeaconBlock{
-		// By default, we return a Deneb block to maintain compatibility.
+		// By default, we set the version to Deneb to maintain compatibility.
 		version: version.Deneb,
 	}
 }

--- a/consensus-types/types/block.go
+++ b/consensus-types/types/block.go
@@ -44,16 +44,17 @@ type BeaconBlock struct {
 	// Body is the body of the BeaconBlock, containing the block's operations.
 	Body *BeaconBlockBody `json:"body"`
 
-	// version is the version of the beacon block.
-	// version must be not serialized
-	version uint32
+	// BbVersion is the BbVersion of the beacon block.
+	// BbVersion must be not serialized but it's exported
+	// to allow unit tests using reflect on beacon block.
+	BbVersion uint32
 }
 
 // Empty creates an empty beacon block.
 func (*BeaconBlock) Empty() *BeaconBlock {
 	return &BeaconBlock{
 		// By default, we set the version to Deneb to maintain backward-compatibility.
-		version: version.Deneb,
+		BbVersion: version.Deneb,
 	}
 }
 
@@ -72,7 +73,7 @@ func NewBeaconBlockWithVersion(
 			ParentRoot:    parentBlockRoot,
 			StateRoot:     common.Root{},
 			Body:          &BeaconBlockBody{},
-			version:       forkVersion,
+			BbVersion:     forkVersion,
 		}, nil
 	default:
 		// we return block here to appease nilaway
@@ -154,7 +155,7 @@ func (b *BeaconBlock) GetStateRoot() common.Root {
 
 // Version identifies the version of the BeaconBlock.
 func (b *BeaconBlock) Version() uint32 {
-	return b.version
+	return b.BbVersion
 }
 
 // SetStateRoot sets the state root of the BeaconBlock.

--- a/consensus-types/types/block_test.go
+++ b/consensus-types/types/block_test.go
@@ -37,11 +37,12 @@ func generateValidBeaconBlock(t *testing.T) *types.BeaconBlock {
 	t.Helper()
 
 	// Initialize your block here
+	version := version.Deneb1
 	beaconBlock, err := types.NewBeaconBlockWithVersion(
 		math.Slot(10),
 		math.ValidatorIndex(5),
 		common.Root{1, 2, 3, 4, 5}, // parent block root
-		version.Deneb1,
+		version,
 	)
 	require.NoError(t, err)
 
@@ -60,6 +61,7 @@ func generateValidBeaconBlock(t *testing.T) *types.BeaconBlock {
 				{Index: 1, Amount: 200},
 			},
 			BaseFeePerGas: math.NewU256(0),
+			EpVersion:     version,
 		},
 		Eth1Data: &types.Eth1Data{},
 		Deposits: []*types.Deposit{
@@ -129,6 +131,7 @@ func TestBeaconBlock_MarshalUnmarshalSSZ(t *testing.T) {
 	err = unmarshalledBlock.UnmarshalSSZ(sszBlock)
 	require.NoError(t, err)
 
+	unmarshalledBlock.Body.ExecutionPayload.EpVersion = block.Version()
 	unmarshalledBlock.BbVersion = block.Version()
 	require.Equal(t, block, unmarshalledBlock)
 }

--- a/consensus-types/types/block_test.go
+++ b/consensus-types/types/block_test.go
@@ -100,7 +100,7 @@ func TestBeaconBlock(t *testing.T) {
 
 	require.NotNil(t, block.Body)
 	require.Equal(t, math.U64(10), block.GetTimestamp())
-	require.Equal(t, version.Deneb, block.Version())
+	require.Equal(t, version.Deneb1, block.Version())
 	require.False(t, block.IsNil())
 
 	// Set a new state root and test the SetStateRoot and GetBody methods
@@ -129,6 +129,7 @@ func TestBeaconBlock_MarshalUnmarshalSSZ(t *testing.T) {
 	err = unmarshalledBlock.UnmarshalSSZ(sszBlock)
 	require.NoError(t, err)
 
+	unmarshalledBlock.BbVersion = block.Version()
 	require.Equal(t, block, unmarshalledBlock)
 }
 

--- a/consensus-types/types/body_test.go
+++ b/consensus-types/types/body_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/berachain/beacon-kit/primitives/eip4844"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/math/log"
+	"github.com/berachain/beacon-kit/primitives/version"
 	"github.com/karalabe/ssz"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +44,7 @@ func generateBeaconBlockBody() types.BeaconBlockBody {
 		Deposits:     []*types.Deposit{},
 		ExecutionPayload: &types.ExecutionPayload{
 			BaseFeePerGas: math.NewU256(0),
+			EpVersion:     version.Deneb1,
 		},
 		BlobKzgCommitments: []eip4844.KZGCommitment{},
 	}
@@ -79,7 +81,7 @@ func TestBeaconBlockBody(t *testing.T) {
 		Eth1Data:           &types.Eth1Data{},
 		Graffiti:           [32]byte{4, 5, 6},
 		Deposits:           []*types.Deposit{},
-		ExecutionPayload:   &types.ExecutionPayload{},
+		ExecutionPayload:   (&types.ExecutionPayload{}).Empty(version.Deneb1),
 		BlobKzgCommitments: []eip4844.KZGCommitment{},
 	}
 
@@ -127,7 +129,7 @@ func TestBeaconBlockBody_MarshalSSZ(t *testing.T) {
 		Eth1Data:           &types.Eth1Data{},
 		Graffiti:           [32]byte{4, 5, 6},
 		Deposits:           []*types.Deposit{},
-		ExecutionPayload:   &types.ExecutionPayload{},
+		ExecutionPayload:   (&types.ExecutionPayload{}).Empty(version.Deneb1),
 		BlobKzgCommitments: []eip4844.KZGCommitment{},
 	}
 	data, err := body.MarshalSSZ()

--- a/consensus-types/types/genesis.go
+++ b/consensus-types/types/genesis.go
@@ -161,5 +161,6 @@ func DefaultGenesisExecutionPayloadHeader() (*ExecutionPayloadHeader, error) {
 		WithdrawalsRoot: engineprimitives.Withdrawals(nil).HashTreeRoot(),
 		BlobGasUsed:     0,
 		ExcessBlobGas:   0,
+		EphVersion:      constants.GenesisVersion,
 	}, nil
 }

--- a/consensus-types/types/payload.go
+++ b/consensus-types/types/payload.go
@@ -569,9 +569,10 @@ func (p *ExecutionPayload) GetExcessBlobGas() math.U64 {
 func (p *ExecutionPayload) ToHeader() (*ExecutionPayloadHeader, error) {
 	txsRoot := p.GetTransactions().HashTreeRoot()
 
-	switch p.Version() {
+	switch p.version {
 	case version.Deneb, version.Deneb1:
 		return &ExecutionPayloadHeader{
+			version:          p.version,
 			ParentHash:       p.ParentHash,
 			FeeRecipient:     p.GetFeeRecipient(),
 			StateRoot:        p.GetStateRoot(),

--- a/consensus-types/types/payload.go
+++ b/consensus-types/types/payload.go
@@ -76,7 +76,7 @@ type ExecutionPayload struct {
 	// EpVersion is the version of the execution payload.
 	// EpVersion must be not serialized, but it's exported
 	// to allow unit tests using reflect on execution payload.
-	EpVersion uint32
+	EpVersion uint32 `json:"-"`
 }
 
 /* -------------------------------------------------------------------------- */

--- a/consensus-types/types/payload.go
+++ b/consensus-types/types/payload.go
@@ -38,6 +38,9 @@ const ExecutionPayloadStaticSize uint32 = 528
 
 // ExecutionPayload represents the payload of an execution block.
 type ExecutionPayload struct {
+	// version is the version of the execution payload.
+	version uint32
+
 	// ParentHash is the hash of the parent block.
 	ParentHash common.ExecutionHash `json:"parentHash"`
 	// FeeRecipient is the address of the fee recipient.
@@ -454,13 +457,15 @@ func (p *ExecutionPayload) UnmarshalJSON(input []byte) error {
 }
 
 // Empty returns an empty ExecutionPayload for the given fork version.
-func (p *ExecutionPayload) Empty(_ uint32) *ExecutionPayload {
-	return &ExecutionPayload{}
+func (p *ExecutionPayload) Empty(forkVersion uint32) *ExecutionPayload {
+	return &ExecutionPayload{
+		version: forkVersion,
+	}
 }
 
 // Version returns the version of the ExecutionPayload.
 func (p *ExecutionPayload) Version() uint32 {
-	return version.Deneb
+	return p.version
 }
 
 // IsNil checks if the ExecutionPayload is nil.

--- a/consensus-types/types/payload_header.go
+++ b/consensus-types/types/payload_header.go
@@ -74,7 +74,9 @@ type ExecutionPayloadHeader struct {
 	// EphVersion is the fork EphVersion of the execution payload header.
 	// EphVersion must be not serialized but it's exported
 	// to allow unit tests using reflect on execution payload header.
-	EphVersion uint32
+	// TODO: Enable once
+	// https://github.com/karalabe/ssz/pull/9/files# is merged.
+	EphVersion uint32 `json:"-"`
 }
 
 // Empty returns an empty ExecutionPayloadHeader.

--- a/consensus-types/types/payload_header.go
+++ b/consensus-types/types/payload_header.go
@@ -26,6 +26,7 @@ import (
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
 	"github.com/berachain/beacon-kit/primitives/math"
+	"github.com/berachain/beacon-kit/primitives/version"
 	fastssz "github.com/ferranbt/fastssz"
 	"github.com/holiman/uint256"
 	"github.com/karalabe/ssz"
@@ -77,6 +78,8 @@ type ExecutionPayloadHeader struct {
 // Empty returns an empty ExecutionPayloadHeader.
 func (h *ExecutionPayloadHeader) Empty() *ExecutionPayloadHeader {
 	return &ExecutionPayloadHeader{
+		// By default, we set the version to Deneb to maintain compatibility.
+		version:       version.Deneb,
 		BaseFeePerGas: &uint256.Int{},
 	}
 }

--- a/consensus-types/types/payload_header.go
+++ b/consensus-types/types/payload_header.go
@@ -26,7 +26,6 @@ import (
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
 	"github.com/berachain/beacon-kit/primitives/math"
-	"github.com/berachain/beacon-kit/primitives/version"
 	fastssz "github.com/ferranbt/fastssz"
 	"github.com/holiman/uint256"
 	"github.com/karalabe/ssz"
@@ -34,13 +33,8 @@ import (
 
 // ExecutionPayloadHeader is the execution header payload of Deneb.
 type ExecutionPayloadHeader struct {
-	// TODO: Enable once
-	// https://github.com/karalabe/ssz/pull/9/files# is merged.
-	//
-	// // Metadata
-	// //
-	// // version is the fork version of the execution payload header.
-	// version uint32
+	// version is the fork version of the execution payload header.
+	version uint32
 
 	// Contents
 	//
@@ -80,7 +74,7 @@ type ExecutionPayloadHeader struct {
 	ExcessBlobGas math.U64 `json:"excessBlobGas"`
 }
 
-// Empty returns an empty ExecutionPayload for the given fork version.
+// Empty returns an empty ExecutionPayloadHeader.
 func (h *ExecutionPayloadHeader) Empty() *ExecutionPayloadHeader {
 	return &ExecutionPayloadHeader{
 		BaseFeePerGas: &uint256.Int{},
@@ -89,17 +83,19 @@ func (h *ExecutionPayloadHeader) Empty() *ExecutionPayloadHeader {
 
 // NewFromSSZ returns a new ExecutionPayloadHeader from the given SSZ bytes.
 func (h *ExecutionPayloadHeader) NewFromSSZ(
-	bz []byte, _ uint32,
+	bz []byte, forkVersion uint32,
 ) (*ExecutionPayloadHeader, error) {
 	h = h.Empty()
+	h.version = forkVersion
 	return h, h.UnmarshalSSZ(bz)
 }
 
 // NewFromJSON returns a new ExecutionPayloadHeader from the given JSON bytes.
 func (h *ExecutionPayloadHeader) NewFromJSON(
-	bz []byte, _ uint32,
+	bz []byte, forkVersion uint32,
 ) (*ExecutionPayloadHeader, error) {
 	h = h.Empty()
+	h.version = forkVersion
 	return h, json.Unmarshal(bz, h)
 }
 
@@ -448,7 +444,7 @@ func (h *ExecutionPayloadHeader) UnmarshalJSON(input []byte) error {
 
 // Version returns the version of the ExecutionPayloadHeader.
 func (h *ExecutionPayloadHeader) Version() uint32 {
-	return version.Deneb
+	return h.version
 }
 
 // IsNil checks if the ExecutionPayloadHeader is nil.

--- a/consensus-types/types/payload_header.go
+++ b/consensus-types/types/payload_header.go
@@ -453,16 +453,11 @@ func (h *ExecutionPayloadHeader) IsNil() bool {
 }
 
 // GetParentHash returns the parent hash of the ExecutionPayloadHeader.
-func (
-	h *ExecutionPayloadHeader,
-) GetParentHash() common.ExecutionHash {
+func (h *ExecutionPayloadHeader) GetParentHash() common.ExecutionHash {
 	return h.ParentHash
 }
 
-// GetFeeRecipient returns the fee recipient address of the
-// ExecutionPayloadHeader.
-//
-
+// GetFeeRecipient returns the fee recipient address of the ExecutionPayloadHeader.
 func (h *ExecutionPayloadHeader) GetFeeRecipient() common.ExecutionAddress {
 	return h.FeeRecipient
 }

--- a/consensus-types/types/payload_header.go
+++ b/consensus-types/types/payload_header.go
@@ -34,9 +34,6 @@ import (
 
 // ExecutionPayloadHeader is the execution header payload of Deneb.
 type ExecutionPayloadHeader struct {
-	// version is the fork version of the execution payload header.
-	version uint32
-
 	// Contents
 	//
 	// ParentHash is the hash of the parent block.
@@ -73,13 +70,18 @@ type ExecutionPayloadHeader struct {
 	BlobGasUsed math.U64 `json:"blobGasUsed"`
 	// ExcessBlobGas is the amount of excess blob gas in the block.
 	ExcessBlobGas math.U64 `json:"excessBlobGas"`
+
+	// EphVersion is the fork EphVersion of the execution payload header.
+	// EphVersion must be not serialized but it's exported
+	// to allow unit tests using reflect on execution payload header.
+	EphVersion uint32
 }
 
 // Empty returns an empty ExecutionPayloadHeader.
 func (h *ExecutionPayloadHeader) Empty() *ExecutionPayloadHeader {
 	return &ExecutionPayloadHeader{
 		// By default, we set the version to Deneb to maintain compatibility.
-		version:       version.Deneb,
+		EphVersion:    version.Deneb,
 		BaseFeePerGas: &uint256.Int{},
 	}
 }
@@ -89,7 +91,7 @@ func (h *ExecutionPayloadHeader) NewFromSSZ(
 	bz []byte, forkVersion uint32,
 ) (*ExecutionPayloadHeader, error) {
 	h = h.Empty()
-	h.version = forkVersion
+	h.EphVersion = forkVersion
 	return h, h.UnmarshalSSZ(bz)
 }
 
@@ -98,7 +100,7 @@ func (h *ExecutionPayloadHeader) NewFromJSON(
 	bz []byte, forkVersion uint32,
 ) (*ExecutionPayloadHeader, error) {
 	h = h.Empty()
-	h.version = forkVersion
+	h.EphVersion = forkVersion
 	return h, json.Unmarshal(bz, h)
 }
 
@@ -447,7 +449,7 @@ func (h *ExecutionPayloadHeader) UnmarshalJSON(input []byte) error {
 
 // Version returns the version of the ExecutionPayloadHeader.
 func (h *ExecutionPayloadHeader) Version() uint32 {
-	return h.version
+	return h.EphVersion
 }
 
 // IsNil checks if the ExecutionPayloadHeader is nil.

--- a/consensus-types/types/payload_header.go
+++ b/consensus-types/types/payload_header.go
@@ -102,8 +102,11 @@ func (h *ExecutionPayloadHeader) NewFromJSON(
 	bz []byte, forkVersion uint32,
 ) (*ExecutionPayloadHeader, error) {
 	h = h.Empty()
+	if err := json.Unmarshal(bz, h); err != nil {
+		return nil, err
+	}
 	h.EphVersion = forkVersion
-	return h, json.Unmarshal(bz, h)
+	return h, nil
 }
 
 /* -------------------------------------------------------------------------- */

--- a/consensus-types/types/payload_requests_test.go
+++ b/consensus-types/types/payload_requests_test.go
@@ -22,10 +22,12 @@ package types_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/berachain/beacon-kit/consensus-types/types"
 	engineprimitives "github.com/berachain/beacon-kit/engine-primitives/engine-primitives"
 	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,8 +53,16 @@ func TestBuildNewPayloadRequest(t *testing.T) {
 
 func TestBuildForkchoiceUpdateRequest(t *testing.T) {
 	state := &engineprimitives.ForkchoiceStateV1{}
-	payloadAttributes := &engineprimitives.PayloadAttributes{}
-	forkVersion := uint32(1)
+	forkVersion := version.Deneb1
+	payloadAttributes, err := engineprimitives.NewPayloadAttributes(
+		forkVersion,
+		uint64(time.Now().Truncate(time.Second).Unix()),
+		common.Bytes32{0x01},
+		common.ExecutionAddress{},
+		engineprimitives.Withdrawals{},
+		common.Root{},
+	)
+	require.NoError(t, err)
 
 	request := types.BuildForkchoiceUpdateRequest(
 		state,

--- a/consensus-types/types/payload_requests_test.go
+++ b/consensus-types/types/payload_requests_test.go
@@ -32,20 +32,22 @@ import (
 )
 
 func TestBuildNewPayloadRequest(t *testing.T) {
-	executionPayload := types.ExecutionPayload{}
-	var versionedHashes []common.ExecutionHash
-	parentBeaconBlockRoot := common.Root{}
-	optimistic := false
+	var (
+		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1)
+		versionedHashes       []common.ExecutionHash
+		parentBeaconBlockRoot = common.Root{}
+		optimistic            = false
+	)
 
 	request := types.BuildNewPayloadRequest(
-		&executionPayload,
+		executionPayload,
 		versionedHashes,
 		&parentBeaconBlockRoot,
 		optimistic,
 	)
 
 	require.NotNil(t, request)
-	require.Equal(t, executionPayload, *request.ExecutionPayload)
+	require.Equal(t, executionPayload, request.ExecutionPayload)
 	require.Equal(t, versionedHashes, request.VersionedHashes)
 	require.Equal(t, &parentBeaconBlockRoot, request.ParentBeaconBlockRoot)
 	require.Equal(t, optimistic, request.Optimistic)
@@ -88,13 +90,15 @@ func TestBuildGetPayloadRequest(t *testing.T) {
 }
 
 func TestHasValidVersionedAndBlockHashesPayloadError(t *testing.T) {
-	executionPayload := types.ExecutionPayload{}
-	versionedHashes := []common.ExecutionHash{}
-	parentBeaconBlockRoot := common.Root{}
-	optimistic := false
+	var (
+		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1)
+		versionedHashes       = []common.ExecutionHash{}
+		parentBeaconBlockRoot = common.Root{}
+		optimistic            = false
+	)
 
 	request := types.BuildNewPayloadRequest(
-		&executionPayload,
+		executionPayload,
 		versionedHashes,
 		&parentBeaconBlockRoot,
 		optimistic,
@@ -105,15 +109,15 @@ func TestHasValidVersionedAndBlockHashesPayloadError(t *testing.T) {
 }
 
 func TestHasValidVersionedAndBlockHashesMismatchedHashes(t *testing.T) {
-	executionPayload := types.ExecutionPayload{}
-	versionedHashes := []common.ExecutionHash{
-		{},
-	}
-	parentBeaconBlockRoot := common.Root{}
-	optimistic := false
+	var (
+		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1)
+		versionedHashes       = []common.ExecutionHash{{}}
+		parentBeaconBlockRoot = common.Root{}
+		optimistic            = false
+	)
 
 	request := types.BuildNewPayloadRequest(
-		&executionPayload,
+		executionPayload,
 		versionedHashes,
 		&parentBeaconBlockRoot,
 		optimistic,

--- a/consensus-types/types/payload_test.go
+++ b/consensus-types/types/payload_test.go
@@ -242,13 +242,9 @@ func TestExecutionPayload_ToHeader(t *testing.T) {
 	require.Equal(t, payload.GetBlockHash(), header.GetBlockHash())
 	require.Equal(t, payload.GetBlobGasUsed(), header.GetBlobGasUsed())
 	require.Equal(t, payload.GetExcessBlobGas(), header.GetExcessBlobGas())
+	require.Equal(t, payload.Version(), header.Version())
 
-	// TODO: FIX LATER
-	// htrHeader, err := header.HashTreeRoot()
-	// require.NoError(t, err)
-	// htrPayload, err := payload.HashTreeRoot()
-	// require.NoError(t, err)
-	// require.Equal(t, htrPayload, htrHeader)
+	require.Equal(t, payload.HashTreeRoot(), header.HashTreeRoot())
 }
 
 func TestExecutionPayload_UnmarshalJSON_Error(t *testing.T) {

--- a/consensus-types/types/signed_beacon_block.go
+++ b/consensus-types/types/signed_beacon_block.go
@@ -56,7 +56,11 @@ func NewSignedBeaconBlockFromSSZ(
 	block := &SignedBeaconBlock{}
 	switch forkVersion {
 	case version.Deneb, version.Deneb1:
-		return block, block.UnmarshalSSZ(bz)
+		if err := block.UnmarshalSSZ(bz); err != nil {
+			return block, err
+		}
+		block.Message.BbVersion = forkVersion
+		return block, nil
 	default:
 		// we return block here to appease nilaway
 		return block, errors.Wrap(

--- a/consensus-types/types/signed_beacon_block.go
+++ b/consensus-types/types/signed_beacon_block.go
@@ -59,6 +59,9 @@ func NewSignedBeaconBlockFromSSZ(
 		if err := block.UnmarshalSSZ(bz); err != nil {
 			return block, err
 		}
+
+		// duly setup fork version in every relevant block member
+		block.Message.Body.ExecutionPayload.EpVersion = forkVersion
 		block.Message.BbVersion = forkVersion
 		return block, nil
 	default:

--- a/consensus-types/types/signed_beacon_block_test.go
+++ b/consensus-types/types/signed_beacon_block_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/berachain/beacon-kit/node-core/components/signer"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/crypto"
-	"github.com/berachain/beacon-kit/primitives/version"
 	cmtcrypto "github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/bls12381"
 	"github.com/cometbft/cometbft/privval"
@@ -92,7 +91,7 @@ func TestNewSignedBeaconBlockFromSSZ(t *testing.T) {
 	require.NotNil(t, blockBytes)
 
 	newBlock, err := types.NewSignedBeaconBlockFromSSZ(
-		blockBytes, version.Deneb,
+		blockBytes, originalBlock.Message.Version(),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, newBlock)

--- a/consensus-types/types/signed_beacon_block_test.go
+++ b/consensus-types/types/signed_beacon_block_test.go
@@ -36,8 +36,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func generateFakeSignedBeaconBlock() *types.SignedBeaconBlock {
-	blk := generateValidBeaconBlock()
+func generateFakeSignedBeaconBlock(t *testing.T) *types.SignedBeaconBlock {
+	t.Helper()
+
+	blk := generateValidBeaconBlock(t)
 	signature := crypto.BLSSignature{}
 	return &types.SignedBeaconBlock{
 		Message:   blk,
@@ -63,8 +65,10 @@ func generateSigningRoot(blk *types.BeaconBlock) (common.Root, error) {
 	return signingRoot, nil
 }
 
-func generateRealSignedBeaconBlock(blsSigner crypto.BLSSigner) (*types.SignedBeaconBlock, error) {
-	blk := generateValidBeaconBlock()
+func generateRealSignedBeaconBlock(t *testing.T, blsSigner crypto.BLSSigner) (*types.SignedBeaconBlock, error) {
+	t.Helper()
+
+	blk := generateValidBeaconBlock(t)
 
 	signingRoot, err := generateSigningRoot(blk)
 	if err != nil {
@@ -82,7 +86,7 @@ func generateRealSignedBeaconBlock(blsSigner crypto.BLSSigner) (*types.SignedBea
 
 // TestNewSignedBeaconBlockFromSSZ tests the roundtrip SSZ encoding for Deneb.
 func TestNewSignedBeaconBlockFromSSZ(t *testing.T) {
-	originalBlock := generateFakeSignedBeaconBlock()
+	originalBlock := generateFakeSignedBeaconBlock(t)
 	blockBytes, err := originalBlock.MarshalSSZ()
 	require.NoError(t, err)
 	require.NotNil(t, blockBytes)
@@ -100,8 +104,8 @@ func TestNewSignedBeaconBlockFromSSZForkVersionNotSupported(t *testing.T) {
 	require.ErrorIs(t, err, types.ErrForkVersionNotSupported)
 }
 
-func TestSignedBeaconBlock_HashTreeRoot(_ *testing.T) {
-	sBlk := generateFakeSignedBeaconBlock()
+func TestSignedBeaconBlock_HashTreeRoot(t *testing.T) {
+	sBlk := generateFakeSignedBeaconBlock(t)
 	sBlk.HashTreeRoot()
 }
 
@@ -118,7 +122,7 @@ func TestSignedBeaconBlock_SignBeaconBlock(t *testing.T) {
 	blsSigner := signer.BLSSigner{PrivValidator: filePV}
 
 	// Generate real signed beacon block
-	signedBlk, err := generateRealSignedBeaconBlock(blsSigner)
+	signedBlk, err := generateRealSignedBeaconBlock(t, blsSigner)
 	require.NoError(t, err)
 	require.NotNil(t, signedBlk)
 
@@ -146,7 +150,7 @@ func TestSignedBeaconBlock_SignBeaconBlock(t *testing.T) {
 }
 
 func TestSignedBeaconBlock_SizeSSZ(t *testing.T) {
-	sBlk := generateFakeSignedBeaconBlock()
+	sBlk := generateFakeSignedBeaconBlock(t)
 	size := ssz.Size(sBlk)
 	require.Positive(t, size)
 }

--- a/da/types/sidecar_test.go
+++ b/da/types/sidecar_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/berachain/beacon-kit/primitives/eip4844"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/math/log"
+	"github.com/berachain/beacon-kit/primitives/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,39 +85,45 @@ func TestSidecarMarshalling(t *testing.T) {
 	)
 }
 
-func generateValidBeaconBlock() *ctypes.BeaconBlock {
+func generateValidBeaconBlock(t *testing.T) *ctypes.BeaconBlock {
+	t.Helper()
+
 	// Initialize your block here
-	beaconBlock := &ctypes.BeaconBlock{
-		Slot:          10,
-		ProposerIndex: 5,
-		ParentRoot:    common.Root{1, 2, 3, 4, 5},
-		StateRoot:     common.Root{5, 4, 3, 2, 1},
-		Body: &ctypes.BeaconBlockBody{
-			ExecutionPayload: &ctypes.ExecutionPayload{
-				Timestamp: 10,
-				ExtraData: []byte("dummy extra data for testing"),
-				Transactions: [][]byte{
-					[]byte("tx1"),
-					[]byte("tx2"),
-					[]byte("tx3"),
-				},
-				Withdrawals: engineprimitives.Withdrawals{
-					{Index: 0, Amount: 100},
-					{Index: 1, Amount: 200},
-				},
-				BaseFeePerGas: math.NewU256(0),
+	beaconBlock, err := ctypes.NewBeaconBlockWithVersion(
+		math.Slot(10),
+		math.ValidatorIndex(5),
+		common.Root{1, 2, 3, 4, 5}, // parent root
+		version.Deneb1,
+	)
+	require.NoError(t, err)
+
+	beaconBlock.StateRoot = common.Root{5, 4, 3, 2, 1}
+	beaconBlock.Body = &ctypes.BeaconBlockBody{
+		ExecutionPayload: &ctypes.ExecutionPayload{
+			Timestamp: 10,
+			ExtraData: []byte("dummy extra data for testing"),
+			Transactions: [][]byte{
+				[]byte("tx1"),
+				[]byte("tx2"),
+				[]byte("tx3"),
 			},
-			Eth1Data: &ctypes.Eth1Data{},
-			Deposits: []*ctypes.Deposit{
-				{
-					Index: 1,
-				},
+			Withdrawals: engineprimitives.Withdrawals{
+				{Index: 0, Amount: 100},
+				{Index: 1, Amount: 200},
 			},
-			BlobKzgCommitments: []eip4844.KZGCommitment{
-				{0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab}, {2}, {0x69},
+			BaseFeePerGas: math.NewU256(0),
+		},
+		Eth1Data: &ctypes.Eth1Data{},
+		Deposits: []*ctypes.Deposit{
+			{
+				Index: 1,
 			},
 		},
+		BlobKzgCommitments: []eip4844.KZGCommitment{
+			{0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab}, {2}, {0x69},
+		},
 	}
+
 	body := beaconBlock.GetBody()
 	body.SetProposerSlashings(ctypes.ProposerSlashings{})
 	body.SetAttesterSlashings(ctypes.AttesterSlashings{})
@@ -189,7 +196,7 @@ func TestHasValidInclusionProof(t *testing.T) {
 			name: "Valid inclusion proof",
 			sidecars: func(t *testing.T) types.BlobSidecars {
 				t.Helper()
-				block := generateValidBeaconBlock()
+				block := generateValidBeaconBlock(t)
 
 				sidecarFactory := blob.NewSidecarFactory(spec, sink)
 				numBlobs := len(block.GetBody().GetBlobKzgCommitments())

--- a/da/types/sidecar_test.go
+++ b/da/types/sidecar_test.go
@@ -89,11 +89,12 @@ func generateValidBeaconBlock(t *testing.T) *ctypes.BeaconBlock {
 	t.Helper()
 
 	// Initialize your block here
+	version := version.Deneb1
 	beaconBlock, err := ctypes.NewBeaconBlockWithVersion(
 		math.Slot(10),
 		math.ValidatorIndex(5),
 		common.Root{1, 2, 3, 4, 5}, // parent root
-		version.Deneb1,
+		version,
 	)
 	require.NoError(t, err)
 
@@ -112,6 +113,7 @@ func generateValidBeaconBlock(t *testing.T) *ctypes.BeaconBlock {
 				{Index: 1, Amount: 200},
 			},
 			BaseFeePerGas: math.NewU256(0),
+			EpVersion:     version,
 		},
 		Eth1Data: &ctypes.Eth1Data{},
 		Deposits: []*ctypes.Deposit{

--- a/engine-primitives/engine-primitives/attributes.go
+++ b/engine-primitives/engine-primitives/attributes.go
@@ -41,7 +41,8 @@ type PayloadAttributer interface {
 
 type PayloadAttributes struct {
 	// version is the version of the payload attributes.
-	version uint32 `json:"-"`
+	version uint32
+
 	// Timestamp is the timestamp at which the block will be built at.
 	Timestamp math.U64 `json:"timestamp"`
 	// PrevRandao is the previous Randao value from the beacon chain as

--- a/engine-primitives/engine-primitives/attributes.go
+++ b/engine-primitives/engine-primitives/attributes.go
@@ -58,9 +58,8 @@ type PayloadAttributes struct {
 	// EIP-4788.
 	ParentBeaconBlockRoot common.Root `json:"parentBeaconBlockRoot"`
 
-	// version is the version of the beacon block.
-	// version must be not serialized
-	version uint32
+	// version is the version of the payload attributes.
+	version uint32 `json:"-"`
 }
 
 // New empty PayloadAttributes.

--- a/engine-primitives/engine-primitives/attributes.go
+++ b/engine-primitives/engine-primitives/attributes.go
@@ -40,9 +40,6 @@ type PayloadAttributer interface {
 //
 
 type PayloadAttributes struct {
-	// version is the version of the payload attributes.
-	version uint32
-
 	// Timestamp is the timestamp at which the block will be built at.
 	Timestamp math.U64 `json:"timestamp"`
 	// PrevRandao is the previous Randao value from the beacon chain as
@@ -60,6 +57,10 @@ type PayloadAttributes struct {
 	// to the block currently being processed. This field was added for
 	// EIP-4788.
 	ParentBeaconBlockRoot common.Root `json:"parentBeaconBlockRoot"`
+
+	// version is the version of the beacon block.
+	// version must be not serialized
+	version uint32
 }
 
 // New empty PayloadAttributes.
@@ -72,12 +73,12 @@ func NewPayloadAttributes(
 	parentBeaconBlockRoot common.Root,
 ) (*PayloadAttributes, error) {
 	pa := &PayloadAttributes{
-		version:               forkVersion,
 		Timestamp:             math.U64(timestamp),
 		PrevRandao:            prevRandao,
 		SuggestedFeeRecipient: suggestedFeeRecipient,
 		Withdrawals:           withdrawals,
 		ParentBeaconBlockRoot: parentBeaconBlockRoot,
+		version:               forkVersion,
 	}
 
 	if err := pa.Validate(); err != nil {
@@ -93,9 +94,7 @@ func (p *PayloadAttributes) IsNil() bool {
 }
 
 // GetSuggestedFeeRecipient returns the suggested fee recipient.
-func (
-	p *PayloadAttributes,
-) GetSuggestedFeeRecipient() common.ExecutionAddress {
+func (p *PayloadAttributes) GetSuggestedFeeRecipient() common.ExecutionAddress {
 	return p.SuggestedFeeRecipient
 }
 

--- a/execution/client/ethclient/engine.go
+++ b/execution/client/ethclient/engine.go
@@ -47,13 +47,13 @@ func (s *Client) NewPayload(
 	// comparison and drop this check here. The EL does not know
 	// anything about CL versions, so payload should not have a
 	// CL version (or at least not a check here).
-	if payload.Version() < version.Deneb1 {
-		return nil, ErrInvalidVersion
+	if payload.Version() == version.Deneb ||
+		payload.Version() == version.Deneb1 {
+		return s.NewPayloadV3(
+			ctx, payload, versionedHashes, parentBlockRoot,
+		)
 	}
-
-	return s.NewPayloadV3(
-		ctx, payload, versionedHashes, parentBlockRoot,
-	)
+	return nil, ErrInvalidVersion
 }
 
 // NewPayloadV3 is used to call the underlying JSON-RPC method for newPayload.

--- a/execution/client/ethclient/engine.go
+++ b/execution/client/ethclient/engine.go
@@ -42,7 +42,12 @@ func (s *Client) NewPayload(
 	versionedHashes []common.ExecutionHash,
 	parentBlockRoot *common.Root,
 ) (*engineprimitives.PayloadStatusV1, error) {
-	if payload.Version() < version.Deneb {
+	// This is wrong. We should do bytes comparison of versions
+	// Setting this to version.Deneb1 but we should fix version
+	// comparison and drop this check here. The EL does not know
+	// anything about CL versions, so payload should not have a
+	// CL version (or at least not a check here).
+	if payload.Version() < version.Deneb1 {
 		return nil, ErrInvalidVersion
 	}
 

--- a/state-transition/core/core_test.go
+++ b/state-transition/core/core_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/transition"
+	"github.com/berachain/beacon-kit/primitives/version"
 	statetransition "github.com/berachain/beacon-kit/testing/state-transition"
 	"github.com/stretchr/testify/require"
 )
@@ -87,13 +88,14 @@ func buildNextBlock(
 	parentBlkHeader.SetStateRoot(root)
 
 	// finally build the block
-	return &types.BeaconBlock{
-		Slot:          parentBlkHeader.GetSlot() + 1,
-		ProposerIndex: parentBlkHeader.GetProposerIndex(),
-		ParentRoot:    parentBlkHeader.HashTreeRoot(),
-		StateRoot:     common.Root{},
-		Body:          nextBlkBody,
-	}
+	blk, err := types.NewBeaconBlockWithVersion(
+		parentBlkHeader.GetSlot()+1,
+		parentBlkHeader.GetProposerIndex(),
+		parentBlkHeader.HashTreeRoot(),
+		version.Deneb1,
+	)
+	require.NoError(t, err)
+	return blk
 }
 
 func generateTestExecutionAddress(

--- a/state-transition/core/state_processor_genesis.go
+++ b/state-transition/core/state_processor_genesis.go
@@ -65,6 +65,7 @@ func (sp *StateProcessor[_]) InitializePreminedBeaconStateFromEth1(
 		Eth1Data: &ctypes.Eth1Data{},
 		ExecutionPayload: &ctypes.ExecutionPayload{
 			ExtraData: make([]byte, ctypes.ExtraDataSize),
+			EpVersion: constants.GenesisVersion,
 		},
 	}
 

--- a/state-transition/core/state_processor_payload.go
+++ b/state-transition/core/state_processor_payload.go
@@ -37,7 +37,7 @@ func (sp *StateProcessor[ContextT]) processExecutionPayload(
 	var (
 		body    = blk.GetBody()
 		payload = body.GetExecutionPayload()
-		header  *ctypes.ExecutionPayloadHeader
+		header  = &ctypes.ExecutionPayloadHeader{} // appeases nilaway
 		g, gCtx = errgroup.WithContext(ctx)
 	)
 

--- a/state-transition/core/state_processor_staking_test.go
+++ b/state-transition/core/state_processor_staking_test.go
@@ -101,15 +101,10 @@ func TestTransitionUpdateValidators(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{blkDeposit},
 		},
@@ -152,15 +147,10 @@ func TestTransitionUpdateValidators(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -240,15 +230,10 @@ func TestTransitionCreateValidator(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{blkDeposit},
 		},
@@ -292,15 +277,10 @@ func TestTransitionCreateValidator(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -336,15 +316,10 @@ func TestTransitionCreateValidator(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -429,27 +404,25 @@ func TestTransitionWithdrawals(t *testing.T) {
 	require.Equal(t, maxBalance+minBalance, val1Bal)
 
 	// Create test inputs.
+	withdrawals := []*engineprimitives.Withdrawal{
+		// The first withdrawal is always for EVM inflation.
+		st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
+		// Partially withdraw validator 1 by minBalance.
+		{
+			Index:     0,
+			Validator: 1,
+			Amount:    minBalance,
+			Address:   address1,
+		},
+	}
 	blk := buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					// The first withdrawal is always for EVM inflation.
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-					// Partially withdraw validator 1 by minBalance.
-					{
-						Index:     0,
-						Validator: 1,
-						Amount:    minBalance,
-						Address:   address1,
-					},
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				withdrawals...,
+			),
 			Eth1Data: types.NewEth1Data(genDeposits.HashTreeRoot()),
 			Deposits: []*types.Deposit{},
 		},
@@ -523,29 +496,24 @@ func TestTransitionMaxWithdrawals(t *testing.T) {
 
 	// Create test inputs.
 	depRoot := genDeposits.HashTreeRoot()
+	withdrawals := []*engineprimitives.Withdrawal{
+		// The first withdrawal is always for EVM inflation.
+		st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
+		// Partially withdraw validator 0 by minBalance.
+		{
+			Index:     0,
+			Validator: 0,
+			Amount:    minBalance,
+			Address:   address0,
+		},
+	}
 	blk := buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					// The first withdrawal is always for EVM inflation.
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-					// Partially withdraw validator 0 by minBalance.
-					{
-						Index:     0,
-						Validator: 0,
-						Amount:    minBalance,
-						Address:   address0,
-					},
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
-			Eth1Data: types.NewEth1Data(depRoot),
-			Deposits: []*types.Deposit{},
+			ExecutionPayload: testPayload(10, withdrawals...),
+			Eth1Data:         types.NewEth1Data(depRoot),
+			Deposits:         []*types.Deposit{},
 		},
 	)
 
@@ -569,27 +537,26 @@ func TestTransitionMaxWithdrawals(t *testing.T) {
 	// Process the next block, ensuring that validator 1 is also withdrawn from,
 	// also ensuring that the state's next withdrawal (validator) index is
 	// appropriately incremented.
+
+	withdrawals = []*engineprimitives.Withdrawal{
+		// The first withdrawal is always for EVM inflation.
+		st.EVMInflationWithdrawal(blk.GetSlot() + 1),
+		// Partially withdraw validator 1 by minBalance.
+		{
+			Index:     1,
+			Validator: 1,
+			Amount:    minBalance,
+			Address:   address1,
+		},
+	}
 	blk = buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    11,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					// The first withdrawal is always for EVM inflation.
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-					// Partially withdraw validator 1 by minBalance.
-					{
-						Index:     1,
-						Validator: 1,
-						Amount:    minBalance,
-						Address:   address1,
-					},
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				withdrawals...,
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -675,15 +642,10 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{extraValDeposit},
 		},
@@ -720,22 +682,17 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 
 	// STEP 2: move the chain to the next epoch and show that
 	// the extra validator is eligible for activation
-	_ = moveToEndOfEpoch(t, blk1, cs, sp, st, ctx, depRoot)
+	blk := moveToEndOfEpoch(t, blk1, cs, sp, st, ctx, depRoot)
 
 	// finally the block turning epoch
-	blk := buildNextBlock(
+	blk = buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk1.GetSlot()),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -764,22 +721,17 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 
 	// STEP 3: move the chain to the next epoch and show that the extra
 	// validator is activate and immediately marked for exit
-	_ = moveToEndOfEpoch(t, blk, cs, sp, st, ctx, depRoot)
+	blk = moveToEndOfEpoch(t, blk, cs, sp, st, ctx, depRoot)
 
 	// finally the block turning epoch
 	blk = buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -799,7 +751,7 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 
 	// STEP 4: move the chain to the next epoch and show withdrawals
 	// for rejected validator are enqueued then
-	_ = moveToEndOfEpoch(t, blk, cs, sp, st, ctx, depRoot)
+	blk = moveToEndOfEpoch(t, blk, cs, sp, st, ctx, depRoot)
 
 	// finally the block turning epoch. extra validator deposits
 	// will be withdrawn within 3 blocks (#Validator / MaxValidatorsPerWithdrawalsSweep)
@@ -809,15 +761,10 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -829,15 +776,10 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -845,25 +787,23 @@ func TestTransitionHittingValidatorsCap_ExtraSmall(t *testing.T) {
 	_, err = sp.Transition(ctx, st, blk)
 	require.NoError(t, err)
 
+	withdrawals := []*engineprimitives.Withdrawal{
+		st.EVMInflationWithdrawal(blk.GetSlot() + 1),
+		{
+			Index:     0,
+			Validator: extraValIdx,
+			Address:   extraValAddr,
+			Amount:    extraValDeposit.Amount,
+		},
+	}
 	blk = buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-					{
-						Index:     0,
-						Validator: extraValIdx,
-						Address:   extraValAddr,
-						Amount:    extraValDeposit.Amount,
-					},
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				withdrawals...,
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -944,15 +884,10 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{extraValDeposit},
 		},
@@ -1006,22 +941,17 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 
 	// STEP 2: move the chain to the next epoch and show that
 	// the extra validator is eligible for activation
-	_ = moveToEndOfEpoch(t, blk1, cs, sp, st, ctx, depRoot)
+	blk := moveToEndOfEpoch(t, blk1, cs, sp, st, ctx, depRoot)
 
 	// finally the block turning epoch
-	blk := buildNextBlock(
+	blk = buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk1.GetSlot()),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -1065,22 +995,17 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 
 	// STEP 3: move the chain to the next epoch and show that the extra
 	// validator is activate and genesis validator immediately marked for exit
-	_ = moveToEndOfEpoch(t, blk, cs, sp, st, ctx, depRoot)
+	blk = moveToEndOfEpoch(t, blk, cs, sp, st, ctx, depRoot)
 
 	// finally the block turning epoch
 	blk = buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -1139,15 +1064,10 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -1159,15 +1079,10 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				st.EVMInflationWithdrawal(blk.GetSlot()),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -1175,25 +1090,23 @@ func TestTransitionHittingValidatorsCap_ExtraBig(t *testing.T) {
 	_, err = sp.Transition(ctx, st, blk)
 	require.NoError(t, err)
 
+	withdrawals := []*engineprimitives.Withdrawal{
+		st.EVMInflationWithdrawal(blk.GetSlot() + 1),
+		{
+			Index:     0,
+			Validator: smallestValIdx,
+			Address:   valToEvictAddr,
+			Amount:    valToEvict.Amount,
+		},
+	}
 	blk = buildNextBlock(
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    blk1.Body.ExecutionPayload.Timestamp + 1,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(blk.GetSlot() + 1),
-					{
-						Index:     0,
-						Validator: smallestValIdx,
-						Address:   valToEvictAddr,
-						Amount:    valToEvict.Amount,
-					},
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				blk.Body.ExecutionPayload.Timestamp+1,
+				withdrawals...,
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{},
 		},
@@ -1249,15 +1162,10 @@ func TestValidatorNotWithdrawable(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: blockDeposits,
 		},

--- a/state-transition/core/validation_deposits_test.go
+++ b/state-transition/core/validation_deposits_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/berachain/beacon-kit/chain"
 	"github.com/berachain/beacon-kit/config/spec"
 	"github.com/berachain/beacon-kit/consensus-types/types"
-	engineprimitives "github.com/berachain/beacon-kit/engine-primitives/engine-primitives"
 	"github.com/berachain/beacon-kit/primitives/bytes"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/constants"
@@ -93,15 +92,10 @@ func TestInvalidDeposits(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: []*types.Deposit{invalidDeposit},
 		},
@@ -166,15 +160,10 @@ func TestInvalidDepositsCount(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: correctDeposits,
 		},
@@ -236,15 +225,10 @@ func TestLocalDepositsExceedBlockDeposits(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(depRoot),
 			Deposits: blockDeposits,
 		},
@@ -320,15 +304,10 @@ func TestLocalDepositsExceedBlockDepositsBadRoot(t *testing.T) {
 		t,
 		st,
 		&types.BeaconBlockBody{
-			ExecutionPayload: &types.ExecutionPayload{
-				Timestamp:    10,
-				ExtraData:    []byte("testing"),
-				Transactions: [][]byte{},
-				Withdrawals: []*engineprimitives.Withdrawal{
-					st.EVMInflationWithdrawal(constants.GenesisSlot + 1),
-				},
-				BaseFeePerGas: math.NewU256(0),
-			},
+			ExecutionPayload: testPayload(
+				10,
+				st.EVMInflationWithdrawal(constants.GenesisSlot+1),
+			),
 			Eth1Data: types.NewEth1Data(badDepRoot),
 			Deposits: blockDeposits,
 		},


### PR DESCRIPTION
There are a few objects which:

- we build passing a Version
- have a Version method, which currently returns Deneb

We are now introducing Deneb1, so these objects should:
- either return the right version in Version
- or have no Version method anymore


This PR attempt to do the first alternative (fix Version)

Open issues:

- we do not serialize version for backward compatibility reaons, which means that the simple checks were we serialize and deserialize an object fails due to version not being set.
  - My idea for this is that the client which does deserialization should know what is the right version and set it once the deserialization succeed. Not sure client can guarantee this.