### PR TITLE
fix(engine api): [1/3] error on engine API errors

### DIFF
--- a/beacon/blockchain/execution_engine.go
+++ b/beacon/blockchain/execution_engine.go
@@ -38,14 +38,14 @@ func (s *Service) sendPostBlockFCU(
 	ctx context.Context,
 	st *statedb.StateDB,
 	blk *contypes.ConsensusBlock,
-) {
+) error {
 	lph, err := st.GetLatestExecutionPayloadHeader()
 	if err != nil {
 		s.logger.Error(
 			"failed to get latest execution payload in postBlockProcess",
 			"error", err,
 		)
-		return
+		return err
 	}
 
 	// Send a forkchoice update without payload attributes to notify
@@ -68,5 +68,7 @@ func (s *Service) sendPostBlockFCU(
 			"failed to send forkchoice update without attributes",
 			"error", err,
 		)
+		return err
 	}
+	return nil
 }

--- a/beacon/blockchain/execution_engine.go
+++ b/beacon/blockchain/execution_engine.go
@@ -61,7 +61,10 @@ func (s *Service) sendPostBlockFCU(
 		),
 	)
 	if err != nil {
-		return fmt.Errorf("failed sending forkchoice update without attributes: %w", err)
+		return fmt.Errorf("failed forkchoice update, head %s: %w",
+			lph.GetBlockHash().String(),
+			err,
+		)
 	}
 	return nil
 }

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -109,7 +109,7 @@ func (s *Service) FinalizeBlock(
 	}
 
 	if err = s.sendPostBlockFCU(ctx, st, consensusBlk); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("sendPostBlockFCU failed: %w", err)
 	}
 
 	return valUpdates, nil

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -108,7 +108,9 @@ func (s *Service) FinalizeBlock(
 		s.logger.Error("failed to processPruning", "error", err)
 	}
 
