### PR TITLE
unlock parallelism in unit tests, pt 2

### DIFF
--- a/consensus-types/types/payload.go
+++ b/consensus-types/types/payload.go
@@ -79,6 +79,18 @@ type ExecutionPayload struct {
 	EpVersion common.Version `json:"-"`
 }
 
+func EnsureNotNilWithdrawals(p *ExecutionPayload) {
+	// Post Shangai an EL explicitly check that Withdrawals are not nil
+	// (instead empty slices are fine). Currently BeaconKit duly builds
+	// a block with Withdrawals set to empty slice if there are no
+	// withdrawals) but as soon as the block is returned by CometBFT
+	// for verification, the SSZ decoding sets the empty slice to nil.
+	// This code change solves the issue.
+	if p.Withdrawals == nil {
+		p.Withdrawals = make([]*engineprimitives.Withdrawal, 0)
+	}
+}
+
 /* -------------------------------------------------------------------------- */
 /*                                     SSZ                                    */
 /* -------------------------------------------------------------------------- */
@@ -133,16 +145,6 @@ func (p *ExecutionPayload) DefineSSZ(codec *ssz.Codec) {
 		constants.MaxBytesPerTx,
 	)
 	ssz.DefineSliceOfStaticObjectsContent(codec, &p.Withdrawals, 16)
-
-	// Post Shangai an EL explicitly check that Withdrawals are not nil
-	// (instead empty slices are fine). Currently BeaconKit duly builds
-	// a block with Withdrawals set to empty slice if there are no
-	// withdrawals) but as soon as the block is returned by CometBFT
-	// for verification, the SSZ decoding sets the empty slice to nil.
-	// This code change solves the issue.
-	if p.Withdrawals == nil {
-		p.Withdrawals = make([]*engineprimitives.Withdrawal, 0)
-	}
 }
 
 // MarshalSSZ serializes the ExecutionPayload object into a slice of bytes.

--- a/consensus-types/types/payload.go
+++ b/consensus-types/types/payload.go
@@ -145,6 +145,12 @@ func (p *ExecutionPayload) DefineSSZ(codec *ssz.Codec) {
 		constants.MaxBytesPerTx,
 	)
 	ssz.DefineSliceOfStaticObjectsContent(codec, &p.Withdrawals, 16)
+
+	// Note that at this state we don't have any guarantee that
+	// p.Withdrawal is not nit, which we require following Capella
+	// (empty list of withdrawals are fine). We ensure non-nillness
+	// in EnsureNotNilWithdrawals which is must be called wherever
+	// we deserialize an execution payload (or anything containing one).
 }
 
 // MarshalSSZ serializes the ExecutionPayload object into a slice of bytes.

