### PR TITLE
Panic if EL is Geth 1.15 while its unsupported

### DIFF
--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -209,5 +209,19 @@ func (s *EngineClient) verifyChainIDAndConnection(
 		s.logger.Error("failed to exchange capabilities", "err", err)
 		return err
 	}
+
+	// Check if Geth client is v1.15 and panic if it is since we don't support it yet.
+	//
+	// TODO: Remove this check once we support Geth v1.15.
+	if s.HasCapability(ethclient.GetClientVersionV1) {
+		info, err2 := s.Client.GetClientVersionV1(ctx)
+		if err2 != nil {
+			return err2
+		}
+		if info[0].Name == "go-ethereum" && strings.HasPrefix(info[0].Version, "1.15") {
+			panic("Version 1.15 of go-ethereum is not supported, please use 1.14.13 or newer")
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
We want to make sure we are not accidentally running [Geth 1.15](https://github.com/ethereum/go-ethereum/releases/tag/v1.15.0) as we don't support it yet _and_ if we ever start CL with it will change the eth db schema so downgrading to back to v1.14.x would require re-syncing the chain.

Starting beacond with Geth 1.15:

```
2025-02-08T16:48:42Z INFO Exchanged capability service=engine.client capability=engine_getPayloadBodiesByHashV1
2025-02-08T16:48:42Z INFO Exchanged capability service=engine.client capability=engine_getPayloadBodiesByHashV2
2025-02-08T16:48:42Z INFO Exchanged capability service=engine.client capability=engine_getPayloadBodiesByRangeV1
2025-02-08T16:48:42Z INFO Exchanged capability service=engine.client capability=engine_getPayloadBodiesByRangeV2
2025-02-08T16:48:42Z INFO Exchanged capability service=engine.client capability=engine_getClientVersionV1
panic: Version 1.15 of go-ethereum is not supported, please use 1.14.13 or newer

goroutine 1 [running]:
github.com/berachain/beacon-kit/execution/client.(*EngineClient).verifyChainIDAndConnection(0x140005619e0, {0x1048dcc58, 0x14000d9c500})
	github.com/berachain/beacon-kit/execution/client/client.go:222 +0x628
github.com/berachain/beacon-kit/execution/client.(*EngineClient).Start(0x140005619e0, {0x1048dcc58, 0x14000d9c500})
	github.com/berachain/beacon-kit/execution/client/client.go:102 +0x164
github.com/berachain/beacon-kit/node-core/services/registry.(*Registry).StartAll(0x14000c632f0, {0x1048dcc58, 0x14000d9c500})
	github.com/berachain/beacon-kit/node-core/services/registry/registry.go:89 +0x24c
github.com/berachain/beacon-kit/node-core/node.(*node).Start(0x14000c66828, {0x1048dcc20?, 0x14000552570?})
	github.com/berachain/beacon-kit/node-core/node/node.go:73 +0x70
github.com/berachain/beacon-kit/cli/commands/server.StartCmdWithOptions[...].func1({0x103e7e1d2, 0x4?, 0x103e7e086?})
	github.com/berachain/beacon-kit/cli/commands/server/start.go:110 +0xf4
github.com/spf13/cobra.(*Command).execute(0x14000bc4908, {0x14000533220, 0xa, 0xa})
	github.com/spf13/cobra@v1.8.1/command.go:985 +0x834
github.com/spf13/cobra.(*Command).ExecuteC(0x14000ba6308)
	github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.8.1/command.go:1034
github.com/berachain/beacon-kit/cli/commands/server/cmd.Execute(0x14000ba6308, {0x0, 0x0}, {0x14000d984e0, 0x21})
	github.com/berachain/beacon-kit/cli/commands/server/cmd/execute.go:56 +0x244
github.com/berachain/beacon-kit/cli/commands.(*Root).Run(0x14000d9fce0?, {0x14000d984e0?, 0x10490b490?})
	github.com/berachain/beacon-kit/cli/commands/root.go:92 +0x34
main.run()
	./main.go:84 +0x334
main.main()
	./main.go:89 +0x1c
make: *** [start] Error 2
```