### PR TITLE
chore: fix variable capture in goroutine within loop

### DIFF
--- a/da/blob/factory.go
+++ b/da/blob/factory.go
@@ -79,6 +79,7 @@ func (f *SidecarFactory) BuildSidecars(
 	sigHeader := ctypes.NewSignedBeaconBlockHeader(header, signedBlk.GetSignature())
 
 	for i := range numBlobs {
+		i := i
 		g.Go(func() error {
 			inclusionProof, err := f.BuildKZGInclusionProof(body, math.U64(i))
 			if err != nil {


### PR DESCRIPTION
I noticed that the variable `i` was being captured by the goroutine inside the loop, causing all goroutines to share the same value of `i` (the final value after the loop completes). This could lead to incorrect behavior, such as writing data to the same index in the `sidecars` array.  

To fix this, I added `i := i` inside the loop. This creates a local copy of `i` for each iteration, ensuring that each goroutine works with the correct index value. This change prevents race conditions and ensures proper parallel execution.  

Here's the updated code:  
```go  
for i := range numBlobs {  
    i := i  
    g.Go(func() error {  
        // ...  
    })  
}  
```  

This is a critical fix for maintaining data integrity in concurrent operations.