--- a/consensus-types/types/payload.go
+++ b/consensus-types/types/payload.go
@@ -147,7 +147,7 @@ func (p *ExecutionPayload) DefineSSZ(codec *ssz.Codec) {
 	ssz.DefineSliceOfStaticObjectsContent(codec, &p.Withdrawals, 16)
 
 	// Note that at this state we don't have any guarantee that
-	// p.Withdrawal is not nit, which we require following Capella
+	// p.Withdrawal is not nil, which we require following Capella
 	// (empty list of withdrawals are fine). We ensure non-nillness
 	// in EnsureNotNilWithdrawals which is must be called wherever
 	// we deserialize an execution payload (or anything containing one).

--- a/consensus-types/types/signed_beacon_block.go
+++ b/consensus-types/types/signed_beacon_block.go
@@ -60,6 +60,9 @@ func NewSignedBeaconBlockFromSSZ(
 			return block, err
 		}
 
+		// make sure Withderawals in execution payload are not nil
+		EnsureNotNilWithdrawals(block.Message.Body.ExecutionPayload)
+
 		// duly setup fork version in every relevant block member
 		block.Message.Body.ExecutionPayload.EpVersion = forkVersion
 		block.Message.BbVersion = forkVersion

--- a/consensus-types/types/signed_beacon_block.go
+++ b/consensus-types/types/signed_beacon_block.go
@@ -60,7 +60,7 @@ func NewSignedBeaconBlockFromSSZ(
 			return block, err
 		}
 
-		// make sure Withderawals in execution payload are not nil
+		// make sure Withdrawals in execution payload are not nil
 		EnsureNotNilWithdrawals(block.Message.Body.ExecutionPayload)
 
 		// duly setup fork version in every relevant block member

--- a/consensus/cometbft/service/encoding/encoding.go
+++ b/consensus/cometbft/service/encoding/encoding.go
@@ -85,13 +85,7 @@ func UnmarshalBeaconBlockFromABCIRequest(
 		return signedBlk, ErrNilBeaconBlockInRequest
 	}
 
-	blk, err := ctypes.NewSignedBeaconBlockFromSSZ(blkBz, forkVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	ctypes.EnsureNotNilWithdrawals(blk.Message.Body.ExecutionPayload)
-	return blk, err
+	return ctypes.NewSignedBeaconBlockFromSSZ(blkBz, forkVersion)
 }
 
 // UnmarshalBlobSidecarsFromABCIRequest extracts blob sidecars from an ABCI

--- a/consensus/cometbft/service/encoding/encoding.go
+++ b/consensus/cometbft/service/encoding/encoding.go
@@ -85,7 +85,13 @@ func UnmarshalBeaconBlockFromABCIRequest(
 		return signedBlk, ErrNilBeaconBlockInRequest
 	}
 
-	return ctypes.NewSignedBeaconBlockFromSSZ(blkBz, forkVersion)
+	blk, err := ctypes.NewSignedBeaconBlockFromSSZ(blkBz, forkVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	ctypes.EnsureNotNilWithdrawals(blk.Message.Body.ExecutionPayload)
+	return blk, err
 }
 
 // UnmarshalBlobSidecarsFromABCIRequest extracts blob sidecars from an ABCI

--- a/payload/builder/errors.go
+++ b/payload/builder/errors.go
@@ -37,4 +37,7 @@ var (
 	// ErrNilPayloadEnvelope is returned when a nil payload envelope is
 	// received.
 	ErrNilPayloadEnvelope = errors.New("received nil payload envelope")
+
+	// ErrNilWithdrawals is returned when nil withdrawals list is received.
+	ErrNilWithdrawals = errors.New("nil withdrawals received from execution client")
 )

--- a/payload/builder/payload.go
+++ b/payload/builder/payload.go
@@ -255,5 +255,8 @@ func (pb *PayloadBuilder) getPayload(
 	if envelope == nil {
 		return nil, ErrNilPayloadEnvelope
 	}
+	if envelope.GetExecutionPayload().Withdrawals == nil {
+		return nil, ErrNilWithdrawals
+	}
 	return envelope, nil
 }

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package builder_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/berachain/beacon-kit/config/spec"
+	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
+	engineprimitives "github.com/berachain/beacon-kit/engine-primitives/engine-primitives"
+	"github.com/berachain/beacon-kit/errors"
+	"github.com/berachain/beacon-kit/log/noop"
+	"github.com/berachain/beacon-kit/payload/builder"
+	"github.com/berachain/beacon-kit/payload/cache"
+	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/eip4844"
+	"github.com/berachain/beacon-kit/primitives/math"
+	statedb "github.com/berachain/beacon-kit/state-transition/core/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetrievePayloadSunnyPath(t *testing.T) {
+	t.Parallel()
+
+	chainSpec, err := spec.MainnetChainSpec()
+	require.NoError(t, err)
+
+	// Create payload builder
+	var (
+		logger = noop.NewLogger[any]()
+		cfg    = &builder.Config{Enabled: true}
+		ee     = &stubExecutionEngine{}
+		cache  = cache.NewPayloadIDCache[[32]byte, math.Slot]()
+		af     = &stubAttributesFactory{}
+	)
+	pb := builder.New(
+		cfg,
+		chainSpec,
+		logger,
+		ee,
+		cache,
+		af,
+	)
+
+	// create inputs and set expectations
+	var (
+		ctx             = context.TODO()
+		slot            = math.Slot(2025)
+		parentBlockRoot = common.Root{0xff, 0xaa}
+		dummyPayloadID  = engineprimitives.PayloadID{0xab}
+
+		res = &ctypes.ExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1[
+			eip4844.KZGCommitment,
+			eip4844.KZGProof,
+			eip4844.Blob,
+		]]{
+			ExecutionPayload: &ctypes.ExecutionPayload{
+				Withdrawals: engineprimitives.Withdrawals{},
+			},
+			BlobsBundle: &engineprimitives.BlobsBundleV1[
+				eip4844.KZGCommitment,
+				eip4844.KZGProof,
+				eip4844.Blob,
+			]{},
+		}
+	)
+
+	cache.Set(slot, parentBlockRoot, dummyPayloadID)
+	ee.payloadEnvToReturn = res
+
+	payload, err := pb.RetrievePayload(ctx, slot, parentBlockRoot)
+	require.NoError(t, err)
+	require.Equal(t, res, payload)
+}
+
+// HELPERS section
+
+var errStubNotImplemented = errors.New("stub not implemented")
+
+type stubExecutionEngine struct {
+	payloadEnvToReturn ctypes.BuiltExecutionPayloadEnv
+	errToReturn        error
+}
+
+func (ee *stubExecutionEngine) GetPayload(
+	context.Context, *ctypes.GetPayloadRequest,
+) (ctypes.BuiltExecutionPayloadEnv, error) {
+	return ee.payloadEnvToReturn, ee.errToReturn
+}
+
+func (ee *stubExecutionEngine) NotifyForkchoiceUpdate(
+	context.Context, *ctypes.ForkchoiceUpdateRequest,
+) (*engineprimitives.PayloadID, *common.ExecutionHash, error) {
+	return nil, nil, errStubNotImplemented
+}
+
+type stubAttributesFactory struct{}
+
+func (ee *stubAttributesFactory) BuildPayloadAttributes(
+	*statedb.StateDB, math.U64,
+	uint64, [32]byte,
+) (*engineprimitives.PayloadAttributes, error) {
+	return nil, errStubNotImplemented
+}

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO cluster these tests into a single test table
 func TestRetrievePayloadSunnyPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Move nil withdrawals check out of SSZ serialisation
- Explicitly rejects payload with nil withdrawals (which should not happen past Shanghai)