### PR TITLE
refactor(deposit-storage): Refactor set-deposit-storage and execution-payload to be callable in Runtime

### DIFF
--- a/cli/commands/genesis/payload.go
+++ b/cli/commands/genesis/payload.go
@@ -34,6 +34,7 @@ import (
 	"github.com/berachain/beacon-kit/primitives/constants"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
 	"github.com/berachain/beacon-kit/primitives/math"
+	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/spf13/afero"
@@ -47,78 +48,82 @@ func AddExecutionPayloadCmd(chainSpec chain.Spec) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Read the genesis file.
-			genesisBz, err := afero.ReadFile(afero.NewOsFs(), args[0])
-			if err != nil {
-				return errors.Wrap(err, "failed to read eth1 genesis file")
-			}
-
-			// Unmarshal the genesis file.
-			ethGenesis := &gethprimitives.Genesis{}
-			if err = ethGenesis.UnmarshalJSON(genesisBz); err != nil {
-				return errors.Wrap(err, "failed to unmarshal eth1 genesis")
-			}
-			genesisBlock := ethGenesis.ToBlock()
-
-			// Create the execution payload.
-			payload := gethprimitives.BlockToExecutableData(
-				genesisBlock,
-				nil,
-				nil,
-				nil,
-			).ExecutionPayload
-
+			elGenesisPath := args[0]
 			config := context.GetConfigFromCmd(cmd)
-
-			appGenesis, err := genutiltypes.AppGenesisFromFile(
-				config.GenesisFile(),
-			)
-			if err != nil {
-				return errors.Wrap(err, "failed to read genesis doc from file")
-			}
-
-			// create the app state
-			appGenesisState, err := genutiltypes.GenesisStateFromAppGenesis(
-				appGenesis,
-			)
-			if err != nil {
-				return err
-			}
-
-			genesisInfo := &types.Genesis{}
-
-			if err = json.Unmarshal(
-				appGenesisState["beacon"], genesisInfo,
-			); err != nil {
-				return errors.Wrap(err, "failed to unmarshal beacon state")
-			}
-
-			// Inject the execution payload.
-			genesisInfo.ExecutionPayloadHeader, err =
-				executableDataToExecutionPayloadHeader(
-					genesisInfo.ForkVersion.ToUint32(),
-					payload,
-					chainSpec.MaxWithdrawalsPerPayload(),
-				)
-			if err != nil {
-				return errors.Wrap(err, "failed to unmarshal beacon state")
-			}
-
-			appGenesisState["beacon"], err = json.Marshal(genesisInfo)
-			if err != nil {
-				return errors.Wrap(err, "failed to marshal beacon state")
-			}
-
-			if appGenesis.AppState, err = json.MarshalIndent(
-				appGenesisState, "", "  ",
-			); err != nil {
-				return err
-			}
-
-			return genutil.ExportGenesisFile(appGenesis, config.GenesisFile())
+			return AddExecutionPayload(chainSpec, elGenesisPath, config)
 		},
 	}
 
 	return cmd
