### PR TITLE
fix(deposits): Modify Deposit Verification Logic

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,7 +47,9 @@ env:
   GCP_SERVICE_ACCOUNT: "sa-apps-deployment@prj-berachain-automation-st-01.iam.gserviceaccount.com"
   GCP_REGISTRY: northamerica-northeast1-docker.pkg.dev
   GHCR_REGISTRY: ghcr.io
-  PUSH_DOCKER_IMAGE: ${{ (github.base_ref == github.head_ref && github.event_name == 'push') || github.ref == 'refs/tags/v*'}}
+  # temporarily set to true to create image
+  PUSH_DOCKER_IMAGE: true
+  # PUSH_DOCKER_IMAGE: ${{ (github.base_ref == github.head_ref && github.event_name == 'push') || github.ref == 'refs/tags/v*'}}
   VERSION: ${{ github.ref_name }}
 
 jobs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -50,7 +50,7 @@ env:
   # temporarily set to true to create image
   PUSH_DOCKER_IMAGE: true
   # PUSH_DOCKER_IMAGE: ${{ (github.base_ref == github.head_ref && github.event_name == 'push') || github.ref == 'refs/tags/v*'}}
-  VERSION: ${{ github.ref_name }}
+  VERSION: ${{ github.sha }}
 
 jobs:
   # -------------------------------------------------------------------------- #

