### PR TITLE
chore(deps): bumped go version to 1.23.5

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.4"
+          go-version: "1.23.5"
           check-latest: true
           cache-dependency-path: "**/*.sum"
         if: ${{ !(matrix.args == 'test-forge-cover' || matrix.args == 'test-forge-fuzz') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ###           Stage 0 - Build Arguments             ###
 #######################################################
 
-ARG GO_VERSION=1.23.4
+ARG GO_VERSION=1.23.5
 ARG RUNNER_IMAGE=alpine:3.20
 ARG BUILD_TAGS="netgo,muslc,blst,bls12381,pebbledb"
 ARG NAME=beacond

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/berachain/beacon-kit
 
-go 1.23.4
+go 1.23.5
 
 replace (
 	github.com/cometbft/cometbft => github.com/berachain/cometbft v1.0.1-0.20250114162124-1022594f4c1e


### PR DESCRIPTION
This is required by https://github.com/berachain/cometbft/pull/21