+}
+
+func AddExecutionPayload(chainSpec chain.Spec, elGenesisPath string, config *cmtcfg.Config) error {
+	genesisBz, err := afero.ReadFile(afero.NewOsFs(), elGenesisPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to read eth1 genesis file")
+	}
+
+	// Unmarshal the genesis file.
+	ethGenesis := &gethprimitives.Genesis{}
+	if err = ethGenesis.UnmarshalJSON(genesisBz); err != nil {
+		return errors.Wrap(err, "failed to unmarshal eth1 genesis")
+	}
+	genesisBlock := ethGenesis.ToBlock()
+
+	// Create the execution payload.
+	payload := gethprimitives.BlockToExecutableData(
+		genesisBlock,
+		nil,
+		nil,
+		nil,
+	).ExecutionPayload
+
+	appGenesis, err := genutiltypes.AppGenesisFromFile(
+		config.GenesisFile(),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to read genesis doc from file")
+	}
+
+	// create the app state
+	appGenesisState, err := genutiltypes.GenesisStateFromAppGenesis(
+		appGenesis,
+	)
+	if err != nil {
+		return err
+	}
+
+	genesisInfo := &types.Genesis{}
+
+	if err = json.Unmarshal(
+		appGenesisState["beacon"], genesisInfo,
+	); err != nil {
+		return errors.Wrap(err, "failed to unmarshal beacon state")
+	}
+
+	// Inject the execution payload.
+	genesisInfo.ExecutionPayloadHeader, err =
+		executableDataToExecutionPayloadHeader(
+			genesisInfo.ForkVersion.ToUint32(),
+			payload,
+			chainSpec.MaxWithdrawalsPerPayload(),
+		)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal beacon state")
+	}
+
+	appGenesisState["beacon"], err = json.Marshal(genesisInfo)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal beacon state")
+	}
+
+	if appGenesis.AppState, err = json.MarshalIndent(
+		appGenesisState, "", "  ",
+	); err != nil {
+		return err
+	}
+
+	return genutil.ExportGenesisFile(appGenesis, config.GenesisFile())
 }
 
 // Converts the eth executable data type to the beacon execution payload header

--- a/cli/commands/genesis/storage.go
+++ b/cli/commands/genesis/storage.go
@@ -40,6 +40,8 @@ import (
 )
 
 // SetDepositStorageCmd sets deposit contract storage in genesis alloc file.
