### PR TITLE
fix(ci): Update Test Configs to work with new Geth version

### DIFF
--- a/kurtosis/src/networks/kurtosis-devnet/network-configs/genesis.json.template
+++ b/kurtosis/src/networks/kurtosis-devnet/network-configs/genesis.json.template
@@ -21,7 +21,14 @@
     "cancunTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
-    "ethash": {}
+    "ethash": {},
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      }
+    }
   },
   "coinbase": "0x0000000000000000000000000000000000000000",
   "difficulty": "0x0",

--- a/testing/files/eth-genesis.json
+++ b/testing/files/eth-genesis.json
@@ -21,7 +21,13 @@
     "cancunTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
-    "ethash": {}
+    "ethash": {},
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      }
   },
   "coinbase": "0x0000000000000000000000000000000000000000",
   "difficulty": "0x0",

--- a/testing/files/eth-genesis.json
+++ b/testing/files/eth-genesis.json
@@ -28,6 +28,7 @@
         "max": 6,
         "baseFeeUpdateFraction": 3338477
       }
+    }
   },
   "coinbase": "0x0000000000000000000000000000000000000000",
   "difficulty": "0x0",

--- a/testing/networks/80084/eth-genesis.json
+++ b/testing/networks/80084/eth-genesis.json
@@ -21,14 +21,7 @@
     "cancunTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
-    "ethash": {},
-    "blobSchedule": {
-      "cancun": {
-        "target": 3,
-        "max": 6,
-        "baseFeeUpdateFraction": 3338477
-      }
-    }
+    "ethash": {}
   },
   "alloc": {
     "0x8a73D1380345942F1cb32541F1b19C40D8e6C94B": {

--- a/testing/networks/80084/eth-genesis.json
+++ b/testing/networks/80084/eth-genesis.json
@@ -21,7 +21,14 @@
     "cancunTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
-    "ethash": {}
+    "ethash": {},
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      }
+    }
   },
   "alloc": {
     "0x8a73D1380345942F1cb32541F1b19C40D8e6C94B": {


### PR DESCRIPTION
This unblocks CI as Geth has made a new release v1.15.0 which results in tests breaking due to a new required configuration