### PR TITLE
fix(ci): Speed up CI, Add t.Parallel and Fix Test Parallelism Issue

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,15 @@ linters-settings:
     # Default: false
     check-type-assertions: true
 
+  paralleltest:
+    # Ignore missing calls to `t.Parallel()` and only report incorrect uses of it.
+    # Default: false
+    ignore-missing: false
+    # Ignore missing calls to `t.Parallel()` in subtests. Top-level tests are
+    # still required to have `t.Parallel`, but subtests are allowed to skip it.
+    # Default: false
+    ignore-missing-subtests: true
+
   exhaustive:
     # Program elements to check for exhaustiveness.
     # Default: [ switch ]
@@ -292,7 +301,7 @@ linters:
     - testableexamples # checks if examples are testable (have an expected output)
     - testifylint # checks usage of github.com/stretchr/testify
     - testpackage # makes you use a separate _test package
-    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+#    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes. Replaced with paralleltest
     - unconvert # removes unnecessary type conversions
     - unparam # reports unused function parameters
     - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
@@ -333,7 +342,7 @@ linters:
     - maintidx # measures the maintainability index of each function
     - misspell # [useless] finds commonly misspelled English words in comments
     #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
-    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    - paralleltest # detects missing usage of t.Parallel() method in your Go test
     # - tagliatelle # checks the struct tags
     - thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
     #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines

