### PR TITLE
chore(e2e): Initialize `finalBlockNum` before wait loop in `WaitForFinalizedBlockNumber`

### DIFF
--- a/testing/e2e/suite/setup.go
+++ b/testing/e2e/suite/setup.go
@@ -325,7 +325,10 @@ func (s *KurtosisE2ESuite) WaitForFinalizedBlockNumber(
 	defer cancel()
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	var finalBlockNum uint64
+	finalBlockNum, err := s.JSONRPCBalancer().BlockNumber(cctx)
+	if err != nil {
+		s.logger.Error("error getting finalized block number", "error", err)
+	}
 	for finalBlockNum < target {
 		// check if cctx deadline is exceeded to prevent endless loop
 		select {
@@ -334,7 +337,6 @@ func (s *KurtosisE2ESuite) WaitForFinalizedBlockNumber(
 		default:
 		}
 
-		var err error
 		finalBlockNum, err = s.JSONRPCBalancer().BlockNumber(cctx)
 		if err != nil {
 			s.logger.Error("error getting finalized block number", "error", err)


### PR DESCRIPTION
Previously, `WaitForFinalizedBlockNumber` would not initialize the `finalBlockNum`, forcing it to enter the loop and wait 1 second, even if the current finalized block is ahead of the target number.

Since the `TestEVMInflation` test is last, we've already progressed decently far past the fork slot from previous tests, so `WaitForFinalizedBlockNumber` should not have to wait 1 second if we are already past the target block number. This massively speeds up the `TestEVMInflation` test case as we no longer have to wait for 2*`SlotsPerEpoch` number of seconds for no reason.