### PR TITLE
chore(ci): add caching when pulling docker image

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -36,10 +36,6 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}-tests
-  # We don't want to cancel in progress on main. This is to allow
-  # us to debug main if a bad commit is pushed.
-  # Case 1: The base branch is main and the event triggered via merge group => we DO NOT want to cancel in progress
-  # Case 2: The reference branch is not main => we want to cancel in progress
   cancel-in-progress: ${{ !(github.base_ref == 'refs/heads/main' && github.event_name == 'merge_group') || github.ref != 'refs/heads/main' }}
 
 env:
@@ -72,20 +68,17 @@ jobs:
           - "test-unit-fuzz"
           - "test-forge-cover"
           - "test-forge-fuzz"
-        os:
-          - ubuntu-24.04-beacon-kit
+    runs-on: ubuntu-latest
     name: ${{ matrix.args }}
-    runs-on:
-      labels: ${{ matrix.os }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         if: ${{ matrix.args == 'lint' || matrix.args == 'generate-check' || matrix.args == 'test-forge-cover' || matrix.args == 'test-forge-fuzz' }}
+      
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -93,11 +86,13 @@ jobs:
           check-latest: true
           cache-dependency-path: "**/*.sum"
         if: ${{ !(matrix.args == 'test-forge-cover' || matrix.args == 'test-forge-fuzz') }}
+      
       - name: Run ${{ matrix.args }}
         run: |
           make ${{ matrix.args }}
         env:
           GOPATH: /home/runner/go
+      
       - name: Upload to Codecov
         uses: codecov/codecov-action@v2
         with:
@@ -111,36 +106,36 @@ jobs:
 
   ci-e2e:
     environment: 'test-e2e'
-    strategy:
-      matrix:
-        args:
-          - "test-e2e"
-        os:
-          - ubuntu-24.04-e2e
-    name: ${{ matrix.args }}
-    runs-on:
-      labels: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    name: test-e2e
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
+
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2.2.0
         with:
           registry: https://index.docker.io/v1/
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
           go-version: "stable"
           check-latest: true
           cache-dependency-path: "**/*.sum"
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2.2.0
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+        with:
+          driver: docker-container
+          driver-opts: image-pull-policy=if-not-present
+
       - name: Install Kurtosis
         run: |
           sudo apt-get install ca-certificates
@@ -150,9 +145,10 @@ jobs:
           sudo apt install kurtosis-cli=$(go list -m -f '{{.Version}}' github.com/kurtosis-tech/kurtosis/api/golang | sed 's/^v//') -y
           kurtosis engine start
         if: ${{ matrix.args == 'test-e2e' }}
-      - name: Run ${{ matrix.args }}
+
+      - name: Run test-e2e
         run: |
-          make ${{ matrix.args }}
+          make test-e2e
         env:
           GOPATH: /home/runner/go
 
@@ -161,14 +157,18 @@ jobs:
   # -------------------------------------------------------------------------- #
 
   build-and-push-container:
-    runs-on:
-      labels: ubuntu-24.04-beacon-kit
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+        with:
+          driver: docker-container
+          driver-opts: image-pull-policy=if-not-present
 
       - name: Echo GitHub Context Variables
         run: |
@@ -190,13 +190,14 @@ jobs:
           echo "GitHub Base Ref: ${{ github.base_ref }}"
           echo "PUSH_DOCKER_IMAGE: ${{ env.PUSH_DOCKER_IMAGE }}"
           echo "VERSION: ${{ env.VERSION }}"
+
       - name: Build Docker image
         run: |
           make build-docker
 
       - if: ${{ env.PUSH_DOCKER_IMAGE == 'true' }}
         name: Authenticate to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2.2.0
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
These change will:
- Cache Docker layers between runs to reduce pulls
- Only pull images if they're not already present
- Prevent the cache from growing too large
- Maintain the cache even if the job fails