--- a/beacon/blockchain/deposit.go
+++ b/beacon/blockchain/deposit.go
@@ -33,6 +33,7 @@ import (
 // defaultRetryInterval processes a deposit event.
 const defaultRetryInterval = 20 * time.Second
 
+// depositFetcher fetches the blocks at blockNum-s.eth1FollowDistance so that they can be included in blockNum+1.
 func (s *Service) depositFetcher(
 	ctx context.Context,
 	blockNum math.U64,

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -178,6 +178,7 @@ func (s *Service) executeStateTransition(
 		WithVerifyPayload(true).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
+		WithVerifyDeposits(false).
 		WithMeterGas(true)
 
 	return s.stateProcessor.Transition(

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -102,7 +102,8 @@ func (s *Service) FinalizeBlock(
 			return nil, fmt.Errorf("failed to enqueue deposits: %w", err)
 		}
 	} else {
-		// If we're NOT syncing we want to run the deposit fetcher as we want to have our own view of the deposits which we can validate in ProcessProposal.
+		// If we're NOT syncing we want to run the deposit fetcher as we want to have our own view
+		// of the deposits which we can validate in ProcessProposal.
 		s.depositFetcher(ctx, blockNum)
 	}
 

--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -340,6 +340,7 @@ func (s *Service) verifyStateRoot(
 		WithVerifyPayload(true).
 		WithVerifyRandao(true).
 		WithVerifyResult(true).
+		WithVerifyDeposits(true).
 		WithMeterGas(false)
 
 	_, err := s.stateProcessor.Transition(txCtx, st, blk)

--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -380,6 +380,7 @@ func (s *Service) computeStateRoot(
 		WithVerifyPayload(false).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
+		WithVerifyDeposits(true).
 		WithMeterGas(false)
 
 	if _, err := s.stateProcessor.Transition(txCtx, st, blk); err != nil {

--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -380,7 +380,7 @@ func (s *Service) computeStateRoot(
 		WithVerifyPayload(false).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
-		WithVerifyDeposits(true).
+		WithVerifyDeposits(false).
 		WithMeterGas(false)
 
 	if _, err := s.stateProcessor.Transition(txCtx, st, blk); err != nil {

--- a/primitives/transition/context.go
+++ b/primitives/transition/context.go
@@ -47,7 +47,7 @@ type Context struct {
 	// verifyResult indicates whether to validate the result of
 	// the state transition.
 	verifyResult bool
-	// verifyDeposits indicated whether to validate the deposits included within a block
+	// verifyDeposits indicates whether to validate the deposits included within a block
 	verifyDeposits bool
 	// meterGas controls whether gas data related to the execution
 	// layer payload should be meter or not. We currently meter only

--- a/primitives/transition/context.go
+++ b/primitives/transition/context.go
@@ -47,7 +47,8 @@ type Context struct {
 	// verifyResult indicates whether to validate the result of
 	// the state transition.
 	verifyResult bool
-
+	// verifyDeposits indicated whether to validate the deposits included within a block
+	verifyDeposits bool
 	// meterGas controls whether gas data related to the execution
 	// layer payload should be meter or not. We currently meter only
 	// finalized blocks.
@@ -69,9 +70,10 @@ func NewTransitionCtx(
 		meterGas: false,
 
 		// by default we keep all verification
-		verifyPayload: true,
-		verifyRandao:  true,
-		verifyResult:  true,
+		verifyPayload:  true,
+		verifyRandao:   true,
+		verifyResult:   true,
+		verifyDeposits: true,
 	}
 }
 
@@ -93,6 +95,11 @@ func (c *Context) WithVerifyRandao(verifyRandao bool) *Context {
 
 func (c *Context) WithVerifyResult(verifyResult bool) *Context {
 	c.verifyResult = verifyResult
+	return c
+}
+
+func (c *Context) WithVerifyDeposits(verifyDeposits bool) *Context {
+	c.verifyDeposits = verifyDeposits
 	return c
 }
 
@@ -119,6 +126,9 @@ func (c *Context) VerifyRandao() bool {
 
 func (c *Context) VerifyResult() bool {
 	return c.verifyResult
+}
+func (c *Context) VerifyDeposits() bool {
+	return c.verifyDeposits
 }
 
 func (c *Context) MeterGas() bool {

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -64,6 +64,7 @@ func (sp *StateProcessor) processOperations(
 		}
 	} else {
 		// If we're not validating the deposits, we want to add the deposits to our Deposit Store to keep it up to date.
+		// This is a performance gain over fetching from the execution client.
 		// The DepositStore also does not get included in AppHash calculation and hence introducing this will not result in AppHash.
 		err := sp.ds.EnqueueDeposits(ctx.ConsensusCtx(), deposits)
 		if err != nil {

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -64,6 +64,7 @@ func (sp *StateProcessor) processOperations(
 		}
 	} else {
 		// If we're not validating the deposits, we want to add the deposits to our Deposit Store to keep it up to date.
+		// The DepositStore also does not get included in AppHash calculation and hence introducing this will not result in AppHash.
 		err := sp.ds.EnqueueDeposits(ctx.ConsensusCtx(), deposits)
 		if err != nil {
 			return err

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -53,7 +53,7 @@ func (sp *StateProcessor) processOperations(
 	// When we're finalizing a block, given that consensus majority has already agreed to the block deposits, we
 	// assume it is correct. However, in ProcessProposal, we do not make this assumption and verify the deposits.
 	if ctx.VerifyDeposits() {
-		// 	Instead we directly compare block deposits with our local store ones.
+		// Instead we directly compare block deposits with our local store ones.
 		if err := sp.validateNonGenesisDeposits(
 			ctx.ConsensusCtx(),
 			st,

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -71,7 +71,6 @@ func (sp *StateProcessor) processOperations(
 	}
 
 	for _, dep := range deposits {
-		// We want to update our local state regardless as `processDeposit` is idempotent
 		if err := sp.processDeposit(st, dep); err != nil {
 			return err
 		}

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -62,14 +62,6 @@ func (sp *StateProcessor) processOperations(
 		); err != nil {
 			return err
 		}
-	} else {
-		// If we're not validating the deposits, we want to add the deposits to our Deposit Store to keep it up to date.
-		// This is a performance gain over fetching from the execution client.
-		// The DepositStore also does not get included in AppHash calculation and hence introducing this will not result in AppHash.
-		err := sp.ds.EnqueueDeposits(ctx.ConsensusCtx(), deposits)
-		if err != nil {
-			return err
-		}
 	}
 
 	for _, dep := range deposits {

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -85,6 +85,7 @@ func (sp *StateProcessor) processDeposit(st *state.StateDB, dep *ctypes.Deposit)
 	if err != nil {
 		return err
 	}
+	
 	if err = st.SetEth1DepositIndex(eth1DepositIndex + 1); err != nil {
 		return err
 	}

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -62,6 +62,12 @@ func (sp *StateProcessor) processOperations(
 		); err != nil {
 			return err
 		}
+	} else {
+		// If we're not validating the deposits, we want to add the deposits to our Deposit Store to keep it up to date.
+		err := sp.ds.EnqueueDeposits(ctx.ConsensusCtx(), deposits)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, dep := range deposits {
@@ -80,7 +86,6 @@ func (sp *StateProcessor) processDeposit(st *state.StateDB, dep *ctypes.Deposit)
 	if err != nil {
 		return err
 	}
-
 	if err = st.SetEth1DepositIndex(eth1DepositIndex + 1); err != nil {
 		return err
 	}

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -85,7 +85,7 @@ func (sp *StateProcessor) processDeposit(st *state.StateDB, dep *ctypes.Deposit)
 	if err != nil {
 		return err
 	}
-	
+
 	if err = st.SetEth1DepositIndex(eth1DepositIndex + 1); err != nil {
 		return err
 	}

--- a/state-transition/core/types.go
+++ b/state-transition/core/types.go
@@ -41,6 +41,7 @@ type ReadOnlyContext interface {
 	VerifyPayload() bool
 	VerifyRandao() bool
 	VerifyResult() bool
+	VerifyDeposits() bool
 	MeterGas() bool
 }
 

--- a/storage/deposit/store.go
+++ b/storage/deposit/store.go
@@ -134,7 +134,7 @@ func (kv *KVStore) EnqueueDeposits(ctx context.Context, deposits []*ctypes.Depos
 	}
 
 	if len(deposits) > 0 {
-		kv.logger.Debug(
+		kv.logger.Info(
 			"EnqueueDeposit", "enqueued", len(deposits),
 			"start", deposits[0].GetIndex(), "end", deposits[len(deposits)-1].GetIndex(),
 		)

--- a/storage/deposit/store.go
+++ b/storage/deposit/store.go
@@ -121,7 +121,7 @@ func (kv *KVStore) GetDepositsByIndex(
 	return deposits, nil
 }
 
-// EnqueueDeposits pushes multiple deposits to the queue.
+// EnqueueDeposits pushes multiple deposits to the queue. EnqueueDeposits is idempotent.
 func (kv *KVStore) EnqueueDeposits(ctx context.Context, deposits []*ctypes.Deposit) error {
 	kv.mu.Lock()
 	defer kv.mu.Unlock()

--- a/testing/state-transition/state-transition.go
+++ b/testing/state-transition/state-transition.go
@@ -142,6 +142,7 @@ func SetupTestState(t *testing.T, cs chain.Spec) (
 		WithVerifyPayload(false).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
+		WithVerifyDeposits(true).
 		WithMeterGas(false)
 
 	return sp, beaconState, depositStore, ctx


### PR DESCRIPTION
This PR modifies the deposit logic such that we trust the deposits in the block in Finalize, which helps users avoid syncing issues. 
However, once at the tip of the chain, users may still encounter deposit issues with this approach but this is less likely due to the lower relative frequency of deposits at the tip of the chain vs historical deposits. 

how can we test this better?