-	go s.sendPostBlockFCU(ctx, st, consensusBlk)
+	if err = s.sendPostBlockFCU(ctx, st, consensusBlk); err != nil {
+		return nil, err
+	}
 
 	return valUpdates, nil
 }

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -155,11 +155,6 @@ func (s *Service) executeStateTransition(
 	defer s.metrics.measureStateTransitionDuration(startTime)
 
 	// Notes about context attributes:
-	// - `OptimisticEngine`: set to true since this is called during
-	// FinalizeBlock. We want to assume the payload is valid. If it
-	// ends up not being valid later, the node will simply AppHash,
-	// which is completely fine. This means we were syncing from a
-	// bad peer, and we would likely AppHash anyways.
 	// - VerifyPayload: set to true. When we are NOT synced to the tip,
 	// process proposal does NOT get called and thus we must ensure that
 	// NewPayload is called to get the execution client the payload.
@@ -170,10 +165,10 @@ func (s *Service) executeStateTransition(
 	// of validators in their process proposal call and thus
 	// the "verification aspect" of this NewPayload call is
 	// actually irrelevant at this point.
-	// VerifyRandao: set to false. We skip randao validation in FinalizeBlock
+	// - VerifyRandao: set to false. We skip randao validation in FinalizeBlock
 	// since either
-	// 1. we validated it during ProcessProposal at the head of the chain OR
-	// 2. we are bootstrapping and implicitly trust that the randao was validated by
+	//   1. we validated it during ProcessProposal at the head of the chain OR
+	//   2. we are bootstrapping and implicitly trust that the randao was validated by
 	//    the super majority during ProcessProposal of the given block height.
 	txCtx := transition.NewTransitionCtx(
 		ctx,

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -183,8 +183,7 @@ func (s *Service) executeStateTransition(
 		WithVerifyPayload(true).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
-		WithMeterGas(true).
-		WithOptimisticEngine(true)
+		WithMeterGas(true)
 
 	return s.stateProcessor.Transition(
 		txCtx,

--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -342,8 +342,7 @@ func (s *Service) verifyStateRoot(
 		WithVerifyPayload(true).
 		WithVerifyRandao(true).
 		WithVerifyResult(true).
-		WithMeterGas(false).
-		WithOptimisticEngine(false)
+		WithMeterGas(false)
 
 	_, err := s.stateProcessor.Transition(txCtx, st, blk)
 	return err

--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -332,8 +332,6 @@ func (s *Service) verifyStateRoot(
 	startTime := time.Now()
 	defer s.metrics.measureStateRootVerificationTime(startTime)
 
-	// We run with a non-optimistic engine here to ensure
-	// that the proposer does not try to push through a bad block.
 	txCtx := transition.NewTransitionCtx(
 		ctx,
 		consensusTime,

--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -370,8 +370,7 @@ func (s *Service) computeStateRoot(
 	startTime := time.Now()
 	defer s.metrics.measureStateRootComputationTime(startTime)
 
-	// TODO: We should think about how having optimistic
-	// engine enabled here would affect the proposer when
+	// TODO: Think about how this would affect the proposer when
 	// the payload in their block has come from a remote builder.
 	txCtx := transition.NewTransitionCtx(
 		ctx,

--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -381,8 +381,7 @@ func (s *Service) computeStateRoot(
 		WithVerifyPayload(false).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
-		WithMeterGas(false).
-		WithOptimisticEngine(true)
+		WithMeterGas(false)
 
 	if _, err := s.stateProcessor.Transition(txCtx, st, blk); err != nil {
 		return common.Root{}, err

--- a/consensus-types/types/payload_requests.go
+++ b/consensus-types/types/payload_requests.go
@@ -39,9 +39,6 @@ type NewPayloadRequest struct {
 	VersionedHashes []common.ExecutionHash
 	// ParentBeaconBlockRoot is the root of the parent beacon block.
 	ParentBeaconBlockRoot *common.Root
-	// Optimistic is a flag that indicates if the payload should be
-	// optimistically deemed valid. This is useful during syncing.
-	Optimistic bool
 }
 
 // BuildNewPayloadRequest builds a new payload request.
@@ -49,13 +46,11 @@ func BuildNewPayloadRequest(
 	executionPayload *ExecutionPayload,
 	versionedHashes []common.ExecutionHash,
 	parentBeaconBlockRoot *common.Root,
-	optimistic bool,
 ) *NewPayloadRequest {
 	return &NewPayloadRequest{
 		ExecutionPayload:      executionPayload,
 		VersionedHashes:       versionedHashes,
 		ParentBeaconBlockRoot: parentBeaconBlockRoot,
-		Optimistic:            optimistic,
 	}
 }
 

--- a/consensus-types/types/payload_requests_test.go
+++ b/consensus-types/types/payload_requests_test.go
@@ -37,21 +37,18 @@ func TestBuildNewPayloadRequest(t *testing.T) {
 		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1())
 		versionedHashes       []common.ExecutionHash
 		parentBeaconBlockRoot = common.Root{}
-		optimistic            = false
 	)
 
 	request := types.BuildNewPayloadRequest(
 		executionPayload,
 		versionedHashes,
 		&parentBeaconBlockRoot,
-		optimistic,
 	)
 
 	require.NotNil(t, request)
 	require.Equal(t, executionPayload, request.ExecutionPayload)
 	require.Equal(t, versionedHashes, request.VersionedHashes)
 	require.Equal(t, &parentBeaconBlockRoot, request.ParentBeaconBlockRoot)
-	require.Equal(t, optimistic, request.Optimistic)
 }
 
 func TestBuildForkchoiceUpdateRequest(t *testing.T) {
@@ -100,14 +97,12 @@ func TestHasValidVersionedAndBlockHashesPayloadError(t *testing.T) {
 		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1())
 		versionedHashes       = []common.ExecutionHash{}
 		parentBeaconBlockRoot = common.Root{}
-		optimistic            = false
 	)
 
 	request := types.BuildNewPayloadRequest(
 		executionPayload,
 		versionedHashes,
 		&parentBeaconBlockRoot,
-		optimistic,
 	)
 
 	err := request.HasValidVersionedAndBlockHashes()
@@ -120,14 +115,12 @@ func TestHasValidVersionedAndBlockHashesMismatchedHashes(t *testing.T) {
 		executionPayload      = (&types.ExecutionPayload{}).Empty(version.Deneb1())
 		versionedHashes       = []common.ExecutionHash{{}}
 		parentBeaconBlockRoot = common.Root{}
-		optimistic            = false
 	)
 
 	request := types.BuildNewPayloadRequest(
 		executionPayload,
 		versionedHashes,
 		&parentBeaconBlockRoot,
-		optimistic,
 	)
 
 	err := request.HasValidVersionedAndBlockHashes()

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -93,8 +93,8 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 		)
 
 	case errors.IsAny(err, engineerrors.ErrSyncingPayloadStatus):
-		// We do not bubble the error up, since we want to handle it
-		// in the same way as the other cases.
+		// We bubble up syncing as an error, to be able to stop
+		// bootstrapping from progressing in CL while EL is syncing.
 		ee.metrics.markForkchoiceUpdateSyncing(req.State, err)
 		return nil, nil, err
 

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -96,13 +96,13 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 		// We do not bubble the error up, since we want to handle it
 		// in the same way as the other cases.
 		ee.metrics.markForkchoiceUpdateSyncing(req.State, err)
-		return payloadID, nil, err
+		return nil, nil, err
 
 	case errors.Is(err, engineerrors.ErrInvalidPayloadStatus):
 		// If we get invalid payload status, we will need to find a valid
 		// ancestor block and force a recovery.
 		ee.metrics.markForkchoiceUpdateInvalid(req.State, err)
-		return payloadID, latestValidHash, ErrBadBlockProduced
+		return nil, nil, ErrBadBlockProduced
 
 	case jsonrpc.IsPreDefinedError(err):
 		// JSON-RPC errors are predefined and should be handled as such.
@@ -124,7 +124,7 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 			"safe_eth1_hash", req.State.SafeBlockHash,
 			"finalized_eth1_hash", req.State.FinalizedBlockHash,
 		)
-		return payloadID, latestValidHash, ErrNilPayloadOnValidResponse
+		return nil, nil, ErrNilPayloadOnValidResponse
 	}
 
 	return payloadID, latestValidHash, nil

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -132,8 +132,6 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 
 // VerifyAndNotifyNewPayload verifies the new payload and notifies the
 // execution client.
-//
-//nolint:funlen
 func (ee *Engine) VerifyAndNotifyNewPayload(
 	ctx context.Context,
 	req *ctypes.NewPayloadRequest,

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -140,7 +140,6 @@ func (ee *Engine) VerifyAndNotifyNewPayload(
 	ee.metrics.markNewPayloadCalled(
 		req.ExecutionPayload.GetBlockHash(),
 		req.ExecutionPayload.GetParentHash(),
-		req.Optimistic,
 	)
 
 	// First we verify the block hash and versioned hashes are valid.
@@ -170,20 +169,17 @@ func (ee *Engine) VerifyAndNotifyNewPayload(
 		ee.metrics.markNewPayloadSyncingPayloadStatus(
 			req.ExecutionPayload.GetBlockHash(),
 			req.ExecutionPayload.GetParentHash(),
-			req.Optimistic,
 		)
 
 	case errors.IsAny(err, engineerrors.ErrAcceptedPayloadStatus):
 		ee.metrics.markNewPayloadAcceptedPayloadStatus(
 			req.ExecutionPayload.GetBlockHash(),
 			req.ExecutionPayload.GetParentHash(),
-			req.Optimistic,
 		)
 
 	case errors.Is(err, engineerrors.ErrInvalidPayloadStatus):
 		ee.metrics.markNewPayloadInvalidPayloadStatus(
 			req.ExecutionPayload.GetBlockHash(),
-			req.Optimistic,
 		)
 
 	case jsonrpc.IsPreDefinedError(err):
@@ -195,7 +191,6 @@ func (ee *Engine) VerifyAndNotifyNewPayload(
 		ee.metrics.markNewPayloadJSONRPCError(
 			req.ExecutionPayload.GetBlockHash(),
 			*lastValidHash,
-			req.Optimistic,
 			err,
 		)
 
@@ -203,14 +198,12 @@ func (ee *Engine) VerifyAndNotifyNewPayload(
 	case err != nil:
 		ee.metrics.markNewPayloadUndefinedError(
 			req.ExecutionPayload.GetBlockHash(),
-			req.Optimistic,
 			err,
 		)
 	default:
 		ee.metrics.markNewPayloadValid(
 			req.ExecutionPayload.GetBlockHash(),
 			req.ExecutionPayload.GetParentHash(),
-			req.Optimistic,
 		)
 	}
 	return err

--- a/execution/engine/metrics.go
+++ b/execution/engine/metrics.go
@@ -51,13 +51,11 @@ func newEngineMetrics(
 func (em *engineMetrics) markNewPayloadCalled(
 	payloadHash common.ExecutionHash,
 	parentHash common.ExecutionHash,
-	isOptimistic bool,
 ) {
 	em.sink.IncrementCounter(
 		"beacon_kit.execution.engine.new_payload",
 		"payload_block_hash", payloadHash.Hex(),
 		"payload_parent_block_hash", parentHash.Hex(),
-		"is_optimistic", strconv.FormatBool(isOptimistic),
 	)
 }
 
@@ -65,18 +63,15 @@ func (em *engineMetrics) markNewPayloadCalled(
 func (em *engineMetrics) markNewPayloadValid(
 	payloadHash common.ExecutionHash,
 	parentHash common.ExecutionHash,
-	isOptimistic bool,
 ) {
 	em.logger.Info(
 		"Inserted new payload into execution chain",
 		"payload_block_hash", payloadHash,
 		"payload_parent_block_hash", parentHash,
-		"is_optimistic", isOptimistic,
 	)
 
 	em.sink.IncrementCounter(
 		"beacon_kit.execution.engine.new_payload_valid",
-		"is_optimistic", strconv.FormatBool(isOptimistic),
 	)
 }
 
@@ -85,19 +80,15 @@ func (em *engineMetrics) markNewPayloadValid(
 func (em *engineMetrics) markNewPayloadSyncingPayloadStatus(
 	payloadHash common.ExecutionHash,
 	parentHash common.ExecutionHash,
-	isOptimistic bool,
 ) {
-	em.errorLoggerFn(isOptimistic)(
+	em.logger.Error(
 		"Received syncing payload status",
 		"payload_block_hash", payloadHash,
 		"parent_hash", parentHash,
-		"is_optimistic", isOptimistic,
 	)
 
 	em.sink.IncrementCounter(
 		"beacon_kit.execution.engine.new_payload_syncing_payload_status",
-		"is_optimistic",
-		strconv.FormatBool(isOptimistic),
 	)
 }
 
@@ -106,19 +97,15 @@ func (em *engineMetrics) markNewPayloadSyncingPayloadStatus(
 func (em *engineMetrics) markNewPayloadAcceptedPayloadStatus(
 	payloadHash common.ExecutionHash,
 	parentHash common.ExecutionHash,
-	isOptimistic bool,
 ) {
-	em.errorLoggerFn(isOptimistic)(
+	em.logger.Error(
 		"Received accepted payload status",
 		"payload_block_hash", payloadHash,
 		"parent_hash", parentHash,
-		"is_optimistic", isOptimistic,
 	)
 
 	em.sink.IncrementCounter(
 		"beacon_kit.execution.engine.new_payload_accepted_payload_status",
-		"is_optimistic",
-		strconv.FormatBool(isOptimistic),
 	)
 }
 
@@ -126,18 +113,15 @@ func (em *engineMetrics) markNewPayloadAcceptedPayloadStatus(
 // for invalid payload status.
 func (em *engineMetrics) markNewPayloadInvalidPayloadStatus(
 	payloadHash common.ExecutionHash,
-	isOptimistic bool,
 ) {
-	em.errorLoggerFn(isOptimistic)(
+	em.logger.Error(
 		"Received invalid payload status during new payload call",
 		"payload_block_hash", payloadHash,
 		"parent_hash", payloadHash,
-		"is_optimistic", isOptimistic,
 	)
 
 	em.sink.IncrementCounter(
 		"beacon_kit.execution.engine.new_payload_invalid_payload_status",
-		"is_optimistic", strconv.FormatBool(isOptimistic),
 	)
 }
 
@@ -145,21 +129,18 @@ func (em *engineMetrics) markNewPayloadInvalidPayloadStatus(
 func (em *engineMetrics) markNewPayloadJSONRPCError(
 	payloadHash common.ExecutionHash,
 	lastValidHash common.ExecutionHash,
-	isOptimistic bool,
 	err error,
 ) {
-	em.errorLoggerFn(isOptimistic)(
+	em.logger.Error(
 		"Received JSON-RPC error during new payload call",
 		"payload_block_hash", payloadHash,
 		"parent_hash", payloadHash,
 		"last_valid_hash", lastValidHash,
-		"is_optimistic", isOptimistic,
 		"error", err,
 	)
 
 	em.sink.IncrementCounter(
 		"beacon_kit.execution.engine.new_payload_json_rpc_error",
-		"is_optimistic", strconv.FormatBool(isOptimistic),
 		"error", err.Error(),
 	)
 }
@@ -167,20 +148,17 @@ func (em *engineMetrics) markNewPayloadJSONRPCError(
 // markNewPayloadUndefinedError increments the counter for undefined errors.
 func (em *engineMetrics) markNewPayloadUndefinedError(
 	payloadHash common.ExecutionHash,
-	isOptimistic bool,
 	err error,
 ) {
-	em.errorLoggerFn(isOptimistic)(
+	em.logger.Error(
 		"Received undefined error during new payload call",
 		"payload_block_hash", payloadHash,
 		"parent_hash", payloadHash,
-		"is_optimistic", isOptimistic,
 		"error", err,
 	)
 
 	em.sink.IncrementCounter(
 		"beacon_kit.execution.engine.new_payload_undefined_error",
-		"is_optimistic", strconv.FormatBool(isOptimistic),
 		"error", err.Error(),
 	)
 }

--- a/execution/engine/metrics.go
+++ b/execution/engine/metrics.go
@@ -203,7 +203,7 @@ func (em *engineMetrics) markForkchoiceUpdateSyncing(
 	state *engineprimitives.ForkchoiceStateV1,
 	err error,
 ) {
-	em.errorLoggerFn(true)(
+	em.logger.Error(
 		"Received syncing payload status during forkchoice update call",
 		"head_block_hash",
 		state.HeadBlockHash,
@@ -270,14 +270,4 @@ func (em *engineMetrics) markForkchoiceUpdateUndefinedError(err error) {
 		"beacon_kit.execution.engine.forkchoice_update_undefined_error",
 		"error", err.Error(),
 	)
-}
-
-// errorLoggerFn returns a logger fn based on the optimistic flag.
-func (em *engineMetrics) errorLoggerFn(
-	isOptimistic bool,
-) func(msg string, keyVals ...any) {
-	if isOptimistic {
-		return em.logger.Warn
-	}
-	return em.logger.Error
 }

--- a/payload/builder/payload.go
+++ b/payload/builder/payload.go
@@ -22,6 +22,7 @@ package builder
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
@@ -79,7 +80,7 @@ func (pb *PayloadBuilder) RequestPayloadAsync(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("RequestPayloadAsync failed sending forkchoice update: %w", err)
 	}
 
 	// Only add to cache if we received back a payload ID.
@@ -234,7 +235,10 @@ func (pb *PayloadBuilder) SendForceHeadFCU(
 			ForkVersion:       pb.chainSpec.ActiveForkVersionForSlot(slot),
 		},
 	)
-	return err
+	if err != nil {
+		return fmt.Errorf("SendForceHeadFCU failed sending forkchoice update: %w", err)
+	}
+	return nil
 }
 
 func (pb *PayloadBuilder) getPayload(

--- a/primitives/transition/context.go
+++ b/primitives/transition/context.go
@@ -52,10 +52,6 @@ type Context struct {
 	// layer payload should be meter or not. We currently meter only
 	// finalized blocks.
 	meterGas bool
-	// optimisticEngine indicates whether to optimistically assume
-	// the execution client has the correct state certain errors
-	// are returned by the execution engine.
-	optimisticEngine bool
 }
 
 func NewTransitionCtx(
@@ -72,10 +68,6 @@ func NewTransitionCtx(
 		// (we care only about finalized blocks gas)
 		meterGas: false,
 
-		// by default we don't have optimistic engine
-		// as it basically mute some checks
-		optimisticEngine: false,
-
 		// by default we keep all verification
 		verifyPayload: true,
 		verifyRandao:  true,
@@ -86,11 +78,6 @@ func NewTransitionCtx(
 // Setters to control context attributes.
 func (c *Context) WithMeterGas(meter bool) *Context {
 	c.meterGas = meter
-	return c
-}
-
-func (c *Context) WithOptimisticEngine(optimistic bool) *Context {
-	c.optimisticEngine = optimistic
 	return c
 }
 
@@ -136,8 +123,4 @@ func (c *Context) VerifyResult() bool {
 
 func (c *Context) MeterGas() bool {
 	return c.meterGas
-}
-
-func (c *Context) OptimisticEngine() bool {
-	return c.optimisticEngine
 }

--- a/state-transition/core/state_processor_payload.go
+++ b/state-transition/core/state_processor_payload.go
@@ -59,7 +59,7 @@ func (sp *StateProcessor) processExecutionPayload(
 	// Perform payload verification only if the context is configured as such.
 	if ctx.VerifyPayload() {
 		g.Go(func() error {
-			return sp.validateExecutionPayload(gCtx, st, blk, ctx.OptimisticEngine())
+			return sp.validateExecutionPayload(gCtx, st, blk)
 		})
 	}
 
@@ -90,12 +90,11 @@ func (sp *StateProcessor) validateExecutionPayload(
 	ctx context.Context,
 	st *statedb.StateDB,
 	blk *ctypes.BeaconBlock,
-	optimisticEngine bool,
 ) error {
 	if err := sp.validateStatelessPayload(blk); err != nil {
 		return err
 	}
-	return sp.validateStatefulPayload(ctx, st, blk, optimisticEngine)
+	return sp.validateStatefulPayload(ctx, st, blk)
 }
 
 // validateStatelessPayload performs stateless checks on the execution payload.
@@ -120,7 +119,9 @@ func (sp *StateProcessor) validateStatelessPayload(blk *ctypes.BeaconBlock) erro
 
 // validateStatefulPayload performs stateful checks on the execution payload.
 func (sp *StateProcessor) validateStatefulPayload(
-	ctx context.Context, st *statedb.StateDB, blk *ctypes.BeaconBlock, optimisticEngine bool,
+	ctx context.Context,
+	st *statedb.StateDB,
+	blk *ctypes.BeaconBlock,
 ) error {
 	body := blk.GetBody()
 	payload := body.GetExecutionPayload()
@@ -147,7 +148,6 @@ func (sp *StateProcessor) validateStatefulPayload(
 			payload,
 			body.GetBlobKzgCommitments().ToVersionedHashes(),
 			&parentBeaconBlockRoot,
-			optimisticEngine,
 		),
 	); err != nil {
 		return err

--- a/state-transition/core/types.go
+++ b/state-transition/core/types.go
@@ -42,7 +42,6 @@ type ReadOnlyContext interface {
 	VerifyRandao() bool
 	VerifyResult() bool
 	MeterGas() bool
-	OptimisticEngine() bool
 }
 
 // Withdrawals defines the interface for managing withdrawal operations.

--- a/testing/state-transition/state-transition.go
+++ b/testing/state-transition/state-transition.go
@@ -142,8 +142,7 @@ func SetupTestState(t *testing.T, cs chain.Spec) (
 		WithVerifyPayload(false).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
-		WithMeterGas(false).
-		WithOptimisticEngine(true)
+		WithMeterGas(false)
 
 	return sp, beaconState, depositStore, ctx
 }


### PR DESCRIPTION
1. Enforces the synchronicity of the `FinalizeBlock`'s `engine_forkchoiceUpdated` call.
2. Always returns error on `engine_newPayload` and `engine_forkchoiceUpdated` failures. Therefore
3. Remove optimistic engine from `transaction.Context` and the engine.

With both of these, we ensure that the CL will fail when it goes out of sync with the EL.

In future PRs, we should attempt retries on these engine API calls to allow for easier recovery.