### PR TITLE
fix: Fix typo in variable name telemtrySink in engine.go

### DIFF
--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -49,12 +49,12 @@ type Engine struct {
 func New(
 	engineClient *client.EngineClient,
 	logger log.Logger,
-	telemtrySink TelemetrySink,
+	telemetrySink TelemetrySink,
 ) *Engine {
 	return &Engine{
 		ec:      engineClient,
 		logger:  logger,
-		metrics: newEngineMetrics(telemtrySink, logger),
+		metrics: newEngineMetrics(telemetrySink, logger),
 	}
 }
 


### PR DESCRIPTION
A typo in the variable name `telemtrySink` within the `New` function.
Fixed to `telemetrySink` to ensure consistency and avoid potential issues in the codebase.

The change is minimal but important for accuracy.

LFG, Bera!