### PR TITLE
Build Process - Fix Linux arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
         configs:
           - arch: arm64
             target-os: linux
-            runs-on: macos-14
+            runs-on: ubuntu-24.04-arm
           - arch: amd64
             target-os: linux
             runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
         configs:
           - arch: arm64
             target-os: linux
-            runs-on: ubuntu-latest
+            runs-on: macos-14
           - arch: amd64
             target-os: linux
             runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes release pipeline for arm64 linux binaries. 

NOTE: Uses arm64 Github Runners, which are in [public preview](https://github.com/orgs/community/discussions/148648).