--- a/beacon/payload-time/time_test.go
+++ b/beacon/payload-time/time_test.go
@@ -32,6 +32,7 @@ import (
 // TestNextTimestampVerifies checks that next payload timestamp
 // built via payloadtime.Next always pass payloadtime.Verify.
 func TestNextTimestampVerifies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		times       func() (time.Time, time.Time)
@@ -68,6 +69,7 @@ func TestNextTimestampVerifies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			consensusTime, parentPayloadTimestamp := tt.times()
 
 			// Optimistic build case

--- a/chain/helpers_test.go
+++ b/chain/helpers_test.go
@@ -45,6 +45,7 @@ var spec, _ = chain.NewSpec(
 
 // TestActiveForkVersionForEpoch tests the ActiveForkVersionForEpoch method.
 func TestActiveForkVersionForEpoch(t *testing.T) {
+	t.Parallel()
 	// Define test cases
 	tests := []struct {
 		name     string
@@ -59,6 +60,7 @@ func TestActiveForkVersionForEpoch(t *testing.T) {
 	// Run test cases
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := spec.ActiveForkVersionForEpoch(tt.epoch)
 			require.Equal(t, tt.expected, result, "Test case : %s", tt.name)
 		})
@@ -67,6 +69,7 @@ func TestActiveForkVersionForEpoch(t *testing.T) {
 
 // TestSlotToEpoch tests the SlotToEpoch method.
 func TestSlotToEpoch(t *testing.T) {
+	t.Parallel()
 	// Define test cases
 	tests := []struct {
 		name     string
@@ -84,6 +87,7 @@ func TestSlotToEpoch(t *testing.T) {
 	// Run test cases
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := spec.SlotToEpoch(tt.slot)
 			require.Equal(t, tt.expected, result, "Test case : %s", tt.name)
 		})
@@ -92,6 +96,7 @@ func TestSlotToEpoch(t *testing.T) {
 
 // TestActiveForkVersionForSlot tests the ActiveForkVersionForSlot method.
 func TestActiveForkVersionForSlot(t *testing.T) {
+	t.Parallel()
 	// Define test cases
 	tests := []struct {
 		name     string
@@ -111,6 +116,7 @@ func TestActiveForkVersionForSlot(t *testing.T) {
 	// Run test cases
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := spec.ActiveForkVersionForSlot(tt.slot)
 			require.Equal(t, tt.expected, result, "Test case : %s", tt.name)
 		})
@@ -119,6 +125,7 @@ func TestActiveForkVersionForSlot(t *testing.T) {
 
 // TestWithinDAPeriod tests the WithinDAPeriod method.
 func TestWithinDAPeriod(t *testing.T) {
+	t.Parallel()
 	// Define test cases
 	tests := []struct {
 		name     string
@@ -144,6 +151,7 @@ func TestWithinDAPeriod(t *testing.T) {
 	// Run test cases
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := spec.WithinDAPeriod(tt.block, tt.current)
 			require.Equal(t, tt.expected, result, "Test case : %s", tt.name)
 		})

--- a/cli/commands/deposit/commands_test.go
+++ b/cli/commands/deposit/commands_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 func TestCreateAndValidateCommandsDuality(t *testing.T) {
+	t.Parallel()
+
 	qc := &quick.Config{MaxCount: 100}
 
 	cs, err := spec.DevnetChainSpec()

--- a/cli/commands/genesis/deposit_test.go
+++ b/cli/commands/genesis/deposit_test.go
@@ -37,6 +37,7 @@ import (
 )
 
 func TestGenesisDeposit(t *testing.T) {
+	t.Parallel()
 	homeDir := t.TempDir()
 	t.Log("Home folder:", homeDir)
 

--- a/cli/commands/genesis/storage_test.go
+++ b/cli/commands/genesis/storage_test.go
@@ -36,7 +36,9 @@ import (
 )
 
 func TestSetDepositStorageCmd(t *testing.T) {
+	t.Parallel()
 	t.Run("command should be available and have correct use", func(t *testing.T) {
+		t.Parallel()
 		chainSpec, err := spec.DevnetChainSpec()
 		require.NoError(t, err)
 		cmd := genesis.SetDepositStorageCmd(chainSpec)
@@ -44,10 +46,9 @@ func TestSetDepositStorageCmd(t *testing.T) {
 	})
 
 	t.Run("should set deposit storage correctly", func(t *testing.T) {
+		t.Parallel()
 		// Create a temporary directory for test files
-		tmpDir, err := os.MkdirTemp("", "genesis-test-*")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir)
+		tmpDir := t.TempDir()
 
 		// Setup test files
 		mockGenesisPath := setupMockGenesis(t, tmpDir)

--- a/cli/commands/jwt/jwt_test.go
+++ b/cli/commands/jwt/jwt_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func Test_NewGenerateJWTCommand(t *testing.T) {
+	t.Parallel()
 	t.Run(
 		"command should be available and have correct use",
 		func(t *testing.T) {

--- a/config/spec/defaults_test.go
+++ b/config/spec/defaults_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestDomainTypeConversion(t *testing.T) {
+	t.Parallel()
 	cs := spec.MainnetChainSpecData()
 	require.Equal(t, bytes.B4([]byte{0x00, 0x00, 0x00, 0x00}), cs.DomainTypeProposer)
 	require.Equal(t, bytes.B4([]byte{0x01, 0x00, 0x00, 0x00}), cs.DomainTypeAttester)

--- a/consensus-types/types/attestation_data_test.go
+++ b/consensus-types/types/attestation_data_test.go
@@ -42,6 +42,7 @@ func generateAttestationData() *types.AttestationData {
 }
 
 func TestAttestationData_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		data     *types.AttestationData
@@ -78,6 +79,7 @@ func TestAttestationData_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			data, err := tc.data.MarshalSSZ()
 			require.NoError(t, err)
 			require.NotNil(t, data)
@@ -104,6 +106,7 @@ func TestAttestationData_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
 }
 
 func TestAttestationData_GetTree(t *testing.T) {
+	t.Parallel()
 	data := generateAttestationData()
 
 	tree, err := data.GetTree()
@@ -118,6 +121,7 @@ func TestAttestationData_GetTree(t *testing.T) {
 }
 
 func TestAttestationData_Getters(t *testing.T) {
+	t.Parallel()
 	data := generateAttestationData()
 	beaconBlockRoot := common.Root{
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,

--- a/consensus-types/types/block_test.go
+++ b/consensus-types/types/block_test.go
@@ -85,6 +85,7 @@ func generateValidBeaconBlock(t *testing.T) *types.BeaconBlock {
 }
 
 func TestBeaconBlockForDeneb(t *testing.T) {
+	t.Parallel()
 	deneb1 := version.Deneb1()
 	block, err := types.NewBeaconBlockWithVersion(
 		math.Slot(10),
@@ -98,6 +99,7 @@ func TestBeaconBlockForDeneb(t *testing.T) {
 }
 
 func TestBeaconBlock(t *testing.T) {
+	t.Parallel()
 	block := generateValidBeaconBlock(t)
 
 	require.NotNil(t, block.Body)
@@ -121,6 +123,7 @@ func TestBeaconBlock(t *testing.T) {
 }
 
 func TestBeaconBlock_MarshalUnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	block := *generateValidBeaconBlock(t)
 
 	sszBlock, err := block.MarshalSSZ()
@@ -137,17 +140,20 @@ func TestBeaconBlock_MarshalUnmarshalSSZ(t *testing.T) {
 }
 
 func TestBeaconBlock_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	block := generateValidBeaconBlock(t)
 	hashRoot := block.HashTreeRoot()
 	require.NotNil(t, hashRoot)
 }
 
 func TestBeaconBlock_IsNil(t *testing.T) {
+	t.Parallel()
 	var block *types.BeaconBlock
 	require.True(t, block.IsNil())
 }
 
 func TestNewWithVersion(t *testing.T) {
+	t.Parallel()
 	slot := math.Slot(10)
 	proposerIndex := math.ValidatorIndex(5)
 	parentBlockRoot := common.Root{1, 2, 3, 4, 5}
@@ -168,6 +174,7 @@ func TestNewWithVersion(t *testing.T) {
 }
 
 func TestNewWithVersionInvalidForkVersion(t *testing.T) {
+	t.Parallel()
 	slot := math.Slot(10)
 	proposerIndex := math.ValidatorIndex(5)
 	parentBlockRoot := common.Root{1, 2, 3, 4, 5}

--- a/consensus-types/types/body_test.go
+++ b/consensus-types/types/body_test.go
@@ -58,6 +58,7 @@ func generateBeaconBlockBody() types.BeaconBlockBody {
 }
 
 func TestBeaconBlockBodyBase(t *testing.T) {
+	t.Parallel()
 	body := types.BeaconBlockBody{
 		RandaoReveal: [96]byte{1, 2, 3},
 		Eth1Data:     &types.Eth1Data{},
@@ -76,6 +77,7 @@ func TestBeaconBlockBodyBase(t *testing.T) {
 }
 
 func TestBeaconBlockBody(t *testing.T) {
+	t.Parallel()
 	body := types.BeaconBlockBody{
 		RandaoReveal:       [96]byte{1, 2, 3},
 		Eth1Data:           &types.Eth1Data{},
@@ -92,6 +94,7 @@ func TestBeaconBlockBody(t *testing.T) {
 }
 
 func TestBeaconBlockBody_SetBlobKzgCommitments(t *testing.T) {
+	t.Parallel()
 	body := types.BeaconBlockBody{}
 	commitments := eip4844.KZGCommitments[common.ExecutionHash]{}
 	body.SetBlobKzgCommitments(commitments)
@@ -100,6 +103,7 @@ func TestBeaconBlockBody_SetBlobKzgCommitments(t *testing.T) {
 }
 
 func TestBeaconBlockBody_SetRandaoReveal(t *testing.T) {
+	t.Parallel()
 	body := types.BeaconBlockBody{}
 	randaoReveal := crypto.BLSSignature{1, 2, 3}
 	body.SetRandaoReveal(randaoReveal)
@@ -108,6 +112,7 @@ func TestBeaconBlockBody_SetRandaoReveal(t *testing.T) {
 }
 
 func TestBeaconBlockBody_SetEth1Data(t *testing.T) {
+	t.Parallel()
 	body := types.BeaconBlockBody{}
 	eth1Data := &types.Eth1Data{}
 	body.SetEth1Data(eth1Data)
@@ -116,6 +121,7 @@ func TestBeaconBlockBody_SetEth1Data(t *testing.T) {
 }
 
 func TestBeaconBlockBody_SetDeposits(t *testing.T) {
+	t.Parallel()
 	body := types.BeaconBlockBody{}
 	deposits := types.Deposits{}
 	body.SetDeposits(deposits)
@@ -124,6 +130,7 @@ func TestBeaconBlockBody_SetDeposits(t *testing.T) {
 }
 
 func TestBeaconBlockBody_MarshalSSZ(t *testing.T) {
+	t.Parallel()
 	body := types.BeaconBlockBody{
 		RandaoReveal:       [96]byte{1, 2, 3},
 		Eth1Data:           &types.Eth1Data{},
@@ -139,12 +146,14 @@ func TestBeaconBlockBody_MarshalSSZ(t *testing.T) {
 }
 
 func TestBeaconBlockBody_GetTopLevelRoots(t *testing.T) {
+	t.Parallel()
 	body := generateBeaconBlockBody()
 	roots := body.GetTopLevelRoots()
 	require.NotNil(t, roots)
 }
 
 func TestBeaconBlockBody_Empty(t *testing.T) {
+	t.Parallel()
 	body := types.BeaconBlockBody{}
 	require.NotNil(t, body)
 }
@@ -152,6 +161,7 @@ func TestBeaconBlockBody_Empty(t *testing.T) {
 // Ensure that the ProposerSlashings field cannot be unmarshaled with data in it,
 // enforcing that it's unused.
 func TestBeaconBlockBody_UnusedProposerSlashingsEnforcement(t *testing.T) {
+	t.Parallel()
 	blockBody := types.BeaconBlockBody{}
 	unused := types.UnusedType(1)
 	blockBody.SetProposerSlashings(types.ProposerSlashings{&unused})
@@ -170,6 +180,7 @@ func TestBeaconBlockBody_UnusedProposerSlashingsEnforcement(t *testing.T) {
 // Ensure that the AttesterSlashings field cannot be unmarshaled with data in it,
 // enforcing that it's unused.
 func TestBeaconBlockBody_UnusedAttesterSlashingsEnforcement(t *testing.T) {
+	t.Parallel()
 	blockBody := types.BeaconBlockBody{}
 	unused := types.UnusedType(1)
 	blockBody.SetAttesterSlashings(types.AttesterSlashings{&unused})
@@ -188,6 +199,7 @@ func TestBeaconBlockBody_UnusedAttesterSlashingsEnforcement(t *testing.T) {
 // Ensure that the Attestations field cannot be unmarshaled with data in it,
 // enforcing that it's unused.
 func TestBeaconBlockBody_UnusedAttestationsEnforcement(t *testing.T) {
+	t.Parallel()
 	blockBody := types.BeaconBlockBody{}
 	unused := types.UnusedType(1)
 	blockBody.SetAttestations(types.Attestations{&unused})
@@ -206,6 +218,7 @@ func TestBeaconBlockBody_UnusedAttestationsEnforcement(t *testing.T) {
 // Ensure that the VoluntaryExits field cannot be unmarshaled with data in it,
 // enforcing that it's unused.
 func TestBeaconBlockBody_UnusedVoluntaryExitsEnforcement(t *testing.T) {
+	t.Parallel()
 	blockBody := types.BeaconBlockBody{}
 	unused := types.UnusedType(1)
 	blockBody.SetVoluntaryExits(types.VoluntaryExits{&unused})
@@ -224,6 +237,7 @@ func TestBeaconBlockBody_UnusedVoluntaryExitsEnforcement(t *testing.T) {
 // Ensure that the BlsToExecutionChanges field cannot be unmarshaled with data in it,
 // enforcing that it's unused.
 func TestBeaconBlockBody_UnusedBlsToExecutionChangesEnforcement(t *testing.T) {
+	t.Parallel()
 	blockBody := types.BeaconBlockBody{}
 	unused := types.UnusedType(1)
 	blockBody.SetBlsToExecutionChanges(types.BlsToExecutionChanges{&unused})
@@ -240,6 +254,7 @@ func TestBeaconBlockBody_UnusedBlsToExecutionChangesEnforcement(t *testing.T) {
 }
 
 func TestBeaconBlockBody_RoundTrip_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	body := generateBeaconBlockBody()
 	data, err := body.MarshalSSZ()
 	require.NoError(t, err)
@@ -253,6 +268,7 @@ func TestBeaconBlockBody_RoundTrip_HashTreeRoot(t *testing.T) {
 
 // This test explains the calculation of the KZG commitment' inclusion proof depth.
 func Test_KZGCommitmentInclusionProofDepth(t *testing.T) {
+	t.Parallel()
 	maxUint8 := uint64(^uint8(0))
 	cs, err := spec.DevnetChainSpec()
 	require.NoError(t, err)

--- a/consensus-types/types/deposit_message_test.go
+++ b/consensus-types/types/deposit_message_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestCreateAndSignDepositMessage(t *testing.T) {
+	t.Parallel()
 	forkData := &types.ForkData{
 		CurrentVersion:        common.Version{0x00, 0x00, 0x00, 0x04},
 		GenesisValidatorsRoot: common.Root{0x00, 0x00, 0x00, 0x00},
@@ -62,6 +63,7 @@ func TestCreateAndSignDepositMessage(t *testing.T) {
 }
 
 func TestDepositMessage_MarshalUnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	original := &types.DepositMessage{
 		Pubkey:      crypto.BLSPubkey{},
 		Credentials: types.WithdrawalCredentials{},
@@ -79,6 +81,7 @@ func TestDepositMessage_MarshalUnmarshalSSZ(t *testing.T) {
 }
 
 func TestDepositMessage_MarshalSSZTo(t *testing.T) {
+	t.Parallel()
 	original := &types.DepositMessage{
 		Pubkey:      crypto.BLSPubkey{},
 		Credentials: types.WithdrawalCredentials{},
@@ -96,6 +99,7 @@ func TestDepositMessage_MarshalSSZTo(t *testing.T) {
 }
 
 func TestDepositMessage_UnmarshalSSZ_ErrSize(t *testing.T) {
+	t.Parallel()
 	buf := make([]byte, 10) // size less than 88
 
 	var unmarshalledDepositMessage types.DepositMessage
@@ -105,6 +109,7 @@ func TestDepositMessage_UnmarshalSSZ_ErrSize(t *testing.T) {
 }
 
 func TestDepositMessage_VerifyCreateValidator_Error(t *testing.T) {
+	t.Parallel()
 	original := &types.DepositMessage{
 		Pubkey:      crypto.BLSPubkey{},
 		Credentials: types.WithdrawalCredentials{},

--- a/consensus-types/types/deposit_test.go
+++ b/consensus-types/types/deposit_test.go
@@ -51,6 +51,7 @@ func generateValidDeposit() *types.Deposit {
 }
 
 func TestDeposit_Equals(t *testing.T) {
+	t.Parallel()
 	// Create base deposit
 	deposit1 := generateValidDeposit()
 
@@ -91,6 +92,7 @@ func TestDeposit_Equals(t *testing.T) {
 }
 
 func TestDeposit_MarshalUnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	originalDeposit := generateValidDeposit()
 
 	// Marshal the original deposit to SSZ
@@ -106,6 +108,7 @@ func TestDeposit_MarshalUnmarshalSSZ(t *testing.T) {
 }
 
 func TestDeposit_MarshalSSZTo(t *testing.T) {
+	t.Parallel()
 	deposit := generateValidDeposit()
 	buf := make([]byte, karalabessz.Size(deposit))
 	target, err := deposit.MarshalSSZTo(buf)
@@ -114,6 +117,7 @@ func TestDeposit_MarshalSSZTo(t *testing.T) {
 }
 
 func TestDeposit_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	deposit := generateValidDeposit()
 	require.NotPanics(t, func() {
 		_ = deposit.HashTreeRoot()
@@ -121,12 +125,14 @@ func TestDeposit_HashTreeRoot(t *testing.T) {
 }
 
 func TestDeposit_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	deposit := generateValidDeposit()
 
 	require.Equal(t, uint32(192), karalabessz.Size(deposit))
 }
 
 func TestDeposit_HashTreeRootWith(t *testing.T) {
+	t.Parallel()
 	deposit := generateValidDeposit()
 	require.NotNil(t, deposit)
 	hasher := ssz.NewHasher()
@@ -136,12 +142,14 @@ func TestDeposit_HashTreeRootWith(t *testing.T) {
 }
 
 func TestDeposit_GetTree(t *testing.T) {
+	t.Parallel()
 	deposit := generateValidDeposit()
 	_, err := deposit.GetTree()
 	require.NoError(t, err)
 }
 
 func TestDeposit_UnmarshalSSZ_ErrSize(t *testing.T) {
+	t.Parallel()
 	// Create a byte slice of incorrect size
 	buf := make([]byte, 10) // size less than 192
 
@@ -152,6 +160,7 @@ func TestDeposit_UnmarshalSSZ_ErrSize(t *testing.T) {
 }
 
 func TestDeposit_VerifySignature(t *testing.T) {
+	t.Parallel()
 	deposit := generateValidDeposit()
 
 	forkData := &types.ForkData{
@@ -172,6 +181,7 @@ func TestDeposit_VerifySignature(t *testing.T) {
 }
 
 func TestDeposit_Getters(t *testing.T) {
+	t.Parallel()
 	deposit := generateValidDeposit()
 
 	require.Equal(t, deposit.Pubkey, deposit.GetPubkey())

--- a/consensus-types/types/eth1data_test.go
+++ b/consensus-types/types/eth1data_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestEth1Data_Serialization(t *testing.T) {
+	t.Parallel()
 	original := types.NewEth1Data(common.Root{})
 	data, err := original.MarshalSSZ()
 	require.NoError(t, err)
@@ -50,18 +51,21 @@ func TestEth1Data_Serialization(t *testing.T) {
 }
 
 func TestEth1Data_UnmarshalError(t *testing.T) {
+	t.Parallel()
 	var unmarshalled types.Eth1Data
 	err := unmarshalled.UnmarshalSSZ([]byte{})
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
 func TestEth1Data_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	eth1Data := types.NewEth1Data(common.Root{})
 	size := karalabessz.Size(eth1Data)
 	require.Equal(t, uint32(72), size)
 }
 
 func TestEth1Data_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	eth1Data := types.NewEth1Data(common.Root{})
 
 	require.NotPanics(t, func() {
@@ -70,6 +74,7 @@ func TestEth1Data_HashTreeRoot(t *testing.T) {
 }
 
 func TestEth1Data_GetTree(t *testing.T) {
+	t.Parallel()
 	eth1Data := types.NewEth1Data(common.Root{})
 	tree, err := eth1Data.GetTree()
 
@@ -78,6 +83,7 @@ func TestEth1Data_GetTree(t *testing.T) {
 }
 
 func TestEth1Data_GetDepositCount(t *testing.T) {
+	t.Parallel()
 	eth1Data := &types.Eth1Data{
 		DepositRoot:  common.Root{},
 		DepositCount: 10,

--- a/consensus-types/types/fork_data_test.go
+++ b/consensus-types/types/fork_data_test.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"testing"
 
-	types "github.com/berachain/beacon-kit/consensus-types/types"
+	"github.com/berachain/beacon-kit/consensus-types/types"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
 	karalabessz "github.com/karalabe/ssz"
@@ -32,6 +32,7 @@ import (
 )
 
 func TestForkData_Serialization(t *testing.T) {
+	t.Parallel()
 	original := &types.ForkData{
 		CurrentVersion:        common.Version{},
 		GenesisValidatorsRoot: common.Root{},
@@ -49,12 +50,14 @@ func TestForkData_Serialization(t *testing.T) {
 }
 
 func TestForkData_Unmarshal(t *testing.T) {
+	t.Parallel()
 	var unmarshalled types.ForkData
 	err := unmarshalled.UnmarshalSSZ([]byte{})
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
 func TestForkData_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	forkData := &types.ForkData{
 		CurrentVersion:        common.Version{},
 		GenesisValidatorsRoot: common.Root{},
@@ -65,6 +68,7 @@ func TestForkData_SizeSSZ(t *testing.T) {
 }
 
 func TestForkData_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	forkData := &types.ForkData{
 		CurrentVersion:        common.Version{},
 		GenesisValidatorsRoot: common.Root{},
@@ -75,6 +79,7 @@ func TestForkData_HashTreeRoot(t *testing.T) {
 }
 
 func TestForkData_ComputeDomain(t *testing.T) {
+	t.Parallel()
 	forkData := &types.ForkData{
 		CurrentVersion:        common.Version{},
 		GenesisValidatorsRoot: common.Root{},
@@ -88,6 +93,7 @@ func TestForkData_ComputeDomain(t *testing.T) {
 }
 
 func TestForkData_ComputeRandaoSigningRoot(t *testing.T) {
+	t.Parallel()
 	fd := &types.ForkData{
 		CurrentVersion:        common.Version{},
 		GenesisValidatorsRoot: common.Root{},
@@ -102,6 +108,7 @@ func TestForkData_ComputeRandaoSigningRoot(t *testing.T) {
 }
 
 func TestNewForkData(t *testing.T) {
+	t.Parallel()
 	currentVersion := common.Version{}
 	genesisValidatorsRoot := common.Root{}
 
@@ -112,6 +119,7 @@ func TestNewForkData(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	currentVersion := common.Version{}
 	genesisValidatorsRoot := common.Root{}
 

--- a/consensus-types/types/fork_test.go
+++ b/consensus-types/types/fork_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestFork_Serialization(t *testing.T) {
+	t.Parallel()
 	original := types.NewFork(
 		common.Version{1, 2, 3, 4},
 		common.Version{5, 6, 7, 8},
@@ -56,6 +57,7 @@ func TestFork_Serialization(t *testing.T) {
 }
 
 func TestFork_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	fork := &types.Fork{
 		PreviousVersion: common.Version{1, 2, 3, 4},
 		CurrentVersion:  common.Version{5, 6, 7, 8},
@@ -67,6 +69,7 @@ func TestFork_SizeSSZ(t *testing.T) {
 }
 
 func TestFork_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	fork := &types.Fork{
 		PreviousVersion: common.Version{1, 2, 3, 4},
 		CurrentVersion:  common.Version{5, 6, 7, 8},
@@ -79,6 +82,7 @@ func TestFork_HashTreeRoot(t *testing.T) {
 }
 
 func TestFork_GetTree(t *testing.T) {
+	t.Parallel()
 	fork := &types.Fork{
 		PreviousVersion: common.Version{1, 2, 3, 4},
 		CurrentVersion:  common.Version{5, 6, 7, 8},
@@ -91,6 +95,7 @@ func TestFork_GetTree(t *testing.T) {
 }
 
 func TestFork_UnmarshalSSZ_ErrSize(t *testing.T) {
+	t.Parallel()
 	buf := make([]byte, 10) // size less than 16
 
 	var unmarshalledFork types.Fork

--- a/consensus-types/types/genesis_test.go
+++ b/consensus-types/types/genesis_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestDefaultGenesis(t *testing.T) {
+	t.Parallel()
 	g := types.DefaultGenesis()
 	if !version.Equals(g.ForkVersion, version.Deneb()) {
 		t.Errorf(
@@ -66,36 +67,42 @@ func TestDefaultGenesis(t *testing.T) {
 }
 
 func TestDefaultGenesisExecutionPayloadHeader(t *testing.T) {
+	t.Parallel()
 	header, err := types.DefaultGenesisExecutionPayloadHeader()
 	require.NoError(t, err)
 	require.NotNil(t, header)
 }
 
 func TestGenesisGetForkVersion(t *testing.T) {
+	t.Parallel()
 	g := types.DefaultGenesis()
 	forkVersion := g.GetForkVersion()
 	require.Equal(t, version.Deneb(), forkVersion)
 }
 
 func TestGenesisGetDeposits(t *testing.T) {
+	t.Parallel()
 	g := types.DefaultGenesis()
 	deposits := g.GetDeposits()
 	require.Empty(t, deposits)
 }
 
 func TestGenesisGetExecutionPayloadHeader(t *testing.T) {
+	t.Parallel()
 	g := types.DefaultGenesis()
 	header := g.GetExecutionPayloadHeader()
 	require.NotNil(t, header)
 }
 
 func TestDefaultGenesisPanics(t *testing.T) {
+	t.Parallel()
 	require.NotPanics(t, func() {
 		types.DefaultGenesis()
 	})
 }
 
 func TestGenesisUnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	t.Helper()
 	testCases := []struct {
 		name                string
@@ -202,6 +209,7 @@ func TestGenesisUnmarshalJSON(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			g := types.DefaultGenesis()
 			err := g.UnmarshalJSON([]byte(tc.jsonInput))
 			if tc.expectedError {

--- a/consensus-types/types/header_test.go
+++ b/consensus-types/types/header_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestBeaconBlockHeader_Equals(t *testing.T) {
+	t.Parallel()
 	var (
 		slot            = math.Slot(100)
 		valIdx          = math.ValidatorIndex(200)
@@ -95,6 +96,7 @@ func TestBeaconBlockHeader_Equals(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got1 := lhs.Equals(tt.rhs)
 			require.Equal(t, tt.want, got1)
 
@@ -112,6 +114,7 @@ func TestBeaconBlockHeader_Equals(t *testing.T) {
 }
 
 func TestBeaconBlockHeader_Serialization(t *testing.T) {
+	t.Parallel()
 	original := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -137,6 +140,7 @@ func TestBeaconBlockHeader_Serialization(t *testing.T) {
 }
 
 func TestBeaconBlockHeader_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -149,7 +153,8 @@ func TestBeaconBlockHeader_SizeSSZ(t *testing.T) {
 	require.Equal(t, uint32(112), size)
 }
 
-func TestBeaconBlockHeader_HashTreeRoot(_ *testing.T) {
+func TestBeaconBlockHeader_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -162,6 +167,7 @@ func TestBeaconBlockHeader_HashTreeRoot(_ *testing.T) {
 }
 
 func TestBeaconBlockHeader_GetTree(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -177,6 +183,7 @@ func TestBeaconBlockHeader_GetTree(t *testing.T) {
 }
 
 func TestBeaconBlockHeader_SetStateRoot(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -192,6 +199,7 @@ func TestBeaconBlockHeader_SetStateRoot(t *testing.T) {
 }
 
 func TestBeaconBlockHeader_SetSlot(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -207,6 +215,7 @@ func TestBeaconBlockHeader_SetSlot(t *testing.T) {
 }
 
 func TestBeaconBlockHeader_SetProposerIndex(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -221,6 +230,7 @@ func TestBeaconBlockHeader_SetProposerIndex(t *testing.T) {
 }
 
 func TestBeaconBlockHeader_SetParentBlockRoot(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -236,6 +246,7 @@ func TestBeaconBlockHeader_SetParentBlockRoot(t *testing.T) {
 }
 
 func TestBeaconBlockHeader_SetBodyRoot(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -251,6 +262,7 @@ func TestBeaconBlockHeader_SetBodyRoot(t *testing.T) {
 }
 
 func TestBeaconBlockHeader_UnmarshalSSZ_ErrSize(t *testing.T) {
+	t.Parallel()
 	header := &types.BeaconBlockHeader{}
 	buf := make([]byte, 100) // Incorrect size
 

--- a/consensus-types/types/payload_header_test.go
+++ b/consensus-types/types/payload_header_test.go
@@ -61,6 +61,7 @@ func generateExecutionPayloadHeader() *types.ExecutionPayloadHeader {
 }
 
 func TestExecutionPayloadHeader_Getters(t *testing.T) {
+	t.Parallel()
 	header := generateExecutionPayloadHeader()
 
 	require.NotNil(t, header)
@@ -89,16 +90,19 @@ func TestExecutionPayloadHeader_Getters(t *testing.T) {
 }
 
 func TestExecutionPayloadHeader_IsNil(t *testing.T) {
+	t.Parallel()
 	header := generateExecutionPayloadHeader()
 	require.False(t, header.IsNil())
 }
 
 func TestExecutionPayloadHeader_Version(t *testing.T) {
+	t.Parallel()
 	header := generateExecutionPayloadHeader()
 	require.Equal(t, version.Deneb1(), header.Version())
 }
 
 func TestExecutionPayloadHeader_MarshalUnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	originalHeader := generateExecutionPayloadHeader()
 
 	data, err := originalHeader.MarshalJSON()
@@ -114,6 +118,7 @@ func TestExecutionPayloadHeader_MarshalUnmarshalJSON(t *testing.T) {
 }
 
 func TestExecutionPayloadHeader_Serialization(t *testing.T) {
+	t.Parallel()
 	original := generateExecutionPayloadHeader()
 
 	data, err := original.MarshalSSZ()
@@ -129,6 +134,7 @@ func TestExecutionPayloadHeader_Serialization(t *testing.T) {
 }
 
 func TestExecutionPayloadHeader_MarshalSSZTo(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name     string
 		malleate func() *types.ExecutionPayloadHeader
@@ -153,6 +159,7 @@ func TestExecutionPayloadHeader_MarshalSSZTo(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			header := tc.malleate()
 			buf := make([]byte, 64)
 			_, err := header.MarshalSSZTo(buf)
@@ -166,6 +173,7 @@ func TestExecutionPayloadHeader_MarshalSSZTo(t *testing.T) {
 }
 
 func TestExecutionPayloadHeader_UnmarshalSSZ_EmptyBuf(t *testing.T) {
+	t.Parallel()
 	header := generateExecutionPayloadHeader()
 	buf := make([]byte, 0)
 	err := header.UnmarshalSSZ(buf)
@@ -234,12 +242,14 @@ func TestExecutionPayloadHeader_UnmarshalSSZ_EmptyBuf(t *testing.T) {
 // }
 
 func TestExecutionPayloadHeader_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	header := generateExecutionPayloadHeader()
 	size := karalabessz.Size(header)
 	require.Equal(t, uint32(584), size)
 }
 
 func TestExecutionPayloadHeader_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	header := generateExecutionPayloadHeader()
 	require.NotPanics(t, func() {
 		header.HashTreeRoot()
@@ -247,12 +257,14 @@ func TestExecutionPayloadHeader_HashTreeRoot(t *testing.T) {
 }
 
 func TestExecutionPayloadHeader_GetTree(t *testing.T) {
+	t.Parallel()
 	header := generateExecutionPayloadHeader()
 	_, err := header.GetTree()
 	require.NoError(t, err)
 }
 
 func TestExecutablePayloadHeaderDeneb_UnmarshalJSON_Error(t *testing.T) {
+	t.Parallel()
 	original := generateExecutionPayloadHeader()
 	validJSON, err := original.MarshalJSON()
 	require.NoError(t, err)
@@ -355,12 +367,14 @@ func TestExecutablePayloadHeaderDeneb_UnmarshalJSON_Error(t *testing.T) {
 }
 
 func TestExecutablePayloadHeaderDeneb_UnmarshalJSON_Empty(t *testing.T) {
+	t.Parallel()
 	var payload types.ExecutionPayloadHeader
 	err := payload.UnmarshalJSON([]byte{})
 	require.Error(t, err)
 }
 
 func TestExecutablePayloadHeaderDeneb_HashTreeRootWith(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name     string
 		malleate func() *types.ExecutionPayloadHeader
@@ -379,6 +393,7 @@ func TestExecutablePayloadHeaderDeneb_HashTreeRootWith(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			hh := ssz.DefaultHasherPool.Get()
 			header := tc.malleate()
 			err := header.HashTreeRootWith(hh)
@@ -388,6 +403,7 @@ func TestExecutablePayloadHeaderDeneb_HashTreeRootWith(t *testing.T) {
 }
 
 func TestExecutionPayloadHeader_NewFromSSZ(t *testing.T) {
+	t.Parallel()
 	t.Helper()
 	testCases := []struct {
 		name           string
@@ -424,6 +440,7 @@ func TestExecutionPayloadHeader_NewFromSSZ(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			if tc.name == "Different fork version" {
 				require.Panics(t, func() {
 					_, _ = new(types.ExecutionPayloadHeader).
@@ -446,6 +463,7 @@ func TestExecutionPayloadHeader_NewFromSSZ(t *testing.T) {
 }
 
 func TestExecutionPayloadHeader_NewFromJSON(t *testing.T) {
+	t.Parallel()
 	t.Helper()
 	type testCase struct {
 		name          string
@@ -475,6 +493,7 @@ func TestExecutionPayloadHeader_NewFromJSON(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			header, err := new(types.ExecutionPayloadHeader).NewFromJSON(
 				tc.data,
 				version.Deneb1(),

--- a/consensus-types/types/payload_requests_test.go
+++ b/consensus-types/types/payload_requests_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestBuildNewPayloadRequest(t *testing.T) {
+	t.Parallel()
 	var (
 		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1())
 		versionedHashes       []common.ExecutionHash
@@ -54,6 +55,7 @@ func TestBuildNewPayloadRequest(t *testing.T) {
 }
 
 func TestBuildForkchoiceUpdateRequest(t *testing.T) {
+	t.Parallel()
 	var (
 		state       = &engineprimitives.ForkchoiceStateV1{}
 		forkVersion = version.Deneb1()
@@ -81,6 +83,7 @@ func TestBuildForkchoiceUpdateRequest(t *testing.T) {
 }
 
 func TestBuildGetPayloadRequest(t *testing.T) {
+	t.Parallel()
 	payloadID := engineprimitives.PayloadID{}
 	forkVersion := version.Altair()
 
@@ -92,6 +95,7 @@ func TestBuildGetPayloadRequest(t *testing.T) {
 }
 
 func TestHasValidVersionedAndBlockHashesPayloadError(t *testing.T) {
+	t.Parallel()
 	var (
 		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1())
 		versionedHashes       = []common.ExecutionHash{}
@@ -111,6 +115,7 @@ func TestHasValidVersionedAndBlockHashesPayloadError(t *testing.T) {
 }
 
 func TestHasValidVersionedAndBlockHashesMismatchedHashes(t *testing.T) {
+	t.Parallel()
 	var (
 		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1())
 		versionedHashes       = []common.ExecutionHash{{}}

--- a/consensus-types/types/payload_test.go
+++ b/consensus-types/types/payload_test.go
@@ -72,6 +72,7 @@ func generateExecutionPayload() *types.ExecutionPayload {
 }
 
 func TestExecutionPayload_Serialization(t *testing.T) {
+	t.Parallel()
 	original := generateExecutionPayload()
 
 	data, err := original.MarshalSSZ()
@@ -94,6 +95,7 @@ func TestExecutionPayload_Serialization(t *testing.T) {
 }
 
 func TestExecutionPayload_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	payload := generateExecutionPayload()
 	size := karalabessz.Size(payload)
 	require.Equal(t, uint32(578), size)
@@ -104,6 +106,7 @@ func TestExecutionPayload_SizeSSZ(t *testing.T) {
 }
 
 func TestExecutionPayload_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	payload := generateExecutionPayload()
 	require.NotPanics(t, func() {
 		_ = payload.HashTreeRoot()
@@ -111,6 +114,7 @@ func TestExecutionPayload_HashTreeRoot(t *testing.T) {
 }
 
 func TestExecutionPayload_GetTree(t *testing.T) {
+	t.Parallel()
 	payload := generateExecutionPayload()
 	tree, err := payload.GetTree()
 	require.NoError(t, err)
@@ -118,6 +122,7 @@ func TestExecutionPayload_GetTree(t *testing.T) {
 }
 
 func TestExecutionPayload_Getters(t *testing.T) {
+	t.Parallel()
 	payload := generateExecutionPayload()
 	require.Equal(t, common.ExecutionHash{}, payload.GetParentHash())
 	require.Equal(
@@ -155,6 +160,7 @@ func TestExecutionPayload_Getters(t *testing.T) {
 }
 
 func TestExecutionPayload_MarshalJSON(t *testing.T) {
+	t.Parallel()
 	payload := generateExecutionPayload()
 
 	data, err := payload.MarshalJSON()
@@ -170,6 +176,7 @@ func TestExecutionPayload_MarshalJSON(t *testing.T) {
 }
 
 func TestExecutionPayload_MarshalJSON_ValueAndPointer(t *testing.T) {
+	t.Parallel()
 	val := types.ExecutionPayload{}
 
 	// Marshal on raw val uses default json marshal
@@ -184,6 +191,7 @@ func TestExecutionPayload_MarshalJSON_ValueAndPointer(t *testing.T) {
 }
 
 func TestExecutionPayload_IsNil(t *testing.T) {
+	t.Parallel()
 	var payload *types.ExecutionPayload
 	require.True(t, payload.IsNil())
 
@@ -192,16 +200,19 @@ func TestExecutionPayload_IsNil(t *testing.T) {
 }
 
 func TestExecutionPayload_IsBlinded(t *testing.T) {
+	t.Parallel()
 	payload := generateExecutionPayload()
 	require.False(t, payload.IsBlinded())
 }
 
 func TestExecutionPayload_Version(t *testing.T) {
+	t.Parallel()
 	payload := generateExecutionPayload()
 	require.Equal(t, version.Deneb1(), payload.Version())
 }
 
 func TestExecutionPayload_ToHeader(t *testing.T) {
+	t.Parallel()
 	payload := &types.ExecutionPayload{
 		ParentHash:    common.ExecutionHash{},
 		FeeRecipient:  common.ExecutionAddress{},
@@ -248,6 +259,7 @@ func TestExecutionPayload_ToHeader(t *testing.T) {
 }
 
 func TestExecutionPayload_UnmarshalJSON_Error(t *testing.T) {
+	t.Parallel()
 	original := generateExecutionPayload()
 	validJSON, err := original.MarshalJSON()
 	require.NoError(t, err)

--- a/consensus-types/types/signed_beacon_block.go
+++ b/consensus-types/types/signed_beacon_block.go
@@ -60,6 +60,9 @@ func NewSignedBeaconBlockFromSSZ(
 			return block, err
 		}
 
+		// make sure Withdrawals in execution payload are not nil
+		EnsureNotNilWithdrawals(block.Message.Body.ExecutionPayload)
+
 		// duly setup fork version in every relevant block member
 		block.Message.Body.ExecutionPayload.EpVersion = forkVersion
 		block.Message.BbVersion = forkVersion

--- a/consensus-types/types/signed_beacon_block_header_test.go
+++ b/consensus-types/types/signed_beacon_block_header_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestSignedBeaconBlockHeader_Serialization(t *testing.T) {
+	t.Parallel()
 	header := types.NewBeaconBlockHeader(
 		math.Slot(100),
 		math.ValidatorIndex(200),
@@ -61,6 +62,7 @@ func TestSignedBeaconBlockHeader_Serialization(t *testing.T) {
 }
 
 func TestSignedBeaconBlockHeader_EmptySerialization(t *testing.T) {
+	t.Parallel()
 	orig := &types.SignedBeaconBlockHeader{}
 	data, err := orig.MarshalSSZ()
 	require.NoError(t, err)
@@ -82,6 +84,7 @@ func TestSignedBeaconBlockHeader_EmptySerialization(t *testing.T) {
 }
 
 func TestSignedBeaconBlockHeader_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	sigHeader := types.NewSignedBeaconBlockHeader(
 		types.NewBeaconBlockHeader(
 			math.Slot(100),
@@ -97,7 +100,8 @@ func TestSignedBeaconBlockHeader_SizeSSZ(t *testing.T) {
 	require.Equal(t, uint32(208), size)
 }
 
-func TestSignedBeaconBlockHeader_HashTreeRoot(_ *testing.T) {
+func TestSignedBeaconBlockHeader_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	sigHeader := types.NewSignedBeaconBlockHeader(
 		types.NewBeaconBlockHeader(
 			math.Slot(100),

--- a/consensus-types/types/signed_beacon_block_test.go
+++ b/consensus-types/types/signed_beacon_block_test.go
@@ -86,6 +86,7 @@ func generateRealSignedBeaconBlock(t *testing.T, blsSigner crypto.BLSSigner) (*t
 
 // TestNewSignedBeaconBlockFromSSZ tests the roundtrip SSZ encoding for Deneb.
 func TestNewSignedBeaconBlockFromSSZ(t *testing.T) {
+	t.Parallel()
 	originalBlock := generateFakeSignedBeaconBlock(t)
 	blockBytes, err := originalBlock.MarshalSSZ()
 	require.NoError(t, err)
@@ -100,11 +101,13 @@ func TestNewSignedBeaconBlockFromSSZ(t *testing.T) {
 }
 
 func TestNewSignedBeaconBlockFromSSZForkVersionNotSupported(t *testing.T) {
+	t.Parallel()
 	_, err := types.NewSignedBeaconBlockFromSSZ([]byte{}, version.Altair())
 	require.ErrorIs(t, err, types.ErrForkVersionNotSupported)
 }
 
 func TestSignedBeaconBlock_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	sBlk := generateFakeSignedBeaconBlock(t)
 	sBlk.HashTreeRoot()
 }
@@ -112,6 +115,7 @@ func TestSignedBeaconBlock_HashTreeRoot(t *testing.T) {
 // TestSignedBeaconBlock_SignBeaconBlock ensures the validity of the block
 // signatures.
 func TestSignedBeaconBlock_SignBeaconBlock(t *testing.T) {
+	t.Parallel()
 	// Generate a new bls key signer
 	filePV, err := privval.GenFilePV(
 		"signed_beacon_block_test_filepv_key",
@@ -150,12 +154,14 @@ func TestSignedBeaconBlock_SignBeaconBlock(t *testing.T) {
 }
 
 func TestSignedBeaconBlock_SizeSSZ(t *testing.T) {
+	t.Parallel()
 	sBlk := generateFakeSignedBeaconBlock(t)
 	size := ssz.Size(sBlk)
 	require.Positive(t, size)
 }
 
 func TestSignedBeaconBlock_EmptySerialization(t *testing.T) {
+	t.Parallel()
 	orig := &types.SignedBeaconBlock{}
 	data, err := orig.MarshalSSZ()
 	require.NoError(t, err)

--- a/consensus-types/types/signing_data_test.go
+++ b/consensus-types/types/signing_data_test.go
@@ -41,6 +41,7 @@ func generateSigningData() *types.SigningData {
 	}
 }
 func TestSigningData_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		data     *types.SigningData
@@ -75,6 +76,7 @@ func TestSigningData_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			data, err := tc.data.MarshalSSZ()
 			require.NoError(t, err)
 			require.NotNil(t, data)

--- a/consensus-types/types/slashing_info_test.go
+++ b/consensus-types/types/slashing_info_test.go
@@ -37,6 +37,7 @@ func generateSlashingInfo() *types.SlashingInfo {
 }
 
 func TestSlashingInfo_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		data     *types.SlashingInfo
@@ -71,6 +72,7 @@ func TestSlashingInfo_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			data, err := tc.data.MarshalSSZ()
 			require.NoError(t, err)
 			require.NotNil(t, data)
@@ -97,6 +99,7 @@ func TestSlashingInfo_MarshalSSZ_UnmarshalSSZ(t *testing.T) {
 }
 
 func TestSlashingInfo_GetTree(t *testing.T) {
+	t.Parallel()
 	data := generateSlashingInfo()
 
 	tree, err := data.GetTree()
@@ -109,6 +112,7 @@ func TestSlashingInfo_GetTree(t *testing.T) {
 }
 
 func TestSlashingInfo_SetSlot(t *testing.T) {
+	t.Parallel()
 	data := generateSlashingInfo()
 
 	newSlot := math.Slot(67890)
@@ -118,6 +122,7 @@ func TestSlashingInfo_SetSlot(t *testing.T) {
 }
 
 func TestSlashingInfo_SetIndex(t *testing.T) {
+	t.Parallel()
 	data := generateSlashingInfo()
 
 	newIndex := math.U64(12345)

--- a/consensus-types/types/state_test.go
+++ b/consensus-types/types/state_test.go
@@ -129,6 +129,7 @@ func generateRandomBytes32(count int) []common.Bytes32 {
 }
 
 func TestBeaconStateMarshalUnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	genState := generateValidBeaconState()
 
 	data, fastSSZMarshalErr := genState.MarshalSSZ()
@@ -146,6 +147,7 @@ func TestBeaconStateMarshalUnmarshalSSZ(t *testing.T) {
 }
 
 func TestHashTreeRoot(t *testing.T) {
+	t.Parallel()
 	state := generateValidBeaconState()
 	require.NotPanics(t, func() {
 		state.HashTreeRoot()
@@ -153,6 +155,7 @@ func TestHashTreeRoot(t *testing.T) {
 }
 
 func TestGetTree(t *testing.T) {
+	t.Parallel()
 	state := generateValidBeaconState()
 	tree, err := state.GetTree()
 	require.NoError(t, err)
@@ -160,12 +163,14 @@ func TestGetTree(t *testing.T) {
 }
 
 func TestBeaconState_UnmarshalSSZ_Error(t *testing.T) {
+	t.Parallel()
 	state := &types.BeaconState{}
 	err := state.UnmarshalSSZ([]byte{0x01, 0x02, 0x03}) // Invalid data
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
 func TestBeaconState_MarshalSSZTo(t *testing.T) {
+	t.Parallel()
 	state := generateValidBeaconState()
 	data, err := state.MarshalSSZ()
 	require.NoError(t, err)
@@ -180,6 +185,7 @@ func TestBeaconState_MarshalSSZTo(t *testing.T) {
 }
 
 func TestBeaconState_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	state := generateValidBeaconState()
 
 	// Get the HashTreeRoot

--- a/consensus-types/types/validator_test.go
+++ b/consensus-types/types/validator_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestNewValidatorFromDeposit(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                      string
 		pubkey                    crypto.BLSPubkey
@@ -142,6 +143,7 @@ func TestNewValidatorFromDeposit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := types.NewValidatorFromDeposit(
 				tt.pubkey,
 				tt.withdrawalCredentials,
@@ -155,6 +157,7 @@ func TestNewValidatorFromDeposit(t *testing.T) {
 }
 
 func TestValidator_IsActive(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		epoch     math.Epoch
@@ -191,12 +194,14 @@ func TestValidator_IsActive(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.want, tt.validator.IsActive(tt.epoch))
 		})
 	}
 }
 
 func TestValidator_IsEligibleForActivation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		finalizedEpoch math.Epoch
@@ -237,6 +242,7 @@ func TestValidator_IsEligibleForActivation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(
 				t,
 				tt.want,
@@ -247,6 +253,7 @@ func TestValidator_IsEligibleForActivation(t *testing.T) {
 }
 
 func TestValidator_IsEligibleForActivationQueue(t *testing.T) {
+	t.Parallel()
 	maxEffectiveBalance := math.Gwei(32e9)
 	tests := []struct {
 		name      string
@@ -284,6 +291,7 @@ func TestValidator_IsEligibleForActivationQueue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(
 				t,
 				tt.want,
@@ -294,6 +302,7 @@ func TestValidator_IsEligibleForActivationQueue(t *testing.T) {
 }
 
 func TestValidator_IsSlashable(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		epoch     math.Epoch
@@ -343,12 +352,14 @@ func TestValidator_IsSlashable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.want, tt.validator.IsSlashable(tt.epoch))
 		})
 	}
 }
 
 func TestValidator_IsFullyWithdrawable(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		balance   math.Gwei
@@ -409,6 +420,7 @@ func TestValidator_IsFullyWithdrawable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(
 				t,
 				tt.want,
@@ -419,6 +431,7 @@ func TestValidator_IsFullyWithdrawable(t *testing.T) {
 }
 
 func TestValidator_IsPartiallyWithdrawable(t *testing.T) {
+	t.Parallel()
 	maxEffectiveBalance := math.Gwei(32e9)
 	tests := []struct {
 		name      string
@@ -476,6 +489,7 @@ func TestValidator_IsPartiallyWithdrawable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(
 				t,
 				tt.want,
@@ -489,6 +503,7 @@ func TestValidator_IsPartiallyWithdrawable(t *testing.T) {
 }
 
 func TestValidator_HasEth1WithdrawalCredentials(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		validator *types.Validator
@@ -516,6 +531,7 @@ func TestValidator_HasEth1WithdrawalCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(
 				t,
 				tt.want,
@@ -526,6 +542,7 @@ func TestValidator_HasEth1WithdrawalCredentials(t *testing.T) {
 }
 
 func TestValidator_HasMaxEffectiveBalance(t *testing.T) {
+	t.Parallel()
 	maxEffectiveBalance := math.Gwei(32e9)
 	tests := []struct {
 		name      string
@@ -549,6 +566,7 @@ func TestValidator_HasMaxEffectiveBalance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(
 				t,
 				tt.want,
@@ -559,6 +577,7 @@ func TestValidator_HasMaxEffectiveBalance(t *testing.T) {
 }
 
 func TestValidator_MarshalUnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		validator  *types.Validator
@@ -657,6 +676,7 @@ func TestValidator_MarshalUnmarshalSSZ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if tt.invalidSSZ {
 				// Create a byte slice with an invalid size (not 121)
 				invalidSizeData := make([]byte, 120)
@@ -696,6 +716,7 @@ func TestValidator_MarshalUnmarshalSSZ(t *testing.T) {
 }
 
 func TestValidator_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		validator *types.Validator
@@ -744,6 +765,7 @@ func TestValidator_HashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Test HashTreeRoot
 			root := tt.validator.HashTreeRoot()
 			require.NotEqual(t, [32]byte{}, root)
@@ -762,6 +784,7 @@ func TestValidator_HashTreeRoot(t *testing.T) {
 }
 
 func TestValidator_SetEffectiveBalance(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		balance   math.Gwei
@@ -787,6 +810,7 @@ func TestValidator_SetEffectiveBalance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tt.validator.SetEffectiveBalance(tt.balance)
 			require.Equal(t, tt.want, tt.validator.EffectiveBalance,
 				"Test case: %s", tt.name)
@@ -795,6 +819,7 @@ func TestValidator_SetEffectiveBalance(t *testing.T) {
 }
 
 func TestValidator_GetWithdrawableEpoch(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		validator *types.Validator
@@ -817,6 +842,7 @@ func TestValidator_GetWithdrawableEpoch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.validator.GetWithdrawableEpoch()
 			require.Equal(t, tt.want, got, "Test case: %s", tt.name)
 		})
@@ -824,6 +850,7 @@ func TestValidator_GetWithdrawableEpoch(t *testing.T) {
 }
 
 func TestValidator_GetWithdrawalCredentials(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		validator *types.Validator
@@ -851,6 +878,7 @@ func TestValidator_GetWithdrawalCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.validator.GetWithdrawalCredentials()
 			require.Equal(t, tt.want, got, "Test case: %s", tt.name)
 		})
@@ -858,6 +886,7 @@ func TestValidator_GetWithdrawalCredentials(t *testing.T) {
 }
 
 func TestValidator_IsSlashed(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		validator *types.Validator
@@ -880,6 +909,7 @@ func TestValidator_IsSlashed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.validator.IsSlashed()
 			require.Equal(t, tt.want, got, "Test case: %s", tt.name)
 		})
@@ -887,6 +917,7 @@ func TestValidator_IsSlashed(t *testing.T) {
 }
 
 func TestValidator_GetPubkey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		validator *types.Validator
@@ -909,6 +940,7 @@ func TestValidator_GetPubkey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.validator.GetPubkey()
 			require.Equal(t, tt.want, got, "Test case: %s", tt.name)
 		})
@@ -916,6 +948,7 @@ func TestValidator_GetPubkey(t *testing.T) {
 }
 
 func TestValidator_GetEffectiveBalance(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		validator *types.Validator
@@ -945,6 +978,7 @@ func TestValidator_GetEffectiveBalance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.validator.GetEffectiveBalance()
 			require.Equal(t, tt.want, got, "Test case: %s", tt.name)
 		})

--- a/consensus-types/types/withdrawal_credentials_test.go
+++ b/consensus-types/types/withdrawal_credentials_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestNewCredentialsFromExecutionAddress(t *testing.T) {
+	t.Parallel()
 	address := common.ExecutionAddress{0xde, 0xad, 0xbe, 0xef}
 	expectedCredentials := types.WithdrawalCredentials{}
 	expectedCredentials[0] = 0x01 // EthSecp256k1CredentialPrefix
@@ -65,6 +66,7 @@ func TestNewCredentialsFromExecutionAddress(t *testing.T) {
 }
 
 func TestIsValidEth1WithdrawalCredentials(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		wc       types.WithdrawalCredentials
@@ -109,6 +111,7 @@ func TestIsValidEth1WithdrawalCredentials(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.wc.IsValidEth1WithdrawalCredentials()
 			require.Equal(t, tt.expected, result,
 				"Test case %s", tt.name)
@@ -117,6 +120,7 @@ func TestIsValidEth1WithdrawalCredentials(t *testing.T) {
 }
 
 func TestToExecutionAddress(t *testing.T) {
+	t.Parallel()
 	expectedAddress := common.ExecutionAddress{0xde, 0xad, 0xbe, 0xef}
 	credentials := types.WithdrawalCredentials{}
 	for i := range credentials {
@@ -143,6 +147,7 @@ func TestToExecutionAddress(t *testing.T) {
 }
 
 func TestToExecutionAddress_InvalidPrefix(t *testing.T) {
+	t.Parallel()
 	credentials := types.WithdrawalCredentials{}
 	for i := range credentials {
 		credentials[i] = 0x00 // Invalid prefix
@@ -154,6 +159,7 @@ func TestToExecutionAddress_InvalidPrefix(t *testing.T) {
 }
 
 func TestWithdrawalCredentials_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -176,6 +182,7 @@ func TestWithdrawalCredentials_UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var wc types.WithdrawalCredentials
 
 			err := wc.UnmarshalJSON([]byte(tt.input))
@@ -190,6 +197,7 @@ func TestWithdrawalCredentials_UnmarshalJSON(t *testing.T) {
 }
 
 func TestWithdrawalCredentials_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		wc       types.WithdrawalCredentials
@@ -220,6 +228,7 @@ func TestWithdrawalCredentials_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.expected, tt.wc.String(),
 				"Test case %s", tt.name)
 		})
@@ -227,6 +236,7 @@ func TestWithdrawalCredentials_String(t *testing.T) {
 }
 
 func TestWithdrawalCredentials_MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		wc       types.WithdrawalCredentials
@@ -268,6 +278,7 @@ func TestWithdrawalCredentials_MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := tt.wc.MarshalText()
 			if tt.wantErr {
 				require.Error(t, err, "Test case %s", tt.name)
@@ -281,6 +292,7 @@ func TestWithdrawalCredentials_MarshalText(t *testing.T) {
 }
 
 func TestWithdrawalCredentials_UnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []byte
@@ -303,6 +315,7 @@ func TestWithdrawalCredentials_UnmarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var wc types.WithdrawalCredentials
 			err := wc.UnmarshalText(tt.input)
 			if tt.wantErr {

--- a/da/kzg/ckzg/ckzg_no_cgo_test.go
+++ b/da/kzg/ckzg/ckzg_no_cgo_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestVerifyBlobKZGProof(t *testing.T) {
+	t.Parallel()
 	validBlob, validProof, validCommitment := setupTestData(
 		t, "test_data.json")
 
@@ -55,6 +56,7 @@ func TestVerifyBlobKZGProof(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			err := globalVerifier.VerifyBlobProof(
 				tc.blob,
 				tc.proof,
@@ -75,6 +77,7 @@ func TestVerifyBlobKZGProof(t *testing.T) {
 
 // TestVerifyBlobProofBatch tests the valid proofs in batch.
 func TestVerifyBlobProofBatch(t *testing.T) {
+	t.Parallel()
 	if globalVerifier == nil {
 		t.Fatal("globalVerifier is not initialized")
 	}
@@ -128,6 +131,7 @@ func TestVerifyBlobProofBatch(t *testing.T) {
 // TestVerifyBlobKZGInvalidProof tests the VerifyBlobProof function for invalid
 // proofs.
 func TestVerifyBlobKZGInvalidProof(t *testing.T) {
+	t.Parallel()
 	validBlob, invalidProof, validCommitment := setupTestData(
 		t, "test_data_incorrect_proof.json")
 	testCases := []struct {
@@ -148,6 +152,7 @@ func TestVerifyBlobKZGInvalidProof(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			err := globalVerifier.VerifyBlobProof(
 				tc.blob,
 				tc.proof,
@@ -163,6 +168,7 @@ func TestVerifyBlobKZGInvalidProof(t *testing.T) {
 }
 
 func TestGetImplementation(t *testing.T) {
+	t.Parallel()
 	require.NotNil(t, globalVerifier)
 	require.Equal(t, "ethereum/c-kzg-4844", globalVerifier.GetImplementation())
 }

--- a/da/kzg/config_test.go
+++ b/da/kzg/config_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestDefaultConfig(t *testing.T) {
+	t.Parallel()
 	cfg := kzg.DefaultConfig()
 	require.Equal(
 		t,

--- a/da/kzg/gokzg/gokzg_test.go
+++ b/da/kzg/gokzg/gokzg_test.go
@@ -36,6 +36,7 @@ import (
 var baseDir = "../../../testing/files/"
 
 func TestVerifyBlobProof(t *testing.T) {
+	t.Parallel()
 	verifier, err := setupVerifier()
 	require.NoError(t, err)
 	validBlob, validProof, validCommitment := setupTestData(
@@ -65,6 +66,7 @@ func TestVerifyBlobProof(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			errVerify := verifier.VerifyBlobProof(
 				tc.blob,
 				tc.proof,
@@ -82,6 +84,7 @@ func TestVerifyBlobProof(t *testing.T) {
 // TestVerifyBlobProofBatch tests the VerifyBlobProofBatch function
 // for valid proofs.
 func TestVerifyBlobProofBatch(t *testing.T) {
+	t.Parallel()
 	// Load the test data
 	verifier, err := setupVerifier()
 	require.NoError(t, err)
@@ -127,6 +130,7 @@ func TestVerifyBlobProofBatch(t *testing.T) {
 }
 
 func TestGetImplementation(t *testing.T) {
+	t.Parallel()
 	verifier, err := setupVerifier()
 	require.NoError(t, err)
 

--- a/da/kzg/noop/noop_test.go
+++ b/da/kzg/noop/noop_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestVerifyBlobProof(t *testing.T) {
+	t.Parallel()
 	verifier := noop.NewVerifier()
 	err := verifier.VerifyBlobProof(
 		&eip4844.Blob{},
@@ -41,6 +42,7 @@ func TestVerifyBlobProof(t *testing.T) {
 }
 
 func TestVerifyBlobProofBatch(t *testing.T) {
+	t.Parallel()
 	verifier := noop.NewVerifier()
 	args := &types.BlobProofArgs{
 		Blobs:       []*eip4844.Blob{{}},

--- a/da/kzg/proof_test.go
+++ b/da/kzg/proof_test.go
@@ -39,6 +39,7 @@ import (
 var baseDir = "../../testing/files/"
 
 func TestNewBlobProofVerifier_KzgImpl(t *testing.T) {
+	t.Parallel()
 	ts, err := loadTrustedSetupFromFile()
 	require.NoError(t, err)
 
@@ -49,6 +50,7 @@ func TestNewBlobProofVerifier_KzgImpl(t *testing.T) {
 }
 
 func TestNewBlobProofVerifier_CkzgImpl(t *testing.T) {
+	t.Parallel()
 	ts, err := loadTrustedSetupFromFile()
 	require.NoError(t, err)
 
@@ -59,6 +61,7 @@ func TestNewBlobProofVerifier_CkzgImpl(t *testing.T) {
 }
 
 func TestNewBlobProofVerifier_InvalidImpl(t *testing.T) {
+	t.Parallel()
 	ts, err := loadTrustedSetupFromFile()
 	require.NoError(t, err)
 
@@ -86,6 +89,7 @@ func loadTrustedSetupFromFile() (*gokzg4844.JSONTrustedSetup, error) {
 }
 
 func TestArgsFromSidecars(t *testing.T) {
+	t.Parallel()
 	fs := afero.NewOsFs()
 	fullPath := filepath.Join(baseDir, "test_data.json")
 	file, err := afero.ReadFile(fs, fullPath)

--- a/da/store/store_test.go
+++ b/da/store/store_test.go
@@ -21,7 +21,6 @@
 package store_test
 
 import (
-	"os"
 	"testing"
 
 	"cosmossdk.io/log"
@@ -43,15 +42,13 @@ func setSlot(scs datypes.BlobSidecars, slot math.Slot) {
 }
 
 func TestStore_PersistRace(t *testing.T) {
+	t.Parallel()
 	// This test case needs to be run with the '-race' flag
-	tmpFilePath := "/tmp/store_test"
+	tmpFilePath := t.TempDir()
 
 	logger := log.NewNopLogger()
 	chainSpec, err := spec.DevnetChainSpec()
 	require.NoError(t, err)
-
-	// Remove DB when we're done
-	defer os.RemoveAll(tmpFilePath)
 
 	// Create the DB
 	s := store.New(

--- a/da/types/sidecar_test.go
+++ b/da/types/sidecar_test.go
@@ -42,6 +42,7 @@ import (
 )
 
 func TestSidecarMarshalling(t *testing.T) {
+	t.Parallel()
 	// Create a sample BlobSidecar
 	blob := eip4844.Blob{}
 	for i := range blob {
@@ -141,6 +142,7 @@ type InclusionSink struct{}
 func (is InclusionSink) MeasureSince(_ string, _ time.Time, _ ...string) {}
 
 func TestHasValidInclusionProof(t *testing.T) {
+	t.Parallel()
 	spec, err := spec.DevnetChainSpec()
 	require.NoError(t, err)
 
@@ -226,6 +228,7 @@ func TestHasValidInclusionProof(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			sidecars := tt.sidecars(t)
 			for _, sidecar := range sidecars {
 				result := sidecar.HasValidInclusionProof()
@@ -241,6 +244,7 @@ func TestHasValidInclusionProof(t *testing.T) {
 // This test explains the calculation of the KZG commitment root's Merkle index
 // in the Body's Merkle tree based on the index of the KZG commitment list in the Body.
 func Test_KZGRootIndex(t *testing.T) {
+	t.Parallel()
 	// Level of the KZG commitment root's parent.
 	kzgParentRootLevel := log.ILog2Ceil(ctypes.KZGPositionDeneb)
 	require.NotEqual(t, 0, kzgParentRootLevel)
@@ -255,6 +259,7 @@ func Test_KZGRootIndex(t *testing.T) {
 }
 
 func TestHashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		sidecar        func(t *testing.T) *types.BlobSidecar
@@ -301,6 +306,7 @@ func TestHashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.NotPanics(t, func() {
 				sidecar := tt.sidecar(t)
 				result := sidecar.HashTreeRoot()

--- a/da/types/sidecars_test.go
+++ b/da/types/sidecars_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestEmptySidecarMarshalling(t *testing.T) {
+	t.Parallel()
 	inclusionProof := make([]common.Root, 0)
 	// Create an empty BlobSidecar
 	for i := 1; i <= ctypes.KZGInclusionProofDepth; i++ {
@@ -88,6 +89,7 @@ func TestEmptySidecarMarshalling(t *testing.T) {
 }
 
 func TestValidateBlockRoots(t *testing.T) {
+	t.Parallel()
 	inclusionProof := make([]common.Root, 0)
 	// Create a sample BlobSidecar with valid roots
 	for i := 1; i <= ctypes.KZGInclusionProofDepth; i++ {
@@ -152,6 +154,7 @@ func TestValidateBlockRoots(t *testing.T) {
 }
 
 func TestZeroSidecarsInBlobSidecarsIsNotNil(t *testing.T) {
+	t.Parallel()
 	// This test exists to ensure that proposing a BlobSidecars with 0
 	// Sidecars is not considered IsNil().
 	sidecars := &types.BlobSidecars{}

--- a/engine-primitives/engine-primitives/attributes_test.go
+++ b/engine-primitives/engine-primitives/attributes_test.go
@@ -39,6 +39,7 @@ type payloadAttributesInput struct {
 }
 
 func TestPayloadAttributes(t *testing.T) {
+	t.Parallel()
 	// default valid data
 	validInput := payloadAttributesInput{
 		forkVersion:           version.Altair(),
@@ -92,6 +93,7 @@ func TestPayloadAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			in := tt.input()
 			got, err := engineprimitives.NewPayloadAttributes(
 				in.forkVersion,

--- a/engine-primitives/engine-primitives/blobs_bundle_test.go
+++ b/engine-primitives/engine-primitives/blobs_bundle_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestBlobsBundleV1(t *testing.T) {
+	t.Parallel()
 	bundle := &engineprimitives.BlobsBundleV1[[48]byte, [48]byte, [131072]byte]{
 		Commitments: [][48]byte{{1, 2, 3}, {4, 5, 6}},
 		Proofs:      [][48]byte{{7, 8, 9}, {10, 11, 12}},

--- a/engine-primitives/engine-primitives/engine_test.go
+++ b/engine-primitives/engine-primitives/engine_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestPayloadID(t *testing.T) {
+	t.Parallel()
 	payloadID := engineprimitives.PayloadID{
 		0x1,
 		0x2,
@@ -54,6 +55,7 @@ func TestPayloadID(t *testing.T) {
 }
 
 func TestForkchoiceStateV1(t *testing.T) {
+	t.Parallel()
 	state := &engineprimitives.ForkchoiceStateV1{
 		HeadBlockHash:      common.ExecutionHash{0x1},
 		SafeBlockHash:      common.ExecutionHash{0x2},
@@ -79,6 +81,7 @@ func TestForkchoiceStateV1(t *testing.T) {
 }
 
 func TestPayloadStatusV1(t *testing.T) {
+	t.Parallel()
 	status := &engineprimitives.PayloadStatusV1{
 		Status:          engineprimitives.PayloadStatusValid,
 		LatestValidHash: &common.ExecutionHash{0x1},

--- a/engine-primitives/engine-primitives/transactions_test.go
+++ b/engine-primitives/engine-primitives/transactions_test.go
@@ -111,8 +111,10 @@ var prysmConsistencyTests = []struct {
 // (engineprimitives.Transactions and engine.primitivesBartioTransactions
 // respectively) since those will be deprecated soon.
 func TestProperTransactions(t *testing.T) {
+	t.Parallel()
 	for _, tt := range prysmConsistencyTests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := engineprimitives.Transactions(
 				tt.txs,
 			).HashTreeRoot()

--- a/engine-primitives/engine-primitives/withdrawal_ssz_test.go
+++ b/engine-primitives/engine-primitives/withdrawal_ssz_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestWithdrawalSSZ(t *testing.T) {
+	t.Parallel()
 	withdrawal := &engineprimitives.Withdrawal{
 		Index:     math.U64(1),
 		Validator: math.ValidatorIndex(2),
@@ -52,6 +53,7 @@ func TestWithdrawalSSZ(t *testing.T) {
 }
 
 func TestWithdrawalGetTree(t *testing.T) {
+	t.Parallel()
 	withdrawal := &engineprimitives.Withdrawal{
 		Index:     math.U64(1),
 		Validator: math.ValidatorIndex(2),
@@ -65,6 +67,7 @@ func TestWithdrawalGetTree(t *testing.T) {
 }
 
 func TestWithdrawalUnmarshalSSZ(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   []byte
@@ -123,6 +126,7 @@ func TestWithdrawalUnmarshalSSZ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			w := &engineprimitives.Withdrawal{}
 			err := w.UnmarshalSSZ(tt.input)
 

--- a/engine-primitives/engine-primitives/withdrawal_test.go
+++ b/engine-primitives/engine-primitives/withdrawal_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestWithdrawal(t *testing.T) {
+	t.Parallel()
 	withdrawal := engineprimitives.NewWithdrawal(
 		math.U64(1),
 		math.ValidatorIndex(1),
@@ -47,6 +48,7 @@ func TestWithdrawal(t *testing.T) {
 }
 
 func TestWithdrawal_Equals(t *testing.T) {
+	t.Parallel()
 	withdrawal1 := &engineprimitives.Withdrawal{
 		Index:     math.U64(1),
 		Validator: math.ValidatorIndex(1),
@@ -76,6 +78,7 @@ func TestWithdrawal_Equals(t *testing.T) {
 }
 
 func TestWithdrawalMethods(t *testing.T) {
+	t.Parallel()
 	withdrawal := &engineprimitives.Withdrawal{
 		Index:     math.U64(1),
 		Validator: math.ValidatorIndex(2),
@@ -84,6 +87,7 @@ func TestWithdrawalMethods(t *testing.T) {
 	}
 
 	t.Run("Getters", func(t *testing.T) {
+		t.Parallel()
 		require.Equal(t, math.U64(1), withdrawal.GetIndex())
 		require.Equal(t, math.ValidatorIndex(2), withdrawal.GetValidatorIndex())
 		require.Equal(t, common.ExecutionAddress([20]byte{0x01, 0x02, 0x03}),

--- a/engine-primitives/engine-primitives/withdrawals_test.go
+++ b/engine-primitives/engine-primitives/withdrawals_test.go
@@ -31,7 +31,9 @@ import (
 )
 
 func TestWithdrawals(t *testing.T) {
+	t.Parallel()
 	t.Run("SizeSSZ", func(t *testing.T) {
+		t.Parallel()
 		withdrawals := engineprimitives.Withdrawals{
 			{Index: 1, Validator: 2, Address: [20]byte{1, 2, 3}, Amount: 100},
 			{Index: 3, Validator: 4, Address: [20]byte{4, 5, 6}, Amount: 200},
@@ -43,6 +45,7 @@ func TestWithdrawals(t *testing.T) {
 	})
 
 	t.Run("HashTreeRoot", func(t *testing.T) {
+		t.Parallel()
 		withdrawals := engineprimitives.Withdrawals{
 			{Index: 1, Validator: 2, Address: [20]byte{1, 2, 3}, Amount: 100},
 			{Index: 3, Validator: 4, Address: [20]byte{4, 5, 6}, Amount: 200},
@@ -52,6 +55,7 @@ func TestWithdrawals(t *testing.T) {
 	})
 
 	t.Run("HashTreeRoot", func(t *testing.T) {
+		t.Parallel()
 		withdrawals := engineprimitives.Withdrawals{
 			{
 				Index:     math.U64(1),
@@ -85,6 +89,7 @@ func TestWithdrawals(t *testing.T) {
 	})
 
 	t.Run("HashTreeRoot of Empty List", func(t *testing.T) {
+		t.Parallel()
 		emptyWithdrawals := engineprimitives.Withdrawals{}
 		emptyRoot := emptyWithdrawals.HashTreeRoot()
 		require.NotEmpty(t, emptyRoot)

--- a/execution/client/ethclient/engine_test.go
+++ b/execution/client/ethclient/engine_test.go
@@ -36,6 +36,7 @@ import (
 // TestGetPayloadV3NeverReturnsEmptyPayload shows that execution payload
 // returned by ethClient is not nil.
 func TestGetPayloadV3NeverReturnsEmptyPayload(t *testing.T) {
+	t.Parallel()
 	c := ethclient.New(&stubRPCClient{t: t})
 
 	var (
@@ -53,6 +54,7 @@ func TestGetPayloadV3NeverReturnsEmptyPayload(t *testing.T) {
 
 // TestNewPayloadWithValidVersion tests that NewPayload correctly handles Deneb version.
 func TestNewPayloadWithValidVersion(t *testing.T) {
+	t.Parallel()
 	c := ethclient.New(&stubRPCClient{t: t})
 	ctx := context.Background()
 
@@ -66,6 +68,7 @@ func TestNewPayloadWithValidVersion(t *testing.T) {
 
 // TestNewPayloadWithInvalidVersion tests that NewPayload returns ErrInvalidVersion for Capella.
 func TestNewPayloadWithInvalidVersion(t *testing.T) {
+	t.Parallel()
 	c := ethclient.New(&stubRPCClient{t: t})
 	ctx := context.Background()
 
@@ -79,6 +82,20 @@ func TestNewPayloadWithInvalidVersion(t *testing.T) {
 
 // TestForkchoiceUpdatedWithValidVersion tests that ForkchoiceUpdated correctly handles Deneb version.
 func TestForkchoiceUpdatedWithValidVersion(t *testing.T) {
+	t.Parallel()
+	c := ethclient.New(&stubRPCClient{t: t})
+	ctx := context.Background()
+
+	state := &engineprimitives.ForkchoiceStateV1{}
+	attrs := struct{}{}
+	forkVersion := version.Deneb1()
+
+	_, err := c.ForkchoiceUpdated(ctx, state, attrs, forkVersion)
+	require.NoError(t, err)
+}
+
+func TestForkchoiceUpdatedWithValidVersion2(t *testing.T) {
+	t.Parallel()
 	c := ethclient.New(&stubRPCClient{t: t})
 	ctx := context.Background()
 
@@ -92,6 +109,7 @@ func TestForkchoiceUpdatedWithValidVersion(t *testing.T) {
 
 // TestForkchoiceUpdatedWithInvalidVersion tests that ForkchoiceUpdated returns ErrInvalidVersion for Capella.
 func TestForkchoiceUpdatedWithInvalidVersion(t *testing.T) {
+	t.Parallel()
 	c := ethclient.New(&stubRPCClient{t: t})
 	ctx := context.Background()
 
@@ -105,6 +123,7 @@ func TestForkchoiceUpdatedWithInvalidVersion(t *testing.T) {
 
 // TestGetPayloadWithValidVersion tests that GetPayload correctly handles >= Deneb version.
 func TestGetPayloadWithValidVersion(t *testing.T) {
+	t.Parallel()
 	c := ethclient.New(&stubRPCClient{t: t})
 	ctx := context.Background()
 
@@ -117,6 +136,7 @@ func TestGetPayloadWithValidVersion(t *testing.T) {
 
 // TestGetPayloadWithInvalidVersion tests that GetPayload returns ErrInvalidVersion for Capella.
 func TestGetPayloadWithInvalidVersion(t *testing.T) {
+	t.Parallel()
 	c := ethclient.New(&stubRPCClient{t: t})
 	ctx := context.Background()
 

--- a/log/noop/noop_test.go
+++ b/log/noop/noop_test.go
@@ -27,34 +27,39 @@ import (
 )
 
 func TestNewLogger(t *testing.T) {
+	t.Parallel()
 	logger := noop.NewLogger[any]()
 	if logger == nil {
 		t.Error("Expected NewLogger to return a non-nil logger")
 	}
 }
 
-func TestLogger_Info(*testing.T) {
+func TestLogger_Info(t *testing.T) {
+	t.Parallel()
 	logger := noop.NewLogger[any]()
 	logger.Info("test message", "key1", "value1", "key2", "value2")
 	// Since it's a no-op logger, there's nothing to assert. This test just
 	// ensures no panic occurs.
 }
 
-func TestLogger_Warn(*testing.T) {
+func TestLogger_Warn(t *testing.T) {
+	t.Parallel()
 	logger := noop.NewLogger[any]()
 	logger.Warn("test warning", "key1", "value1", "key2", "value2")
 	// Since it's a no-op logger, there's nothing to assert. This test just
 	// ensures no panic occurs.
 }
 
-func TestLogger_Error(*testing.T) {
+func TestLogger_Error(t *testing.T) {
+	t.Parallel()
 	logger := noop.NewLogger[any]()
 	logger.Error("test error", "key1", "value1", "key2", "value2")
 	// Since it's a no-op logger, there's nothing to assert. This test just
 	// ensures no panic occurs.
 }
 
-func TestLogger_Debug(*testing.T) {
+func TestLogger_Debug(t *testing.T) {
+	t.Parallel()
 	logger := noop.NewLogger[any]()
 	logger.Debug("test debug", "key1", "value1", "key2", "value2")
 	// Since it's a no-op logger, there's nothing to assert. This test just

--- a/node-api/handlers/proof/merkle/beacon_state_test.go
+++ b/node-api/handlers/proof/merkle/beacon_state_test.go
@@ -33,6 +33,7 @@ import (
 // TestProveBeaconStateInBlock tests the ProveBeaconStateInBlock function and
 // that the generated proof correctly verifies.
 func TestProveBeaconStateInBlock(t *testing.T) {
+	t.Parallel()
 	bbh := (&types.BeaconBlockHeader{}).Empty()
 
 	testCases := []struct {

--- a/node-api/handlers/proof/merkle/block_proposer_index_test.go
+++ b/node-api/handlers/proof/merkle/block_proposer_index_test.go
@@ -33,6 +33,7 @@ import (
 // TestBlockProposerIndexProof tests the ProveProposerIndexInBlock function
 // and that the generated proof correctly verifies.
 func TestBlockProposerIndexProof(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name              string
 		slot              math.Slot
@@ -64,6 +65,7 @@ func TestBlockProposerIndexProof(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			bbh := types.NewBeaconBlockHeader(
 				tc.slot,
 				tc.proposerIndex,

--- a/node-api/handlers/proof/merkle/block_proposer_pubkey_test.go
+++ b/node-api/handlers/proof/merkle/block_proposer_pubkey_test.go
@@ -35,6 +35,7 @@ import (
 // TestBlockProposerPubkeyProof tests the ProveProposerPubkeyInBlock function
 // and that the generated proof correctly verifies.
 func TestBlockProposerPubkeyProof(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name              string
 		numValidators     int

--- a/node-api/handlers/proof/merkle/constants_test.go
+++ b/node-api/handlers/proof/merkle/constants_test.go
@@ -112,6 +112,7 @@ var (
 // TestGIndexProposerIndexDeneb tests the generalized index of the proposer
 // index in the beacon block on the Deneb fork.
 func TestGIndexProposerIndexDeneb(t *testing.T) {
+	t.Parallel()
 	// GIndex of the proposer index in the beacon block.
 	_, proposerIndexGIndexDenebBlock, _, err := mlib.ObjectPath[
 		mlib.GeneralizedIndex, [32]byte,
@@ -127,6 +128,7 @@ func TestGIndexProposerIndexDeneb(t *testing.T) {
 // TestGIndicesValidatorPubkeyDeneb tests the generalized indices used by
 // beacon state proofs for validator pubkeys on the Deneb fork.
 func TestGIndicesValidatorPubkeyDeneb(t *testing.T) {
+	t.Parallel()
 	// GIndex of state in the block.
 	_, stateGIndexDenebBlock, _, err := mlib.ObjectPath[
 		mlib.GeneralizedIndex, [32]byte,
@@ -178,6 +180,7 @@ func TestGIndicesValidatorPubkeyDeneb(t *testing.T) {
 // TestGInidicesExecutionDeneb tests the generalized indices used by
 // beacon state proofs from the execution payload header on the Deneb fork.
 func TestGInidicesExecutionDeneb(t *testing.T) {
+	t.Parallel()
 	// GIndex of the execution number in the state.
 	_, executionNumberGIndexDenebState, _, err := mlib.ObjectPath[
 		mlib.GeneralizedIndex, [32]byte,

--- a/node-api/handlers/proof/merkle/execution_fee_recipient_test.go
+++ b/node-api/handlers/proof/merkle/execution_fee_recipient_test.go
@@ -34,6 +34,7 @@ import (
 // TestExecutionFeeRecipientProof tests the ProveExecutionFeeRecipientInBlock
 // function and that the generated proof correctly verifies.
 func TestExecutionFeeRecipientProof(t *testing.T) {
+	t.Parallel()
 	var proof []common.Root
 
 	testCases := []struct {

--- a/node-api/handlers/proof/merkle/execution_number_test.go
+++ b/node-api/handlers/proof/merkle/execution_number_test.go
@@ -34,6 +34,7 @@ import (
 // TestExecutionNumberProof tests the ProveExecutionNumberInBlock
 // function and that the generated proof correctly verifies.
 func TestExecutionNumberProof(t *testing.T) {
+	t.Parallel()
 	var proof []common.Root
 
 	testCases := []struct {

--- a/node-core/services/registry/registry_test.go
+++ b/node-core/services/registry/registry_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestRegistry_StartAll(t *testing.T) {
+	t.Parallel()
 	logger := noop.NewLogger[any]()
 	registry := service.NewRegistry(logger)
 
@@ -63,6 +64,7 @@ func TestRegistry_StartAll(t *testing.T) {
 }
 
 func TestRegistry_FetchService(t *testing.T) {
+	t.Parallel()
 	logger := noop.NewLogger[any]()
 	registry := service.NewRegistry(logger)
 

--- a/payload/builder/errors.go
+++ b/payload/builder/errors.go
@@ -37,4 +37,7 @@ var (
 	// ErrNilPayloadEnvelope is returned when a nil payload envelope is
 	// received.
 	ErrNilPayloadEnvelope = errors.New("received nil payload envelope")
+
+	// ErrNilWithdrawals is returned when nil withdrawals list is received.
+	ErrNilWithdrawals = errors.New("nil withdrawals received from execution client")
 )

--- a/payload/builder/payload.go
+++ b/payload/builder/payload.go
@@ -255,5 +255,8 @@ func (pb *PayloadBuilder) getPayload(
 	if envelope == nil {
 		return nil, ErrNilPayloadEnvelope
 	}
+	if envelope.GetExecutionPayload().Withdrawals == nil {
+		return nil, ErrNilWithdrawals
+	}
 	return envelope, nil
 }

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package builder_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/berachain/beacon-kit/config/spec"
+	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
+	engineprimitives "github.com/berachain/beacon-kit/engine-primitives/engine-primitives"
+	"github.com/berachain/beacon-kit/errors"
+	"github.com/berachain/beacon-kit/log/noop"
+	"github.com/berachain/beacon-kit/payload/builder"
+	"github.com/berachain/beacon-kit/payload/cache"
+	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/eip4844"
+	"github.com/berachain/beacon-kit/primitives/math"
+	statedb "github.com/berachain/beacon-kit/state-transition/core/state"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO cluster these tests into a single test table
+func TestRetrievePayloadSunnyPath(t *testing.T) {
+	t.Parallel()
+
+	chainSpec, err := spec.MainnetChainSpec()
+	require.NoError(t, err)
+
+	// Create payload builder
+	var (
+		logger = noop.NewLogger[any]()
+		cfg    = &builder.Config{Enabled: true}
+		ee     = &stubExecutionEngine{}
+		cache  = cache.NewPayloadIDCache[[32]byte, math.Slot]()
+		af     = &stubAttributesFactory{}
+	)
+	pb := builder.New(
+		cfg,
+		chainSpec,
+		logger,
+		ee,
+		cache,
+		af,
+	)
+
+	// create inputs and set expectations
+	var (
+		ctx             = context.TODO()
+		slot            = math.Slot(2025)
+		parentBlockRoot = common.Root{0xff, 0xaa}
+		dummyPayloadID  = engineprimitives.PayloadID{0xab}
+
+		expectedPayload = &ctypes.ExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1[
+			eip4844.KZGCommitment,
+			eip4844.KZGProof,
+			eip4844.Blob,
+		]]{
+			ExecutionPayload: &ctypes.ExecutionPayload{
+				Withdrawals: engineprimitives.Withdrawals{},
+			},
+			BlobsBundle: &engineprimitives.BlobsBundleV1[
+				eip4844.KZGCommitment,
+				eip4844.KZGProof,
+				eip4844.Blob,
+			]{},
+		}
+	)
+
+	// set expectations
+	cache.Set(slot, parentBlockRoot, dummyPayloadID)
+	ee.payloadEnvToReturn = expectedPayload
+
+	// test and checks
+	payload, err := pb.RetrievePayload(ctx, slot, parentBlockRoot)
+	require.NoError(t, err)
+	require.Equal(t, expectedPayload, payload)
+}
+
+func TestRetrievePayloadNilWithdrawalsListRejected(t *testing.T) {
+	t.Parallel()
+
+	chainSpec, err := spec.MainnetChainSpec()
+	require.NoError(t, err)
+
+	// Create payload builder
+	var (
+		logger = noop.NewLogger[any]()
+		cfg    = &builder.Config{Enabled: true}
+		ee     = &stubExecutionEngine{}
+		cache  = cache.NewPayloadIDCache[[32]byte, math.Slot]()
+		af     = &stubAttributesFactory{}
+	)
+	pb := builder.New(
+		cfg,
+		chainSpec,
+		logger,
+		ee,
+		cache,
+		af,
+	)
+
+	// create inputs
+	var (
+		ctx             = context.TODO()
+		slot            = math.Slot(2025)
+		parentBlockRoot = common.Root{0xff, 0xaa}
+		dummyPayloadID  = engineprimitives.PayloadID{0xab}
+
+		faultyPayload = &ctypes.ExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1[
+			eip4844.KZGCommitment,
+			eip4844.KZGProof,
+			eip4844.Blob,
+		]]{
+			ExecutionPayload: &ctypes.ExecutionPayload{
+				Withdrawals: nil, // empty withdrawals are fine, nil list should be rejected
+			},
+			BlobsBundle: &engineprimitives.BlobsBundleV1[
+				eip4844.KZGCommitment,
+				eip4844.KZGProof,
+				eip4844.Blob,
+			]{},
+		}
+	)
+
+	// set expectations
+	cache.Set(slot, parentBlockRoot, dummyPayloadID)
+	ee.payloadEnvToReturn = faultyPayload
+
+	// test and checks
+	_, err = pb.RetrievePayload(ctx, slot, parentBlockRoot)
+	require.ErrorIs(t, builder.ErrNilWithdrawals, err)
+}
+
+// HELPERS section
+
+var errStubNotImplemented = errors.New("stub not implemented")
+
+type stubExecutionEngine struct {
+	payloadEnvToReturn ctypes.BuiltExecutionPayloadEnv
+	errToReturn        error
+}
+
+func (ee *stubExecutionEngine) GetPayload(
+	context.Context, *ctypes.GetPayloadRequest,
+) (ctypes.BuiltExecutionPayloadEnv, error) {
+	return ee.payloadEnvToReturn, ee.errToReturn
+}
+
+func (ee *stubExecutionEngine) NotifyForkchoiceUpdate(
+	context.Context, *ctypes.ForkchoiceUpdateRequest,
+) (*engineprimitives.PayloadID, *common.ExecutionHash, error) {
+	return nil, nil, errStubNotImplemented
+}
+
+type stubAttributesFactory struct{}
+
+func (ee *stubAttributesFactory) BuildPayloadAttributes(
+	*statedb.StateDB, math.U64,
+	uint64, [32]byte,
+) (*engineprimitives.PayloadAttributes, error) {
+	return nil, errStubNotImplemented
+}

--- a/payload/cache/payload_id_test.go
+++ b/payload/cache/payload_id_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestPayloadIDCache(t *testing.T) {
+	t.Parallel()
 	cacheUnderTest := cache.NewPayloadIDCache[[32]byte, uint64]()
 
 	t.Run("Get from empty cache", func(t *testing.T) {

--- a/primitives/bytes/b20_test.go
+++ b/primitives/bytes/b20_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestBytes20MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B20
@@ -65,6 +66,7 @@ func TestBytes20MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalText()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, string(got))
@@ -73,6 +75,7 @@ func TestBytes20MarshalText(t *testing.T) {
 }
 
 func TestBytes20MarshalSSZ(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B20
@@ -93,6 +96,7 @@ func TestBytes20MarshalSSZ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalSSZ()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
@@ -101,6 +105,7 @@ func TestBytes20MarshalSSZ(t *testing.T) {
 }
 
 func TestBytes20HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B20
@@ -122,6 +127,7 @@ func TestBytes20HashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.HashTreeRoot()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
@@ -130,6 +136,7 @@ func TestBytes20HashTreeRoot(t *testing.T) {
 }
 
 func TestBytes20UnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -154,6 +161,7 @@ func TestBytes20UnmarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B20
 			err := got.UnmarshalText([]byte(tt.input))
 			if tt.wantErr {
@@ -167,6 +175,7 @@ func TestBytes20UnmarshalText(t *testing.T) {
 }
 
 func TestBytes20UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -191,6 +200,7 @@ func TestBytes20UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B20
 			err := got.UnmarshalJSON([]byte(tt.input))
 			if tt.wantErr {
@@ -204,6 +214,7 @@ func TestBytes20UnmarshalJSON(t *testing.T) {
 }
 
 func TestToBytes20(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   []byte
@@ -241,6 +252,7 @@ func TestToBytes20(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := bytes.ToBytes20(tt.input)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)

--- a/primitives/bytes/b32_test.go
+++ b/primitives/bytes/b32_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestBytes32UnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -87,6 +88,7 @@ func TestBytes32UnmarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B32
 			err := got.UnmarshalText([]byte(tt.input))
 			if tt.wantErr {
@@ -100,6 +102,7 @@ func TestBytes32UnmarshalText(t *testing.T) {
 }
 
 func TestBytes32UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -164,6 +167,7 @@ func TestBytes32UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B32
 			err := got.UnmarshalJSON([]byte(tt.input))
 			if tt.wantErr {
@@ -177,6 +181,7 @@ func TestBytes32UnmarshalJSON(t *testing.T) {
 }
 
 func TestBytes32MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B32
@@ -199,6 +204,7 @@ func TestBytes32MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalText()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, string(got))
@@ -207,6 +213,7 @@ func TestBytes32MarshalText(t *testing.T) {
 }
 
 func TestBytes32String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B32
@@ -229,6 +236,7 @@ func TestBytes32String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.input.String()
 			require.Equal(t, tt.want, got)
 		})
@@ -236,6 +244,7 @@ func TestBytes32String(t *testing.T) {
 }
 
 func TestToBytes32(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   []byte
@@ -264,6 +273,7 @@ func TestToBytes32(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := bytes.ToBytes32(tt.input)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -276,6 +286,7 @@ func TestToBytes32(t *testing.T) {
 }
 
 func TestB32MarshalSSZ(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B32
@@ -296,6 +307,7 @@ func TestB32MarshalSSZ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalSSZ()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)

--- a/primitives/bytes/b48_test.go
+++ b/primitives/bytes/b48_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestBytes48String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B48
@@ -97,6 +98,7 @@ func TestBytes48String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.input.String()
 			require.Equal(t, tt.want, got)
 		})
@@ -104,6 +106,7 @@ func TestBytes48String(t *testing.T) {
 }
 
 func TestBytes48MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B48
@@ -172,6 +175,7 @@ func TestBytes48MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalText()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, string(got))
@@ -180,6 +184,7 @@ func TestBytes48MarshalText(t *testing.T) {
 }
 
 func TestBytes48UnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -254,6 +259,7 @@ func TestBytes48UnmarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B48
 			err := got.UnmarshalText([]byte(tt.input))
 			if tt.wantErr {
@@ -267,6 +273,7 @@ func TestBytes48UnmarshalText(t *testing.T) {
 }
 
 func TestToBytes48(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   []byte
@@ -294,6 +301,7 @@ func TestToBytes48(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := bytes.ToBytes48(tt.input)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -306,6 +314,7 @@ func TestToBytes48(t *testing.T) {
 }
 
 func TestB48UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -340,6 +349,7 @@ func TestB48UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B48
 			err := got.UnmarshalJSON([]byte(tt.input))
 			if tt.wantErr {
@@ -353,6 +363,7 @@ func TestB48UnmarshalJSON(t *testing.T) {
 }
 
 func TestB48_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B48
@@ -367,6 +378,7 @@ func TestB48_HashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.input.HashTreeRoot()
 			require.Equal(t, tt.want, result)
 		})
@@ -374,6 +386,7 @@ func TestB48_HashTreeRoot(t *testing.T) {
 }
 
 func TestB48MarshalSSZ(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B48
@@ -398,6 +411,7 @@ func TestB48MarshalSSZ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalSSZ()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)

--- a/primitives/bytes/b4_test.go
+++ b/primitives/bytes/b4_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestFromUint32_CustomType(t *testing.T) {
+	t.Parallel()
 	input := uint32(123456789)
 	expected := bytes.B4{}
 	binary.LittleEndian.PutUint32(expected[:], input)
@@ -38,6 +39,7 @@ func TestFromUint32_CustomType(t *testing.T) {
 }
 
 func TestToUint32_CustomType(t *testing.T) {
+	t.Parallel()
 	input := bytes.B4{0x15, 0xCD, 0x5B, 0x07}
 	expected := uint32(123456789)
 
@@ -46,6 +48,7 @@ func TestToUint32_CustomType(t *testing.T) {
 }
 
 func TestBytes4UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -72,6 +75,7 @@ func TestBytes4UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B4
 			err := got.UnmarshalJSON([]byte(tt.input))
 			if tt.wantErr {
@@ -85,6 +89,7 @@ func TestBytes4UnmarshalJSON(t *testing.T) {
 }
 
 func TestBytes4String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		h    bytes.B4
@@ -104,6 +109,7 @@ func TestBytes4String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.h.String()
 			require.Equal(t, tt.want, got)
 		})
@@ -111,6 +117,7 @@ func TestBytes4String(t *testing.T) {
 }
 
 func TestBytes4MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		h    bytes.B4
@@ -140,6 +147,7 @@ func TestBytes4MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.h.MarshalText()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, string(got))
@@ -148,6 +156,7 @@ func TestBytes4MarshalText(t *testing.T) {
 }
 
 func TestBytes4UnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -174,6 +183,7 @@ func TestBytes4UnmarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B4
 			err := got.UnmarshalText([]byte(tt.input))
 			if tt.wantErr {
@@ -187,6 +197,7 @@ func TestBytes4UnmarshalText(t *testing.T) {
 }
 
 func TestToBytes4(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   []byte
@@ -220,6 +231,7 @@ func TestToBytes4(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := bytes.ToBytes4(tt.input)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -232,6 +244,7 @@ func TestToBytes4(t *testing.T) {
 }
 
 func TestBytes4MarshalSSZ(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B4
@@ -246,6 +259,7 @@ func TestBytes4MarshalSSZ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalSSZ()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
@@ -254,6 +268,7 @@ func TestBytes4MarshalSSZ(t *testing.T) {
 }
 
 func TestBytes4HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B4
@@ -268,6 +283,7 @@ func TestBytes4HashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.HashTreeRoot()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)

--- a/primitives/bytes/b8_test.go
+++ b/primitives/bytes/b8_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestBytes8UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -54,6 +55,7 @@ func TestBytes8UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B8
 			err := got.UnmarshalJSON([]byte(tt.input))
 			if tt.wantErr {
@@ -66,6 +68,7 @@ func TestBytes8UnmarshalJSON(t *testing.T) {
 }
 
 func TestBytes8String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		h    bytes.B8
@@ -85,6 +88,7 @@ func TestBytes8String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.h.String()
 			require.Equal(t, tt.want, got)
 		})
@@ -92,6 +96,7 @@ func TestBytes8String(t *testing.T) {
 }
 
 func TestBytes8MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		h    bytes.B8
@@ -126,6 +131,7 @@ func TestBytes8MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.h.MarshalText()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, string(got))
@@ -134,6 +140,7 @@ func TestBytes8MarshalText(t *testing.T) {
 }
 
 func TestBytes8UnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -160,6 +167,7 @@ func TestBytes8UnmarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B8
 			err := got.UnmarshalText([]byte(tt.input))
 			if tt.wantErr {
@@ -172,6 +180,7 @@ func TestBytes8UnmarshalText(t *testing.T) {
 }
 
 func TestToBytes8(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   []byte
@@ -208,6 +217,7 @@ func TestToBytes8(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := bytes.ToBytes8(tt.input)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -220,6 +230,7 @@ func TestToBytes8(t *testing.T) {
 }
 
 func TestBytes8MarshalSSZ(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B8
@@ -234,6 +245,7 @@ func TestBytes8MarshalSSZ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalSSZ()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
@@ -242,6 +254,7 @@ func TestBytes8MarshalSSZ(t *testing.T) {
 }
 
 func TestBytes8HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B8
@@ -256,6 +269,7 @@ func TestBytes8HashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.HashTreeRoot()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)

--- a/primitives/bytes/b96_test.go
+++ b/primitives/bytes/b96_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestBytes96UnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -64,6 +65,7 @@ func TestBytes96UnmarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B96
 			err := got.UnmarshalText([]byte(tt.input))
 			if tt.wantErr {
@@ -77,6 +79,7 @@ func TestBytes96UnmarshalText(t *testing.T) {
 }
 
 func TestBytes96UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -108,6 +111,7 @@ func TestBytes96UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got bytes.B96
 			err := got.UnmarshalJSON([]byte(tt.input))
 			if tt.wantErr {
@@ -120,6 +124,7 @@ func TestBytes96UnmarshalJSON(t *testing.T) {
 	}
 }
 func TestBytes96MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		h    bytes.B96
@@ -162,6 +167,7 @@ func TestBytes96MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.h.MarshalText()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, string(got))
@@ -170,6 +176,7 @@ func TestBytes96MarshalText(t *testing.T) {
 }
 
 func TestBytes96String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		h    bytes.B96
@@ -195,6 +202,7 @@ func TestBytes96String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.h.String()
 			require.Equal(t, tt.want, got)
 		})
@@ -202,6 +210,7 @@ func TestBytes96String(t *testing.T) {
 }
 
 func TestToBytes96(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   []byte
@@ -229,6 +238,7 @@ func TestToBytes96(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := bytes.ToBytes96(tt.input)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -241,6 +251,7 @@ func TestToBytes96(t *testing.T) {
 }
 
 func TestB96_HashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B96
@@ -255,6 +266,7 @@ func TestB96_HashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.input.HashTreeRoot()
 			require.Equal(t, tt.want, result)
 		})
@@ -284,6 +296,7 @@ func BenchmarkB96_UnmarshalJSON(b *testing.B) {
 }
 
 func TestB96MarshalSSZ(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B96
@@ -316,6 +329,7 @@ func TestB96MarshalSSZ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalSSZ()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)

--- a/primitives/bytes/b_test.go
+++ b/primitives/bytes/b_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestFromHex(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		input      string
@@ -71,6 +72,7 @@ func TestFromHex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := hex.ToBytes(tt.input)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -83,6 +85,7 @@ func TestFromHex(t *testing.T) {
 }
 
 func TestMustFromHex(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       string
@@ -117,6 +120,7 @@ func TestMustFromHex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var (
 				res []byte
 				f   = func() {
@@ -134,6 +138,7 @@ func TestMustFromHex(t *testing.T) {
 }
 
 func TestBytesUnmarshalJSONText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		input     []byte
@@ -163,6 +168,7 @@ func TestBytesUnmarshalJSONText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			b := &bytes.Bytes{}
 			err := b.UnmarshalJSON(tt.input)
 			if tt.expectErr {
@@ -175,6 +181,7 @@ func TestBytesUnmarshalJSONText(t *testing.T) {
 }
 
 func TestReverseEndianness(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []byte
@@ -196,6 +203,7 @@ func TestReverseEndianness(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := bytes.CopyAndReverseEndianess(tt.input)
 			require.Equal(t, tt.expected, result)
 		})
@@ -203,6 +211,7 @@ func TestReverseEndianness(t *testing.T) {
 }
 
 func TestHashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input bytes.B32
@@ -222,6 +231,7 @@ func TestHashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.input.HashTreeRoot()
 			require.Equal(t, tt.want, result)
 		})
@@ -229,6 +239,7 @@ func TestHashTreeRoot(t *testing.T) {
 }
 
 func TestUnmarshalFixedJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		typ      reflect.Type
@@ -265,6 +276,7 @@ func TestUnmarshalFixedJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := bytes.UnmarshalFixedJSON(tt.input, tt.out)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -277,6 +289,7 @@ func TestUnmarshalFixedJSON(t *testing.T) {
 }
 
 func TestUnmarshalFixedText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		typename string
@@ -313,6 +326,7 @@ func TestUnmarshalFixedText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := bytes.UnmarshalFixedText(tt.input, tt.out)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -325,6 +339,7 @@ func TestUnmarshalFixedText(t *testing.T) {
 }
 
 func TestBytes_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    bytes.Bytes
@@ -354,6 +369,7 @@ func TestBytes_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.input.String()
 			require.Equal(t, tt.expected, result)
 		})
@@ -361,6 +377,7 @@ func TestBytes_String(t *testing.T) {
 }
 
 func TestBytes_MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   bytes.Bytes
@@ -395,6 +412,7 @@ func TestBytes_MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.input.MarshalText()
 			if tt.wantErr {
 				require.Error(t, err)

--- a/primitives/bytes/buffer/buffer_test.go
+++ b/primitives/bytes/buffer/buffer_test.go
@@ -46,6 +46,7 @@ func getBuffer(usageType string) bufferI {
 
 // Test getting a slice of the internal re-usable buffer and modifying.
 func TestReusableGet(t *testing.T) {
+	t.Parallel()
 	buffer := getBuffer("reusable")
 
 	testCases := []struct {
@@ -88,6 +89,7 @@ func TestReusableGet(t *testing.T) {
 
 // Test getting a slice of the internal single-use buffer and modifying.
 func TestSingleuseGet(t *testing.T) {
+	t.Parallel()
 	buffer := getBuffer("singleuse")
 
 	testCases := []struct {

--- a/primitives/common/consensus_test.go
+++ b/primitives/common/consensus_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestNewRootFromHex(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       func() string
@@ -68,6 +69,7 @@ func TestNewRootFromHex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var err error
 			f := func() {
 				input := tt.input()

--- a/primitives/common/execution_test.go
+++ b/primitives/common/execution_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestExecutionAddressMarshalling(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       []byte
@@ -56,6 +57,7 @@ func TestExecutionAddressMarshalling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var (
 				v   common.ExecutionAddress
 				err error

--- a/primitives/eip4844/blob_test.go
+++ b/primitives/eip4844/blob_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestBlob_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []byte
@@ -69,6 +70,7 @@ func TestBlob_UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var b eip4844.Blob
 			err := b.UnmarshalJSON(tt.input)
 			if tt.wantErr {
@@ -83,6 +85,7 @@ func TestBlob_UnmarshalJSON(t *testing.T) {
 }
 
 func TestBlob_MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    eip4844.Blob
@@ -164,6 +167,7 @@ func TestBlob_MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			output, err := tt.input.MarshalText()
 			require.NoError(t, err, "Test case: %s", tt.name)
 			require.Equal(

--- a/primitives/eip4844/kzg_commitment_test.go
+++ b/primitives/eip4844/kzg_commitment_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestKzgCommitmentToVersionedHash(t *testing.T) {
+	t.Parallel()
+
 	commitment := newTestCommitment("test commitment")
 	expectedPrefix := constants.BlobCommitmentVersion
 
@@ -41,6 +43,7 @@ func TestKzgCommitmentToVersionedHash(t *testing.T) {
 }
 
 func TestKzgCommitmentsToVersionedHashHashes(t *testing.T) {
+	t.Parallel()
 	commitments := []eip4844.KZGCommitment{
 		newTestCommitment("commitment 1"),
 		newTestCommitment("commitment 2"),
@@ -57,6 +60,7 @@ func TestKzgCommitmentsToVersionedHashHashes(t *testing.T) {
 }
 
 func TestKZGCommitmentToHashChunks(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    eip4844.KZGCommitment
@@ -72,6 +76,7 @@ func TestKZGCommitmentToHashChunks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			chunks := tt.input.ToHashChunks()
 			require.Len(t, chunks, tt.expected,
 				"Incorrect number of chunks for test: "+tt.name)
@@ -80,6 +85,7 @@ func TestKZGCommitmentToHashChunks(t *testing.T) {
 }
 
 func TestKZGCommitmentHashTreeRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    eip4844.KZGCommitment
@@ -97,6 +103,7 @@ func TestKZGCommitmentHashTreeRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			hashTreeRoot := tt.input.HashTreeRoot()
 			require.Equal(
 				t,
@@ -110,6 +117,7 @@ func TestKZGCommitmentHashTreeRoot(t *testing.T) {
 }
 
 func TestKZGCommitmentUnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       string
@@ -147,6 +155,7 @@ func TestKZGCommitmentUnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var commitment eip4844.KZGCommitment
 			err := commitment.UnmarshalJSON([]byte(tt.input))
 			if tt.shouldError {
@@ -161,6 +170,7 @@ func TestKZGCommitmentUnmarshalJSON(t *testing.T) {
 }
 
 func TestKZGCommitment_MarshalText(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		input    eip4844.KZGCommitment
@@ -192,6 +202,7 @@ func TestKZGCommitment_MarshalText(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			output, err := tc.input.MarshalText()
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, hex.EncodeToString(output),
@@ -201,6 +212,7 @@ func TestKZGCommitment_MarshalText(t *testing.T) {
 }
 
 func TestKZGCommitments_Leafify(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input []eip4844.KZGCommitment
@@ -226,6 +238,7 @@ func TestKZGCommitments_Leafify(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Dynamically compute expected values based on input
 			expected := make([]common.Root, len(tt.input))
 			for i, commitment := range tt.input {

--- a/primitives/encoding/hex/bit_int_test.go
+++ b/primitives/encoding/hex/bit_int_test.go
@@ -31,6 +31,7 @@ import (
 
 // FromBigInt, then ToBigInt.
 func TestBigIntRoundTrip(t *testing.T) {
+	t.Parallel()
 	// assume FromBigInt only called on non-negative big.Int
 	tests := []struct {
 		name     string
@@ -56,6 +57,7 @@ func TestBigIntRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := hex.FromBigInt(tt.input)
 			require.Equal(t, tt.expected, result)
 
@@ -78,6 +80,7 @@ func TestBigIntRoundTrip(t *testing.T) {
 }
 
 func TestString_MustToBigInt(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -92,6 +95,7 @@ func TestString_MustToBigInt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var (
 				res *big.Int
 				f   = func() {

--- a/primitives/encoding/hex/bytes_test.go
+++ b/primitives/encoding/hex/bytes_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestEncodeAndDecodeBytes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []byte
@@ -62,6 +63,7 @@ func TestEncodeAndDecodeBytes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := hex.EncodeBytes(tt.input)
 			require.Equal(t, tt.expected, result)
 
@@ -81,6 +83,7 @@ func TestEncodeAndDecodeBytes(t *testing.T) {
 }
 
 func TestUnmarshalByteText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		input     []byte
@@ -115,6 +118,7 @@ func TestUnmarshalByteText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := hex.UnmarshalByteText(tt.input)
 			if tt.expectErr {
 				require.Error(t, err)
@@ -127,6 +131,7 @@ func TestUnmarshalByteText(t *testing.T) {
 }
 
 func TestDecodeFixedText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		typename  string
@@ -166,6 +171,7 @@ func TestDecodeFixedText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			out := make([]byte, len(tt.expected))
 			err := hex.DecodeFixedText(tt.input, out)
 			if tt.expectErr {
@@ -179,6 +185,7 @@ func TestDecodeFixedText(t *testing.T) {
 }
 
 func TestDecodeFixedJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		typename  string
@@ -218,6 +225,7 @@ func TestDecodeFixedJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := hex.DecodeFixedJSON(
 				tt.input,
 				tt.out,

--- a/primitives/encoding/hex/format_test.go
+++ b/primitives/encoding/hex/format_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestIsValidHex(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -62,6 +63,7 @@ func TestIsValidHex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := hex.IsValidHex(test.input)
 			if test.wantErr != nil {
 				require.ErrorIs(t, test.wantErr, err)

--- a/primitives/encoding/hex/u64_test.go
+++ b/primitives/encoding/hex/u64_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestMarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    uint64
@@ -43,6 +44,7 @@ func TestMarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := hex.MarshalText(tt.input)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
@@ -55,6 +57,7 @@ func TestMarshalText(t *testing.T) {
 }
 
 func TestValidateQuotedString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []byte
@@ -68,6 +71,7 @@ func TestValidateQuotedString(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := hex.ValidateQuotedString(test.input)
 			if test.expected != nil {
 				require.ErrorIs(t, test.expected, err)
@@ -79,6 +83,7 @@ func TestValidateQuotedString(t *testing.T) {
 }
 
 func TestUnmarshalUint64Text(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []byte
@@ -96,6 +101,7 @@ func TestUnmarshalUint64Text(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := hex.UnmarshalUint64Text(test.input)
 			if test.err != nil {
 				require.ErrorIs(t, test.err, err)

--- a/primitives/encoding/ssz/db/node_test.go
+++ b/primitives/encoding/ssz/db/node_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func Test_Schema_Paths(t *testing.T) {
+	t.Parallel()
 	nestedType := schema.DefineContainer(
 		schema.NewField("bytes32", schema.DefineByteVector(32)),
 		schema.NewField("uint64", schema.U64()),
@@ -71,6 +72,7 @@ func Test_Schema_Paths(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(strings.ReplaceAll(tc.path, "/", "."), func(t *testing.T) {
+			t.Parallel()
 			objectPath := merkle.ObjectPath[uint64, [32]byte](tc.path)
 			node, err := db.NewTreeNode(root, objectPath)
 			require.NoError(t, err)
@@ -94,6 +96,7 @@ func Test_Schema_Paths(t *testing.T) {
 }
 
 func TestNewTreeNodeEdgeCases(t *testing.T) {
+	t.Parallel()
 	nestedType := schema.DefineContainer(
 		schema.NewField("uint64", schema.U64()),
 		schema.NewField("bytes32", schema.B32()),
@@ -137,6 +140,7 @@ func TestNewTreeNodeEdgeCases(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			objectPath := merkle.ObjectPath[uint64, [32]byte](tc.path)
 			_, err := db.NewTreeNode(root, objectPath)
 			if tc.expectError {

--- a/primitives/encoding/ssz/merkle/index_test.go
+++ b/primitives/encoding/ssz/merkle/index_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestNewGeneralizedIndex(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		depth  uint8
 		index  uint64
@@ -56,6 +57,7 @@ func TestNewGeneralizedIndex(t *testing.T) {
 }
 
 func TestConcatGeneralizedIndices(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		indices merkle.GeneralizedIndices
 		expect  merkle.GeneralizedIndex
@@ -77,6 +79,7 @@ func TestConcatGeneralizedIndices(t *testing.T) {
 }
 
 func TestGeneralizedIndexMethods(t *testing.T) {
+	t.Parallel()
 	gi := merkle.GeneralizedIndex(12) // Example index
 
 	require.Equal(
@@ -122,6 +125,7 @@ func TestGeneralizedIndexMethods(t *testing.T) {
 }
 
 func TestGetBranchIndices(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		index  merkle.GeneralizedIndex
@@ -135,6 +139,7 @@ func TestGetBranchIndices(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.index.GetBranchIndices()
 			require.Equal(
 				t,
@@ -148,6 +153,7 @@ func TestGetBranchIndices(t *testing.T) {
 }
 
 func TestGetPathIndices(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		index  merkle.GeneralizedIndex
@@ -168,6 +174,7 @@ func TestGetPathIndices(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.index.GetPathIndices()
 			require.Equal(
 				t,
@@ -181,6 +188,7 @@ func TestGetPathIndices(t *testing.T) {
 }
 
 func TestGetHelperIndices(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		indices merkle.GeneralizedIndices
@@ -210,6 +218,7 @@ func TestGetHelperIndices(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.indices.GetHelperIndices()
 			require.Equal(t, tt.expect, result,
 				"Failed for indices %v", tt.indices)

--- a/primitives/encoding/ssz/merkle/object_path_test.go
+++ b/primitives/encoding/ssz/merkle/object_path_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func Test_ObjectPath(t *testing.T) {
+	t.Parallel()
 	nested := schema.DefineContainer(
 		schema.NewField("bytes32", schema.B32()),
 		schema.NewField("uint64", schema.U64()),
@@ -72,6 +73,7 @@ func Test_ObjectPath(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(strings.ReplaceAll(tc.path, "/", "."), func(t *testing.T) {
+			t.Parallel()
 			objectPath := merkle.ObjectPath[uint64, [32]byte](tc.path)
 			typ, gindex, offset, err := objectPath.GetGeneralizedIndex(root)
 

--- a/primitives/encoding/ssz/merkle/tree_test.go
+++ b/primitives/encoding/ssz/merkle/tree_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestCalculateMerkleRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		index     merkle.GeneralizedIndex
@@ -59,6 +60,7 @@ func TestCalculateMerkleRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := merkle.CalculateRoot(
 				tt.index,
 				tt.leaf,
@@ -75,6 +77,7 @@ func TestCalculateMerkleRoot(t *testing.T) {
 }
 
 func TestVerifyMerkleProof(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		index       merkle.GeneralizedIndex
@@ -109,6 +112,7 @@ func TestVerifyMerkleProof(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := merkle.VerifyProof(
 				tt.index,
 				tt.leaf,
@@ -126,6 +130,7 @@ func TestVerifyMerkleProof(t *testing.T) {
 }
 
 func TestCalculateMultiMerkleRoot(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		indices   merkle.GeneralizedIndices
@@ -175,6 +180,7 @@ func TestCalculateMultiMerkleRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := merkle.CalculateMultiRoot(
 				tt.indices,
 				tt.leaves,
@@ -191,6 +197,7 @@ func TestCalculateMultiMerkleRoot(t *testing.T) {
 }
 
 func TestVerifyMerkleMultiproof(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		indices merkle.GeneralizedIndices
@@ -248,6 +255,7 @@ func TestVerifyMerkleMultiproof(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := merkle.VerifyMultiproof(
 				tt.indices,
 				tt.leaves,

--- a/primitives/math/log/log_test.go
+++ b/primitives/math/log/log_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestILog2Ceil(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    uint64
 		expected uint8
@@ -55,6 +56,7 @@ func TestILog2Ceil(t *testing.T) {
 }
 
 func TestILog2Floor(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    uint64
 		expected uint8

--- a/primitives/math/pow/pow_test.go
+++ b/primitives/math/pow/pow_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestPrevPowerOfTwo(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    uint64
 		expected uint64
@@ -60,6 +61,7 @@ func TestPrevPowerOfTwo(t *testing.T) {
 }
 
 func TestNextPowerOfTwo(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    uint64
 		expected uint64

--- a/primitives/math/u64_test.go
+++ b/primitives/math/u64_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestU64_MarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    uint64
@@ -43,6 +44,7 @@ func TestU64_MarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			u := math.U64(tt.input)
 			result, err := u.MarshalText()
 			require.NoError(t, err)
@@ -52,6 +54,7 @@ func TestU64_MarshalText(t *testing.T) {
 }
 
 func TestU64_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		json     string
@@ -69,6 +72,7 @@ func TestU64_UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var u math.U64
 			err := u.UnmarshalJSON([]byte(tt.json))
 			if tt.err != nil {
@@ -83,6 +87,7 @@ func TestU64_UnmarshalJSON(t *testing.T) {
 }
 
 func TestU64_UnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -99,6 +104,7 @@ func TestU64_UnmarshalText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var u math.U64
 			err := u.UnmarshalText([]byte(tt.input))
 			if tt.err != nil {
@@ -113,6 +119,7 @@ func TestU64_UnmarshalText(t *testing.T) {
 }
 
 func TestU64_NextPowerOfTwo(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		value    math.U64
@@ -157,6 +164,7 @@ func TestU64_NextPowerOfTwo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.value.NextPowerOfTwo()
 			require.Equal(t, tt.expected, result)
 			require.Equal(
@@ -169,6 +177,7 @@ func TestU64_NextPowerOfTwo(t *testing.T) {
 }
 
 func TestU64_NextPowerOfTwoPanic(t *testing.T) {
+	t.Parallel()
 	u := ^math.U64(0)
 	require.Panics(t, func() {
 		_ = u.NextPowerOfTwo()
@@ -176,6 +185,7 @@ func TestU64_NextPowerOfTwoPanic(t *testing.T) {
 }
 
 func TestU64_ILog2Ceil(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		value    math.U64
@@ -210,6 +220,7 @@ func TestU64_ILog2Ceil(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.value.ILog2Ceil()
 			require.Equal(t, tt.expected, result)
 		})
@@ -217,6 +228,7 @@ func TestU64_ILog2Ceil(t *testing.T) {
 }
 
 func TestU64_ILog2Floor(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		value    math.U64
@@ -251,6 +263,7 @@ func TestU64_ILog2Floor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.value.ILog2Floor()
 			require.Equal(t, tt.expected, result)
 		})
@@ -258,6 +271,7 @@ func TestU64_ILog2Floor(t *testing.T) {
 }
 
 func TestU64_PrevPowerOfTwo(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		value    math.U64
@@ -317,6 +331,7 @@ func TestU64_PrevPowerOfTwo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.value.PrevPowerOfTwo()
 			require.Equal(t, tt.expected, result)
 			require.Equal(
@@ -329,6 +344,7 @@ func TestU64_PrevPowerOfTwo(t *testing.T) {
 }
 
 func TestGweiFromWei(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       func(t *testing.T) *big.Int
@@ -400,6 +416,7 @@ func TestGweiFromWei(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := math.GweiFromWei(tt.input(t))
 			if tt.expectedErr != nil {
 				require.ErrorIs(t, err, tt.expectedErr)
@@ -412,6 +429,7 @@ func TestGweiFromWei(t *testing.T) {
 }
 
 func TestGwei_ToWei(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    math.Gwei
@@ -469,6 +487,7 @@ func TestGwei_ToWei(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.input.ToWei()
 			require.Equal(t, tt.expected(t), result)
 		})
@@ -476,6 +495,7 @@ func TestGwei_ToWei(t *testing.T) {
 }
 
 func TestU64_Base10(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		value    math.U64
@@ -505,6 +525,7 @@ func TestU64_Base10(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.value.Base10()
 			require.Equal(t, tt.expected, result,
 				"Test case: %s", tt.name)
@@ -513,6 +534,7 @@ func TestU64_Base10(t *testing.T) {
 }
 
 func TestU64_UnwrapPtr(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		value    math.U64
@@ -542,6 +564,7 @@ func TestU64_UnwrapPtr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := tt.value.UnwrapPtr()
 			require.NotNil(t, result)
 			require.Equal(t, tt.expected, *result,

--- a/primitives/merkle/hasher_test.go
+++ b/primitives/merkle/hasher_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestCombi(t *testing.T) {
+	t.Parallel()
 	// Initialize the hasher function
 	hashFunc := func(data []byte) [32]byte {
 		var result [32]byte
@@ -69,6 +70,7 @@ func TestCombi(t *testing.T) {
 }
 
 func TestMixIn(t *testing.T) {
+	t.Parallel()
 	// Initialize the hasher function
 	hashFunc := func(data []byte) [32]byte {
 		var result [32]byte

--- a/primitives/merkle/root_hasher_test.go
+++ b/primitives/merkle/root_hasher_test.go
@@ -37,6 +37,7 @@ import (
 
 // Test NewRootWithMaxLeaves with empty leaves.
 func TestNewRootWithMaxLeaves_EmptyLeaves(t *testing.T) {
+	t.Parallel()
 	hasher := merkle.NewHasher[[32]byte](sha256.Hash)
 	rootHasher := merkle.NewRootHasher[[32]byte](
 		hasher, merkle.BuildParentTreeRoots,
@@ -53,6 +54,7 @@ func TestNewRootWithMaxLeaves_EmptyLeaves(t *testing.T) {
 
 // Test NewRootWithDepth with empty leaves.
 func TestNewRootWithDepth_EmptyLeaves(t *testing.T) {
+	t.Parallel()
 	hasher := merkle.NewHasher[[32]byte](sha256.Hash)
 	rootHasher := merkle.NewRootHasher[[32]byte](
 		hasher, merkle.BuildParentTreeRoots,
@@ -76,6 +78,7 @@ func createDummyLeaf(value byte) [32]byte {
 
 // Test NewRootWithMaxLeaves with one leaf.
 func TestNewRootWithMaxLeaves_OneLeaf(t *testing.T) {
+	t.Parallel()
 	hasher := merkle.NewHasher[[32]byte](sha256.Hash)
 	rootHasher := merkle.NewRootHasher[[32]byte](
 		hasher, merkle.BuildParentTreeRoots,
@@ -116,6 +119,7 @@ func BenchmarkHasher(b *testing.B) {
 }
 
 func Test_HashTreeRootEqualInputs(t *testing.T) {
+	t.Parallel()
 	// Test with slices of varying sizes to ensure robustness across different
 	// conditions
 	sliceSizes := []int{16, 32, 64}
@@ -123,6 +127,7 @@ func Test_HashTreeRootEqualInputs(t *testing.T) {
 		t.Run(
 			fmt.Sprintf("Size%d", size*merkle.MinParallelizationSize),
 			func(t *testing.T) {
+				t.Parallel()
 				largeSlice := make(
 					[][32]byte, size*merkle.MinParallelizationSize,
 				)
@@ -159,6 +164,7 @@ func Test_HashTreeRootEqualInputs(t *testing.T) {
 }
 
 func Test_GoHashTreeHashConformance(t *testing.T) {
+	t.Parallel()
 	// Define a test table with various input sizes,
 	// including ones above and below MinParallelizationSize
 	testCases := []struct {
@@ -197,6 +203,7 @@ func Test_GoHashTreeHashConformance(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			inputList := make([][32]byte, tc.size)
 			// Fill inputList with pseudo-random data
 			randSource := rand.NewSource(time.Now().UnixNano())
@@ -286,6 +293,7 @@ func requireGoHashTreeEquivalence(
 }
 
 func TestNewRootWithDepth(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		leaves   [][32]byte
@@ -341,6 +349,7 @@ func TestNewRootWithDepth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			rootHashFn := func(dst, src [][32]byte) error {
 				if tt.wantErr {
 					return errors.New("hasher error")
@@ -368,6 +377,7 @@ func TestNewRootWithDepth(t *testing.T) {
 }
 
 func TestNewRootWithMaxLeaves(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		leaves   [][32]byte
@@ -416,6 +426,7 @@ func TestNewRootWithMaxLeaves(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			hasher := merkle.NewHasher[[32]byte](sha256.Hash)
 			rootHasher := merkle.NewRootHasher(
 				hasher, merkle.BuildParentTreeRoots,

--- a/primitives/merkle/tree_test.go
+++ b/primitives/merkle/tree_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestNewTreeFromLeavesWithDepth_NoItemsProvided(t *testing.T) {
+	t.Parallel()
 	treeDepth := uint8(32)
 	_, err := merkle.NewTreeFromLeavesWithDepth[[32]byte](
 		nil,
@@ -40,6 +41,7 @@ func TestNewTreeFromLeavesWithDepth_NoItemsProvided(t *testing.T) {
 }
 
 func TestNewTreeFromLeavesWithDepth_DepthSupport(t *testing.T) {
+	t.Parallel()
 	items := make([][32]byte, 0)
 	for _, v := range [][]byte{
 		byteslib.ExtendToSize([]byte("A"), byteslib.B32Size),
@@ -73,6 +75,7 @@ func TestNewTreeFromLeavesWithDepth_DepthSupport(t *testing.T) {
 }
 
 func TestMerkleTree_IsValidMerkleBranch(t *testing.T) {
+	t.Parallel()
 	treeDepth := uint8(32)
 	items := make([][32]byte, 0)
 	for _, v := range [][]byte{
@@ -137,6 +140,7 @@ func TestMerkleTree_IsValidMerkleBranch(t *testing.T) {
 }
 
 func TestMerkleTree_VerifyProof(t *testing.T) {
+	t.Parallel()
 	treeDepth := uint8(32)
 
 	items := make([][32]byte, 0)
@@ -190,6 +194,7 @@ func TestMerkleTree_VerifyProof(t *testing.T) {
 }
 
 func TestMerkleTree_NegativeIndexes(t *testing.T) {
+	t.Parallel()
 	treeDepth := uint8(32)
 	items := make([][32]byte, 0)
 	for _, v := range [][]byte{
@@ -219,6 +224,7 @@ func TestMerkleTree_NegativeIndexes(t *testing.T) {
 }
 
 func TestMerkleTree_VerifyProof_TrieUpdated(t *testing.T) {
+	t.Parallel()
 	treeDepth := uint8(32)
 	items := [][32]byte{
 		{1},

--- a/primitives/net/jwt/jwt_test.go
+++ b/primitives/net/jwt/jwt_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestNewFromHex(t *testing.T) {
+	t.Parallel()
 	wantValid := jwt.Secret(
 		hex.MustToBytes(
 			"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
@@ -71,6 +72,7 @@ func TestNewFromHex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := jwt.NewFromHex(tt.hexStr)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -82,6 +84,7 @@ func TestNewFromHex(t *testing.T) {
 }
 
 func TestSecretString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		secret jwt.Secret
@@ -100,6 +103,7 @@ func TestSecretString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(
 				t,
 				tt.want,
@@ -111,12 +115,14 @@ func TestSecretString(t *testing.T) {
 }
 
 func TestNewRandom(t *testing.T) {
+	t.Parallel()
 	secret, err := jwt.NewRandom()
 	require.NoError(t, err, "NewRandom() error")
 	require.Len(t, secret.Bytes(), 32, "NewRandom() length mismatch")
 }
 
 func TestSecretBytes(t *testing.T) {
+	t.Parallel()
 	expectedLength := 32 // Assuming the secret is expected to be 32 bytes long
 	secret, _ := jwt.NewRandom()
 	bytes := secret.Bytes()
@@ -124,6 +130,7 @@ func TestSecretBytes(t *testing.T) {
 }
 
 func TestSecretHexWithFixedInput(t *testing.T) {
+	t.Parallel()
 	expectedHex := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 	expectedHexLength := 64
 
@@ -152,6 +159,7 @@ func TestSecretHexWithFixedInput(t *testing.T) {
 }
 
 func TestSecretRoundTripEncoding(t *testing.T) {
+	t.Parallel()
 	originalSecret, err := jwt.NewRandom()
 	require.NoError(t, err, "NewRandom() error")
 
@@ -172,6 +180,7 @@ func TestSecretRoundTripEncoding(t *testing.T) {
 }
 
 func TestBuildSignedToken(t *testing.T) {
+	t.Parallel()
 	secret, err := jwt.NewRandom()
 	require.NoError(t, err, "NewRandom() error")
 
@@ -185,6 +194,7 @@ func TestBuildSignedToken(t *testing.T) {
 }
 
 func TestNewFromHexEdgeCases(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		hexStr  string
@@ -224,6 +234,7 @@ func TestNewFromHexEdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := jwt.NewFromHex(tt.hexStr)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -235,6 +246,7 @@ func TestNewFromHexEdgeCases(t *testing.T) {
 }
 
 func TestHexRegexp(t *testing.T) {
+	t.Parallel()
 	validHexStrings := []string{
 		"0x1234567890abcdef",
 		"1234567890ABCDEF",
@@ -269,6 +281,7 @@ func TestHexRegexp(t *testing.T) {
 }
 
 func TestSecretComparison(t *testing.T) {
+	t.Parallel()
 	secret1, err := jwt.NewRandom()
 	require.NoError(t, err, "NewRandom() error for secret1")
 

--- a/primitives/transition/validator_update_test.go
+++ b/primitives/transition/validator_update_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestValidatorUpdate_CanonicalSort(t *testing.T) {
+	t.Parallel()
 	pubkey1 := crypto.BLSPubkey{1}
 	pubkey2 := crypto.BLSPubkey{2}
 	pubkey3 := crypto.BLSPubkey{3}
@@ -103,6 +104,7 @@ func TestValidatorUpdate_CanonicalSort(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := tc.input.CanonicalSort()
 			require.Equal(t, tc.want, got)
 		})

--- a/primitives/version/comparable_test.go
+++ b/primitives/version/comparable_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestIsBefore(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		a, b     common.Version
@@ -87,6 +88,7 @@ func TestIsBefore(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := version.IsBefore(tc.a, tc.b)
 			require.Equal(t, tc.expected, result)
 		})
@@ -94,6 +96,7 @@ func TestIsBefore(t *testing.T) {
 }
 
 func TestEquals(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		a, b     common.Version
@@ -133,6 +136,7 @@ func TestEquals(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := version.Equals(tc.a, tc.b)
 			require.Equal(t, tc.expected, result)
 		})
@@ -140,6 +144,7 @@ func TestEquals(t *testing.T) {
 }
 
 func TestIsAfter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		a, b     common.Version
@@ -173,6 +178,7 @@ func TestIsAfter(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := version.IsAfter(tc.a, tc.b)
 			require.Equal(t, tc.expected, result)
 		})
@@ -180,6 +186,7 @@ func TestIsAfter(t *testing.T) {
 }
 
 func TestSort(t *testing.T) {
+	t.Parallel()
 	// Recommended function implementing cmp from the comments.
 	cmp := func(a, b common.Version) int {
 		if version.IsBefore(a, b) {
@@ -247,6 +254,7 @@ func TestSort(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			// Sort the input slice using the cmp function
 			slices.SortFunc(tc.input, cmp)
 			require.Equal(t, tc.expected, tc.input)

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -264,10 +264,15 @@ test-unit: ## run golang unit tests
 	@go list -f '{{.Dir}}/...' -m | xargs \
 		go test -race -tags bls12381,test
 
-test-unit-cover: ## run golang unit tests with coverage
+test-unit-cover: test-unit-norace ## run golang unit tests with coverage
 	@echo "Running unit tests with coverage..."
 	@go list -f '{{.Dir}}/...' -m | xargs \
 		go test -race -coverprofile=test-unit-cover.txt -tags bls12381,test
+
+test-unit-norace: ## run golang unit tests with coverage but without race as some tests are too slow with race
+	@echo "Running unit tests with coverage..."
+	@go list -f '{{.Dir}}/...' -m | xargs \
+		go test -coverprofile=test-unit-cover-norace -tags bls12381,test,norace
 
 test-unit-bench: ## run golang unit benchmarks
 	@echo "Running unit tests with benchmarks..."

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -264,6 +264,7 @@ test-unit: ## run golang unit tests
 	@go list -f '{{.Dir}}/...' -m | xargs \
 		go test -race -tags bls12381,test
 
+# This currently ends up running some tests twice but is still faster than running all tests with -race
 test-unit-cover: test-unit-norace ## run golang unit tests with coverage
 	@echo "Running unit tests with coverage and race checks..."
 	@go list -f '{{.Dir}}/...' -m | xargs \

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -265,12 +265,12 @@ test-unit: ## run golang unit tests
 		go test -race -tags bls12381,test
 
 test-unit-cover: test-unit-norace ## run golang unit tests with coverage
-	@echo "Running unit tests with coverage..."
+	@echo "Running unit tests with coverage and race checks..."
 	@go list -f '{{.Dir}}/...' -m | xargs \
 		go test -race -coverprofile=test-unit-cover.txt -tags bls12381,test
 
 test-unit-norace: ## run golang unit tests with coverage but without race as some tests are too slow with race
-	@echo "Running unit tests with coverage..."
+	@echo "Running unit tests with coverage but no race checks..."
 	@go list -f '{{.Dir}}/...' -m | xargs \
 		go test -coverprofile=test-unit-cover-norace -tags bls12381,test,norace
 

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -272,7 +272,7 @@ test-unit-cover: test-unit-norace ## run golang unit tests with coverage
 test-unit-norace: ## run golang unit tests with coverage but without race as some tests are too slow with race
 	@echo "Running unit tests with coverage but no race checks..."
 	@go list -f '{{.Dir}}/...' -m | xargs \
-		go test -coverprofile=test-unit-cover-norace -tags bls12381,test,norace
+		go test -coverprofile=test-unit-cover-norace -tags norace
 
 test-unit-bench: ## run golang unit benchmarks
 	@echo "Running unit tests with benchmarks..."

--- a/storage/beacondb/index/validator_test.go
+++ b/storage/beacondb/index/validator_test.go
@@ -24,7 +24,8 @@ import (
 	"testing"
 )
 
-func TestValidatorIndexes(_ *testing.T) {
+func TestValidatorIndexes(t *testing.T) {
+	t.Parallel()
 	// testName := "test"
 	// logger := log.NewTestLogger(t)
 	// keys := storetypes.NewKVStoreKeys(testName)

--- a/storage/beacondb/registry_test.go
+++ b/storage/beacondb/registry_test.go
@@ -54,6 +54,7 @@ func (kvs *testKVStoreService) OpenKVStore(context.Context) corestore.KVStore {
 var testStoreKey = storetypes.NewKVStoreKey("storage-tests")
 
 func TestBalances(t *testing.T) {
+	t.Parallel()
 	store, err := initTestStore()
 	require.NoError(t, err)
 
@@ -107,6 +108,7 @@ func TestBalances(t *testing.T) {
 }
 
 func TestValidators(t *testing.T) {
+	t.Parallel()
 	store, err := initTestStore()
 	require.NoError(t, err)
 

--- a/storage/block/store_test.go
+++ b/storage/block/store_test.go
@@ -51,6 +51,7 @@ func (m MockBeaconBlock) GetStateRoot() common.Root {
 }
 
 func TestBlockStore(t *testing.T) {
+	t.Parallel()
 	blockStore := block.NewStore[*MockBeaconBlock](noop.NewLogger[any](), 5)
 
 	var (

--- a/storage/filedb/db_test.go
+++ b/storage/filedb/db_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestDB(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		setupFunc     func(db *file.DB) error
@@ -161,6 +162,7 @@ func TestDB(t *testing.T) {
 // Test with `etc` as root directory to cause creation failure
 // due to permission denied.
 func TestDB_SetExistingKey_CreateError(t *testing.T) {
+	t.Parallel()
 	test := struct {
 		name          string
 		setupFunc     func(db *file.DB) error
@@ -178,6 +180,7 @@ func TestDB_SetExistingKey_CreateError(t *testing.T) {
 	}
 
 	t.Run(test.name, func(t *testing.T) {
+		t.Parallel()
 		fs := afero.NewMemMapFs()
 		db := file.NewDB(
 			file.WithRootDirectory("/etc"),
@@ -201,6 +204,7 @@ func TestDB_SetExistingKey_CreateError(t *testing.T) {
 
 // Test with root directory as a file.
 func TestDB_SetHas_NotDirError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		setupFunc     func(db *file.DB) error
@@ -232,6 +236,7 @@ func TestDB_SetHas_NotDirError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			fs := afero.NewMemMapFs()
 			db := file.NewDB(
 				file.WithRootDirectory("/etc/passwd"),
@@ -257,6 +262,7 @@ func TestDB_SetHas_NotDirError(t *testing.T) {
 // Test with root directory to be created in `etc`
 // which will result in permission denied.
 func TestDB_Set_MkDirError(t *testing.T) {
+	t.Parallel()
 	test := struct {
 		name          string
 		setupFunc     func(db *file.DB) error
@@ -273,6 +279,7 @@ func TestDB_Set_MkDirError(t *testing.T) {
 	}
 
 	t.Run(test.name, func(t *testing.T) {
+		t.Parallel()
 		fs := afero.NewMemMapFs()
 		db := file.NewDB(
 			file.WithRootDirectory("/etc/test"),

--- a/storage/filedb/range_db_test.go
+++ b/storage/filedb/range_db_test.go
@@ -35,6 +35,7 @@ import (
 // =========================== BASIC OPERATIONS ============================
 
 func TestRangeDB(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		setupFunc     func(rdb *file.RangeDB) error
@@ -148,6 +149,7 @@ func TestRangeDB(t *testing.T) {
 }
 
 func TestExtractIndex(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		prefixedKey []byte
@@ -178,7 +180,7 @@ func TestExtractIndex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Helper()
+			t.Parallel()
 			idx, err := file.ExtractIndex(tt.prefixedKey)
 			require.Equal(t, tt.expectedIdx, idx)
 			if tt.expectedErr != nil {
@@ -191,6 +193,7 @@ func TestExtractIndex(t *testing.T) {
 // =========================== PRUNING =====================================
 
 func TestRangeDB_DeleteRange_NotSupported(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		db   *mocks.DB
@@ -203,6 +206,7 @@ func TestRangeDB_DeleteRange_NotSupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			t.Helper()
 			require.Panics(t, func() { _ = file.NewRangeDB(tt.db) })
 		})
@@ -210,6 +214,7 @@ func TestRangeDB_DeleteRange_NotSupported(t *testing.T) {
 }
 
 func TestRangeDB_Prune(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		setupFunc     func(rdb *file.RangeDB) error
@@ -246,6 +251,7 @@ func TestRangeDB_Prune(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			rdb := file.NewRangeDB(newTestFDB("/tmp/testdb-2"))
 
 			if tt.setupFunc != nil {
@@ -271,6 +277,7 @@ func TestRangeDB_Prune(t *testing.T) {
 
 // invariant: all indexes up to the firstNonNilIndex should be nil.
 func TestRangeDB_Invariants(t *testing.T) {
+	t.Parallel()
 	// we ignore errors for most of the tests below because we want to ensure
 	// that the invariants hold in exceptional circumstances.
 	tests := []struct {
@@ -327,6 +334,7 @@ func TestRangeDB_Invariants(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			rdb := file.NewRangeDB(newTestFDB("/tmp/testdb-3"))
 
 			if tt.setupFunc != nil {

--- a/testing/e2e/suite/types/account_test.go
+++ b/testing/e2e/suite/types/account_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestNewEthAccount(t *testing.T) {
+	t.Parallel()
 	name := "testAccount"
 	hexPk := "f561d45d1df30a6556d30e39f97011faa3632e43cd378224ad6cc83bb8aea3e6"
 
@@ -39,6 +40,7 @@ func TestNewEthAccount(t *testing.T) {
 }
 
 func TestEthAccount_PublicKey(t *testing.T) {
+	t.Parallel()
 	hexPk := "f561d45d1df30a6556d30e39f97011faa3632e43cd378224ad6cc83bb8aea3e6"
 	expectedPrivateKey, _ := crypto.HexToECDSA(hexPk)
 	require.NotNil(t, expectedPrivateKey)
@@ -50,6 +52,7 @@ func TestEthAccount_PublicKey(t *testing.T) {
 }
 
 func TestEthAccount_Address(t *testing.T) {
+	t.Parallel()
 	hexPk := "f561d45d1df30a6556d30e39f97011faa3632e43cd378224ad6cc83bb8aea3e6"
 	account := types.NewEthAccountFromHex("testAccount", hexPk)
 	address := account.Address()

--- a/testing/quick/compare_test.go
+++ b/testing/quick/compare_test.go
@@ -48,6 +48,7 @@ var (
 )
 
 func TestExecutionPayloadHashTreeRootZrnt(t *testing.T) {
+	t.Parallel()
 	f := func(payload *ctypes.ExecutionPayload, logsBloom [256]byte) bool {
 		// skip these cases lest we trigger a
 		// nil-pointer dereference in fastssz
@@ -100,6 +101,7 @@ func TestExecutionPayloadHashTreeRootZrnt(t *testing.T) {
 }
 
 func TestBlobSidecarTreeRootPrysm(t *testing.T) {
+	t.Parallel()
 	f := func(sidecar *datypes.BlobSidecar) bool {
 		// skip these cases lest we trigger a
 		// nil-pointer dereference in fastssz

--- a/testing/quick/compare_test.go
+++ b/testing/quick/compare_test.go
@@ -1,3 +1,5 @@
+//go:build norace
+
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2025, Berachain Foundation. All rights reserved.


### PR DESCRIPTION
CI got extremely slow because the `-race` flag and `quick.Check` don't like eachother. This fixes it by running the quick.Check tests without `-race`.

CI time goes from ~9 minutes to ~4

Contains : 
- https://github.com/berachain/beacon-kit/pull/2455
- https://github.com/berachain/beacon-kit/pull/2461