### PR TITLE
fix: remove redundant *LoggerConfig type from function signature

### DIFF
--- a/cmd/beacond/main.go
+++ b/cmd/beacond/main.go
@@ -44,7 +44,7 @@ func run() error {
 	// Build the node using the node-core.
 	nb := nodebuilder.New(
 		// Set the Runtime Components to the Default.
-		nodebuilder.WithComponents[Node, *Logger, *LoggerConfig](
+		nodebuilder.WithComponents[Node, *Logger](
 			DefaultComponents(),
 		),
 	)


### PR DESCRIPTION
I noticed that the function `DefaultComponents()` is declared to return three types: `Node`, `*Logger`, and `*LoggerConfig`. However, the implementation only returns `Node` and `*Logger`.

The `*LoggerConfig` type is unnecessary and should be removed from the function signature to avoid confusion and keep the code consistent.  
