### PR TITLE
refactor(deposits): Modularize Deposit Command for Easier Testing in Runtime

### DIFF
--- a/cli/commands/genesis/deposit.go
+++ b/cli/commands/genesis/deposit.go
@@ -77,14 +77,13 @@ func AddGenesisDepositCmd(cs chain.Spec) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
 			return AddGenesisDeposit(cs, cometConfig, blsSigner, depositAmount, withdrawalAddress, outputDocument)
 		},
 	}
 	return cmd
 }
 
-// AddGenesisDeposit is the modularized version of AddGenesisDepositCmd that can be properly tested from within the runtime
+// AddGenesisDeposit is the modularized version of AddGenesisDepositCmd that can be properly tested from within the runtime.
 func AddGenesisDeposit(
 	cs chain.Spec,
 	cometConfig *cmtcfg.Config,

--- a/cli/commands/genesis/deposit_test.go
+++ b/cli/commands/genesis/deposit_test.go
@@ -1,6 +1,7 @@
 package genesis_test
 
 import (
+	"path"
 	"testing"
 
 	"github.com/berachain/beacon-kit/cli/commands/genesis"
@@ -37,6 +38,10 @@ func TestGenesisDeposit(t *testing.T) {
 	blsSigner := signer.BLSSigner{PrivValidator: types.NewMockPVWithKeyType(bls12381.KeyType)}
 
 	err = genesis.AddGenesisDeposit(chainSpec, cometConfig, blsSigner, depositAmount, withdrawalAdress, outputDocument)
-
 	require.NoError(t, err)
+
+	require.FileExists(t, path.Join(homeDir, "nodekey.json"))
+	require.FileExists(t, path.Join(homeDir, "data", "priv_validator_state.json"))
+	require.FileExists(t, path.Join(homeDir, "config", "priv_validator_key.json"))
+	require.DirExists(t, path.Join(homeDir, "config", "premined-deposits"))
 }

--- a/cli/commands/genesis/deposit_test.go
+++ b/cli/commands/genesis/deposit_test.go
@@ -1,0 +1,26 @@
+package genesis
+
+import (
+	"testing"
+
+	"github.com/berachain/beacon-kit/config/spec"
+	"github.com/berachain/beacon-kit/node-core/components/signer"
+	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/math"
+	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisDeposit(t *testing.T) {
+	chainSpec, err := spec.DevnetChainSpec()
+	require.NoError(t, err)
+
+	cometConfig := cmtcfg.DefaultConfig()
+	depositAmount := math.Gwei(32000000000)
+	withdrawalAdress := common.NewExecutionAddressFromHex("0x981114102592310C347E61368342DDA67017bf84")
+	outputDocument := ""
+
+	blsSigner := signer.NewBLSSigner(privValKeyFile, privValStateFile)
+	err = AddGenesisDeposit(chainSpec, cometConfig, blsSigner, depositAmount, withdrawalAdress, outputDocument)
+	require.NoError(t, err)
+}

--- a/cli/commands/genesis/deposit_test.go
+++ b/cli/commands/genesis/deposit_test.go
@@ -1,26 +1,42 @@
-package genesis
+package genesis_test
 
 import (
 	"testing"
 
+	"github.com/berachain/beacon-kit/cli/commands/genesis"
 	"github.com/berachain/beacon-kit/config/spec"
 	"github.com/berachain/beacon-kit/node-core/components/signer"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
+	"github.com/berachain/beacon-kit/testing/utils"
 	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/bls12381"
+	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenesisDeposit(t *testing.T) {
+	homeDir := utils.MakeTempHomeDir(t)
+	t.Log("Home folder:", homeDir)
+	defer utils.DeleteTempHomeDir(t, homeDir)
+
 	chainSpec, err := spec.DevnetChainSpec()
 	require.NoError(t, err)
 
 	cometConfig := cmtcfg.DefaultConfig()
+
+	cometConfig.SetRoot(homeDir)
+
+	// Forces Comet to Create it
+	cometConfig.NodeKey = "nodekey.json"
+
 	depositAmount := math.Gwei(32000000000)
 	withdrawalAdress := common.NewExecutionAddressFromHex("0x981114102592310C347E61368342DDA67017bf84")
 	outputDocument := ""
 
-	blsSigner := signer.NewBLSSigner(privValKeyFile, privValStateFile)
-	err = AddGenesisDeposit(chainSpec, cometConfig, blsSigner, depositAmount, withdrawalAdress, outputDocument)
+	blsSigner := signer.BLSSigner{PrivValidator: types.NewMockPVWithKeyType(bls12381.KeyType)}
+
+	err = genesis.AddGenesisDeposit(chainSpec, cometConfig, blsSigner, depositAmount, withdrawalAdress, outputDocument)
+
 	require.NoError(t, err)
 }

--- a/testing/utils/homedir.go
+++ b/testing/utils/homedir.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func MakeTempHomeDir(t *testing.T) string {
+	t.Helper()
+	// create random suffix to avoid conflicts
+	const rndSuffixLen = 5
+	bytes := make([]byte, rndSuffixLen)
+	_, err := rand.Read(bytes)
+	require.NoError(t, err)
+
+	rndSuffix := hex.EncodeToString(bytes)
+
+	tmpFolder := filepath.Join(os.TempDir(), "/injected-consensus", rndSuffix)
+	require.NoError(t, os.MkdirAll(tmpFolder, os.ModePerm))
+	return tmpFolder
+}
+
+func DeleteTempHomeDir(t *testing.T, homedir string) {
+	t.Helper()
+	err := os.RemoveAll(homedir)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR contributes towards the [Godzilla PR](https://github.com/berachain/beacon-kit/pull/2411) by modularisiing the deposits function so that it can be realistically called in an active runtime. This is proven through the unit test added. 