+//
+//nolint:lll // reads better if long description is one line
 func SetDepositStorageCmd(chainSpec chain.Spec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-deposit-storage [eth/genesis/file.json]",

--- a/cli/commands/genesis/storage.go
+++ b/cli/commands/genesis/storage.go
@@ -32,15 +32,14 @@ import (
 	gethprimitives "github.com/berachain/beacon-kit/geth-primitives"
 	libcommon "github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
+	cmtcfg "github.com/cometbft/cometbft/config"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-// Set deposit contract storage in genesis alloc file.
-//
-//nolint:lll // reads better if long description is one line
+// SetDepositStorageCmd sets deposit contract storage in genesis alloc file.
 func SetDepositStorageCmd(chainSpec chain.Spec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-deposit-storage [eth/genesis/file.json]",
@@ -48,75 +47,15 @@ func SetDepositStorageCmd(chainSpec chain.Spec) *cobra.Command {
 		Long:  `Updates the deposit contract storage in the passed in eth genesis file. Creates a new EL genesis file with the changes in the BEACOND_HOME directory.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Get the deposits from the beacon chain genesis appstate.
-			config := context.GetConfigFromCmd(cmd)
-
-			clGenesis, err := genutiltypes.AppGenesisFromFile(
-				config.GenesisFile(),
-			)
-			if err != nil {
-				return errors.Wrap(err, "failed to read genesis doc from file")
-			}
-
-			genesisState, err := genutiltypes.GenesisStateFromAppGenesis(
-				clGenesis,
-			)
-			if err != nil {
-				return errors.Wrap(err, "failed to read appstate from genesis")
-			}
-
-			beaconStateRaw := genesisState["beacon"]
-			var beaconState struct {
-				Deposits ctypes.Deposits `json:"deposits"`
-			}
-			if err = json.Unmarshal(beaconStateRaw, &beaconState); err != nil {
-				return errors.Wrap(err, "failed to unmarshal beacon state")
-			}
-			deposits := beaconState.Deposits
-
-			// Set the storage of the deposit contract with deposits count and root.
-			count := big.NewInt(int64(len(deposits)))
-			root := deposits.HashTreeRoot()
-
 			// Read the EL genesis file.
-			elGenesisBz, err := afero.ReadFile(afero.NewOsFs(), args[0])
-			if err != nil {
-				return errors.Wrap(err, "failed to read eth1 genesis file")
-			}
-
+			elGenesisFilePath := args[0]
 			isNethermind, err := cmd.Flags().GetBool(nethermindGenesis)
 			if err != nil {
 				return err
 			}
-			var allocsKey string
-
-			// Unmarshal the genesis file.
-			var elGenesis types.EthGenesis
-			if isNethermind {
-				elGenesis = &types.NethermindEthGenesisJSON{}
-				allocsKey = types.NethermindAllocsKey
-			} else {
-				elGenesis = &types.DefaultEthGenesisJSON{}
-				allocsKey = types.DefaultAllocsKey
-			}
-			if err = json.Unmarshal(elGenesisBz, elGenesis); err != nil {
-				return errors.Wrap(err, "failed to unmarshal eth1 genesis")
-			}
-
-			depositAddr := common.Address(chainSpec.DepositContractAddress())
-			allocs := writeDepositStorage(elGenesis, depositAddr, count, root)
-
-			// Get just the filename from the path
-			filename := filepath.Base(args[0])
-			outputPath := filepath.Join(config.RootDir, filename)
-
-			// Write to file.
-			err = writeGenesisAllocToFile(depositAddr, outputPath, args[0], allocs, allocsKey)
-			if err != nil {
-				return errors.Wrap(err, "failed to write genesis alloc to file")
-			}
-
-			return nil
+			// Get the deposits from the beacon chain genesis appstate.
+			config := context.GetConfigFromCmd(cmd)
+			return SetDepositStorage(chainSpec, config, elGenesisFilePath, isNethermind)
 		},
 	}
 
@@ -125,6 +64,74 @@ func SetDepositStorageCmd(chainSpec chain.Spec) *cobra.Command {
 		nethermindGenesisDefault, nethermindGenesisMsg,
 	)
 	return cmd
+}
+
+func SetDepositStorage(
+	chainSpec chain.Spec,
+	config *cmtcfg.Config,
+	elGenesisFilePath string,
+	isNethermind bool,
+) error {
+	elGenesisBz, err := afero.ReadFile(afero.NewOsFs(), elGenesisFilePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to read eth1 genesis file")
+	}
+
+	clGenesis, err := genutiltypes.AppGenesisFromFile(
+		config.GenesisFile(),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to read genesis doc from file")
+	}
+
+	genesisState, err := genutiltypes.GenesisStateFromAppGenesis(
+		clGenesis,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to read appstate from genesis")
+	}
+
+	beaconStateRaw := genesisState["beacon"]
+	var beaconState struct {
+		Deposits ctypes.Deposits `json:"deposits"`
+	}
+	if err = json.Unmarshal(beaconStateRaw, &beaconState); err != nil {
+		return errors.Wrap(err, "failed to unmarshal beacon state")
+	}
+	deposits := beaconState.Deposits
+
+	// Set the storage of the deposit contract with deposits count and root.
+	count := big.NewInt(int64(len(deposits)))
+	root := deposits.HashTreeRoot()
+
+	var allocsKey string
+
+	// Unmarshal the genesis file.
+	var elGenesis types.EthGenesis
+	if isNethermind {
+		elGenesis = &types.NethermindEthGenesisJSON{}
+		allocsKey = types.NethermindAllocsKey
+	} else {
+		elGenesis = &types.DefaultEthGenesisJSON{}
+		allocsKey = types.DefaultAllocsKey
+	}
+	if err = json.Unmarshal(elGenesisBz, elGenesis); err != nil {
+		return errors.Wrap(err, "failed to unmarshal eth1 genesis")
+	}
+
+	depositAddr := common.Address(chainSpec.DepositContractAddress())
+	allocs := writeDepositStorage(elGenesis, depositAddr, count, root)
+
+	// Get just the filename from the path
+	filename := filepath.Base(elGenesisFilePath)
+	outputPath := filepath.Join(config.RootDir, filename)
+
+	// Write to file.
+	err = writeGenesisAllocToFile(depositAddr, outputPath, elGenesisFilePath, allocs, allocsKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to write genesis alloc to file")
+	}
+	return nil
 }
 
 func writeDepositStorage(


### PR DESCRIPTION
This contributes to the [larger testing PR](https://github.com/berachain/beacon-kit/pull/2411/files) by allowing these commands to be callable directly in the Go runtime. 