### PR TITLE
fix(signing): Correctly calculate domain based on block slot

### DIFF
--- a/state-transition/core/state_processor_sidecars.go
+++ b/state-transition/core/state_processor_sidecars.go
@@ -37,10 +37,8 @@ func (sp *StateProcessor[_]) GetSignatureVerifierFn(st *statedb.StateDB) (
 	}
 
 	return func(blk *ctypes.BeaconBlock, signature crypto.BLSSignature) error {
-		blockSlot := blk.GetSlot()
-		epoch := sp.cs.SlotToEpoch(blockSlot)
 		fd := ctypes.NewForkData(
-			bytes.FromUint32(sp.cs.ActiveForkVersionForEpoch(epoch)), genesisValidatorsRoot,
+			bytes.FromUint32(sp.cs.ActiveForkVersionForSlot(blk.GetSlot())), genesisValidatorsRoot,
 		)
 		domain := fd.ComputeDomain(sp.cs.DomainTypeProposer())
 

--- a/state-transition/core/state_processor_sidecars.go
+++ b/state-transition/core/state_processor_sidecars.go
@@ -31,23 +31,19 @@ func (sp *StateProcessor[_]) GetSignatureVerifierFn(st *statedb.StateDB) (
 	func(blk *ctypes.BeaconBlock, signature crypto.BLSSignature) error,
 	error,
 ) {
-	slot, err := st.GetSlot()
-	if err != nil {
-		return nil, err
-	}
-	epoch := sp.cs.SlotToEpoch(slot)
-
 	genesisValidatorsRoot, err := st.GetGenesisValidatorsRoot()
 	if err != nil {
 		return nil, err
 	}
 
-	fd := ctypes.NewForkData(
-		bytes.FromUint32(sp.cs.ActiveForkVersionForEpoch(epoch)), genesisValidatorsRoot,
-	)
-	domain := fd.ComputeDomain(sp.cs.DomainTypeProposer())
-
 	return func(blk *ctypes.BeaconBlock, signature crypto.BLSSignature) error {
+		blockSlot := blk.GetSlot()
+		epoch := sp.cs.SlotToEpoch(blockSlot)
+		fd := ctypes.NewForkData(
+			bytes.FromUint32(sp.cs.ActiveForkVersionForEpoch(epoch)), genesisValidatorsRoot,
+		)
+		domain := fd.ComputeDomain(sp.cs.DomainTypeProposer())
+
 		//nolint:govet // shadow
 		proposer, err := st.ValidatorByIndex(blk.GetProposerIndex())
 		if err != nil {


### PR DESCRIPTION
Currently, the slot retrieved from state is behind the block slot in `GetSignatureVerifierFn`. This causes signature verification to fail on hard fork as the computed domain in signature verification does not match the computed domain in signing. 
This fixes it.