### PR TITLE
chore(generics): Remove Generics from Node Builder

### DIFF
--- a/cli/builder/builder.go
+++ b/cli/builder/builder.go
@@ -30,14 +30,13 @@ import (
 	"github.com/berachain/beacon-kit/cli/config"
 	cometbft "github.com/berachain/beacon-kit/consensus/cometbft/service"
 	"github.com/berachain/beacon-kit/log/phuslu"
-	"github.com/berachain/beacon-kit/node-core/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 )
 
 // CLIBuilder is the builder for the commands.Root (root command).
-type CLIBuilder[T types.Node] struct {
+type CLIBuilder struct {
 	name        string
 	description string
 	// components is a list of component providers for depinject.
@@ -47,12 +46,12 @@ type CLIBuilder[T types.Node] struct {
 	// nodeBuilderFunc is a function that builds the Node,
 	// eventually called by the cosmos-sdk.
 	// TODO: CLI should not know about the AppCreator
-	nodeBuilderFunc servertypes.AppCreator[T]
+	nodeBuilderFunc servertypes.AppCreator
 }
 
 // New returns a new CLIBuilder with the given options.
-func New[T types.Node](opts ...Opt[T]) *CLIBuilder[T] {
-	cb := &CLIBuilder[T]{
+func New(opts ...Opt) *CLIBuilder {
+	cb := &CLIBuilder{
 		suppliers: []any{
 			os.Stdout, // supply io.Writer for logger
 		},
@@ -64,7 +63,7 @@ func New[T types.Node](opts ...Opt[T]) *CLIBuilder[T] {
 }
 
 // Build builds the CLI commands.
-func (cb *CLIBuilder[T]) Build() (*cmdlib.Root, error) {
+func (cb *CLIBuilder) Build() (*cmdlib.Root, error) {
 	// allocate memory to hold the dependencies
 	var (
 		clientCtx client.Context
@@ -96,7 +95,7 @@ func (cb *CLIBuilder[T]) Build() (*cmdlib.Root, error) {
 	)
 
 	// apply default root command setup
-	cmdlib.DefaultRootCommandSetup[T](
+	cmdlib.DefaultRootCommandSetup(
 		rootCmd,
 		&cometbft.Service{},
 		cb.nodeBuilderFunc,
@@ -107,7 +106,7 @@ func (cb *CLIBuilder[T]) Build() (*cmdlib.Root, error) {
 }
 
 // defaultRunHandler returns the default run handler for the CLIBuilder.
-func (cb *CLIBuilder[_]) defaultRunHandler(logger *phuslu.Logger) func(cmd *cobra.Command) error {
+func (cb *CLIBuilder) defaultRunHandler(logger *phuslu.Logger) func(cmd *cobra.Command) error {
 	return func(cmd *cobra.Command) error {
 		return cb.InterceptConfigsPreRunHandler(
 			cmd,
@@ -119,7 +118,7 @@ func (cb *CLIBuilder[_]) defaultRunHandler(logger *phuslu.Logger) func(cmd *cobr
 	}
 }
 
-func (cb *CLIBuilder[_]) InterceptConfigsPreRunHandler(
+func (cb *CLIBuilder) InterceptConfigsPreRunHandler(
 	cmd *cobra.Command,
 	logger *phuslu.Logger,
 	customAppConfigTemplate string,

--- a/cli/builder/options.go
+++ b/cli/builder/options.go
@@ -22,36 +22,35 @@ package builder
 
 import (
 	servertypes "github.com/berachain/beacon-kit/cli/commands/server/types"
-	"github.com/berachain/beacon-kit/node-core/types"
 )
 
 // Opt is a type that defines a function that modifies CLIBuilder.
-type Opt[T types.Node] func(*CLIBuilder[T])
+type Opt func(*CLIBuilder)
 
 // WithName sets the name for the CLIBuilder.
-func WithName[T types.Node](name string) Opt[T] {
-	return func(cb *CLIBuilder[T]) {
+func WithName(name string) Opt {
+	return func(cb *CLIBuilder) {
 		cb.name = name
 	}
 }
 
 // WithDescription sets the description for the CLIBuilder.
-func WithDescription[T types.Node](description string) Opt[T] {
-	return func(cb *CLIBuilder[T]) {
+func WithDescription(description string) Opt {
+	return func(cb *CLIBuilder) {
 		cb.description = description
 	}
 }
 
 // WithComponents sets the components for the CLIBuilder.
-func WithComponents[T types.Node](components []any) Opt[T] {
-	return func(cb *CLIBuilder[T]) {
+func WithComponents(components []any) Opt {
+	return func(cb *CLIBuilder) {
 		cb.components = components
 	}
 }
 
 // WithNodeBuilderFunc sets the cosmos app creator for the CLIBuilder.
-func WithNodeBuilderFunc[T types.Node](nodeBuilderFunc servertypes.AppCreator[T]) Opt[T] {
-	return func(cb *CLIBuilder[T]) {
+func WithNodeBuilderFunc(nodeBuilderFunc servertypes.AppCreator) Opt {
+	return func(cb *CLIBuilder) {
 		cb.nodeBuilderFunc = nodeBuilderFunc
 	}
 }

--- a/cli/commands/server/rollback.go
+++ b/cli/commands/server/rollback.go
@@ -21,10 +21,8 @@
 package server
 
 import (
-	"context"
 	"fmt"
 
-	"cosmossdk.io/store"
 	types "github.com/berachain/beacon-kit/cli/commands/server/types"
 	clicontext "github.com/berachain/beacon-kit/cli/context"
 	"github.com/berachain/beacon-kit/storage/db"
@@ -35,13 +33,8 @@ import (
 
 // NewRollbackCmd creates a command to rollback CometBFT and multistore state by
 // one height.
-func NewRollbackCmd[
-	T interface {
-		Start(context.Context) error
-		CommitMultiStore() store.CommitMultiStore
-	},
-](
-	appCreator types.AppCreator[T],
+func NewRollbackCmd(
+	appCreator types.AppCreator,
 ) *cobra.Command {
 	var removeBlock bool
 

--- a/cli/commands/server/start.go
+++ b/cli/commands/server/start.go
@@ -22,8 +22,6 @@
 package server
 
 import (
-	"context"
-
 	pruningtypes "cosmossdk.io/store/pruning/types"
 	types "github.com/berachain/beacon-kit/cli/commands/server/types"
 	clicontext "github.com/berachain/beacon-kit/cli/context"
@@ -51,11 +49,7 @@ const (
 
 // StartCmdOptions defines options that can be customized in
 // `StartCmdWithOptions`,.
-type StartCmdOptions[
-	T interface {
-		Start(context.Context) error
-	},
-] struct {
+type StartCmdOptions struct {
 	// AddFlags allows adding custom flags to the start command.
 	AddFlags func(cmd *cobra.Command)
 }
@@ -63,13 +57,9 @@ type StartCmdOptions[
 // StartCmdWithOptions runs the service passed in, either stand-alone or
 // in-process with
 // CometBFT.
-func StartCmdWithOptions[
-	T interface {
-		Start(context.Context) error
-	},
-](
-	appCreator types.AppCreator[T],
-	opts StartCmdOptions[T],
+func StartCmdWithOptions(
+	appCreator types.AppCreator,
+	opts StartCmdOptions,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "start",
@@ -116,13 +106,9 @@ custom: allow pruning options to be manually specified through 'pruning-keep-rec
 }
 
 // addStartNodeFlags should be added to any CLI commands that start the network.
-func addStartNodeFlags[
-	T interface {
-		Start(context.Context) error
-	},
-](
+func addStartNodeFlags(
 	cmd *cobra.Command,
-	opts StartCmdOptions[T],
+	opts StartCmdOptions,
 ) {
 	cmd.Flags().String(
 		flagAddress, "tcp://127.0.0.1:26658", "Listen address")

--- a/cli/commands/server/types/app.go
+++ b/cli/commands/server/types/app.go
@@ -24,7 +24,7 @@ import (
 	"io"
 
 	"github.com/berachain/beacon-kit/log/phuslu"
-	nodetypes "github.com/berachain/beacon-kit/node-core/types"
+	"github.com/berachain/beacon-kit/node-core/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	dbm "github.com/cosmos/cosmos-db"
 )
@@ -46,5 +46,5 @@ type (
 	// application using various configurations.
 	AppCreator func(
 		*phuslu.Logger, dbm.DB, io.Writer, *cmtcfg.Config, AppOptions,
-	) nodetypes.Node
+	) types.Node
 )

--- a/cli/commands/server/types/app.go
+++ b/cli/commands/server/types/app.go
@@ -21,10 +21,10 @@
 package types
 
 import (
-	"context"
 	"io"
 
 	"github.com/berachain/beacon-kit/log/phuslu"
+	nodetypes "github.com/berachain/beacon-kit/node-core/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	dbm "github.com/cosmos/cosmos-db"
 )
@@ -37,19 +37,14 @@ type (
 	// is defined by the server package and is typically implemented via a Viper
 	// literal defined on the server Context. Note, casting Get calls may not
 	// yield the expected types and could result in type assertion errors. It is
-	// recommend
-	// to either use the cast package or perform manual conversion for safety.
+	// recommended to either use the cast package or perform manual conversion for safety.
 	AppOptions interface {
 		Get(string) interface{}
 	}
 
 	// AppCreator is a function that allows us to lazily initialize an
 	// application using various configurations.
-	AppCreator[
-		AppT interface {
-			Start(ctx context.Context) error
-		},
-	] func(
+	AppCreator func(
 		*phuslu.Logger, dbm.DB, io.Writer, *cmtcfg.Config, AppOptions,
-	) AppT
+	) nodetypes.Node
 )

--- a/cli/commands/setup.go
+++ b/cli/commands/setup.go
@@ -31,15 +31,14 @@ import (
 	"github.com/berachain/beacon-kit/cli/flags"
 	cmtcli "github.com/berachain/beacon-kit/consensus/cometbft/cli"
 	cometbft "github.com/berachain/beacon-kit/consensus/cometbft/service"
-	"github.com/berachain/beacon-kit/node-core/types"
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // DefaultRootCommandSetup sets up the default commands for the root command.
-func DefaultRootCommandSetup[T types.Node](
+func DefaultRootCommandSetup(
 	root *Root,
 	mm *cometbft.Service,
-	appCreator servertypes.AppCreator[T],
+	appCreator servertypes.AppCreator,
 	chainSpec chain.Spec,
 ) {
 	// Add all the commands to the root command.
@@ -57,7 +56,7 @@ func DefaultRootCommandSetup[T types.Node](
 		// `rollback`
 		server.NewRollbackCmd(appCreator),
 		// `start`
-		server.StartCmdWithOptions(appCreator, server.StartCmdOptions[T]{
+		server.StartCmdWithOptions(appCreator, server.StartCmdOptions{
 			AddFlags: flags.AddBeaconKitFlags,
 		}),
 		// `status`

--- a/cmd/beacond/main.go
+++ b/cmd/beacond/main.go
@@ -32,8 +32,6 @@ import (
 	"go.uber.org/automaxprocs/maxprocs"
 )
 
-type Node = nodetypes.Node
-
 // run runs the beacon node.
 func run() error {
 	// Set the uber max procs
@@ -44,7 +42,7 @@ func run() error {
 	// Build the node using the node-core.
 	nb := nodebuilder.New(
 		// Set the Runtime Components to the Default.
-		nodebuilder.WithComponents[Node](
+		nodebuilder.WithComponents(
 			DefaultComponents(),
 		),
 	)
@@ -52,15 +50,15 @@ func run() error {
 	// Build the root command using the builder
 	cb := clibuilder.New(
 		// Set the Name to the Default.
-		clibuilder.WithName[Node](
+		clibuilder.WithName[nodetypes.Node](
 			"beacond",
 		),
 		// Set the Description to the Default.
-		clibuilder.WithDescription[Node](
+		clibuilder.WithDescription[nodetypes.Node](
 			"A basic beacon node, usable most standard networks.",
 		),
 		// Set the Runtime Components to the Default.
-		clibuilder.WithComponents[Node](
+		clibuilder.WithComponents[nodetypes.Node](
 			append(
 				clicomponents.DefaultClientComponents(),
 				// TODO: remove these, and eventually pull cfg and chainspec
@@ -69,7 +67,7 @@ func run() error {
 			),
 		),
 		// Set the NodeBuilderFunc to the NodeBuilder Build.
-		clibuilder.WithNodeBuilderFunc[Node](nb.Build),
+		clibuilder.WithNodeBuilderFunc[nodetypes.Node](nb.Build),
 	)
 
 	cmd, err := cb.Build()

--- a/cmd/beacond/main.go
+++ b/cmd/beacond/main.go
@@ -32,6 +32,8 @@ import (
 	"go.uber.org/automaxprocs/maxprocs"
 )
 
+type Node = nodetypes.Node
+
 // run runs the beacon node.
 func run() error {
 	// Set the uber max procs
@@ -50,15 +52,15 @@ func run() error {
 	// Build the root command using the builder
 	cb := clibuilder.New(
 		// Set the Name to the Default.
-		clibuilder.WithName[nodetypes.Node](
+		clibuilder.WithName[Node](
 			"beacond",
 		),
 		// Set the Description to the Default.
-		clibuilder.WithDescription[nodetypes.Node](
+		clibuilder.WithDescription[Node](
 			"A basic beacon node, usable most standard networks.",
 		),
 		// Set the Runtime Components to the Default.
-		clibuilder.WithComponents[nodetypes.Node](
+		clibuilder.WithComponents[Node](
 			append(
 				clicomponents.DefaultClientComponents(),
 				// TODO: remove these, and eventually pull cfg and chainspec
@@ -67,7 +69,7 @@ func run() error {
 			),
 		),
 		// Set the NodeBuilderFunc to the NodeBuilder Build.
-		clibuilder.WithNodeBuilderFunc[nodetypes.Node](nb.Build),
+		clibuilder.WithNodeBuilderFunc[Node](nb.Build),
 	)
 
 	cmd, err := cb.Build()

--- a/cmd/beacond/main.go
+++ b/cmd/beacond/main.go
@@ -52,15 +52,15 @@ func run() error {
 	// Build the root command using the builder
 	cb := clibuilder.New(
 		// Set the Name to the Default.
-		clibuilder.WithName[Node](
+		clibuilder.WithName(
 			"beacond",
 		),
 		// Set the Description to the Default.
-		clibuilder.WithDescription[Node](
+		clibuilder.WithDescription(
 			"A basic beacon node, usable most standard networks.",
 		),
 		// Set the Runtime Components to the Default.
-		clibuilder.WithComponents[Node](
+		clibuilder.WithComponents(
 			append(
 				clicomponents.DefaultClientComponents(),
 				// TODO: remove these, and eventually pull cfg and chainspec
@@ -69,7 +69,7 @@ func run() error {
 			),
 		),
 		// Set the NodeBuilderFunc to the NodeBuilder Build.
-		clibuilder.WithNodeBuilderFunc[Node](nb.Build),
+		clibuilder.WithNodeBuilderFunc(nb.Build),
 	)
 
 	cmd, err := cb.Build()

--- a/consensus/cometbft/cli/commands.go
+++ b/consensus/cometbft/cli/commands.go
@@ -23,7 +23,6 @@ package server
 import (
 	"context"
 
-	"cosmossdk.io/store"
 	types "github.com/berachain/beacon-kit/cli/commands/server/types"
 	clicontext "github.com/berachain/beacon-kit/cli/context"
 	service "github.com/berachain/beacon-kit/consensus/cometbft/service"
@@ -48,13 +47,8 @@ import (
 )
 
 // Commands add server commands.
-func Commands[
-	T interface {
-		Start(context.Context) error
-		CommitMultiStore() store.CommitMultiStore
-	},
-](
-	appCreator types.AppCreator[T],
+func Commands(
+	appCreator types.AppCreator,
 ) *cobra.Command {
 	cometCmd := &cobra.Command{
 		Use:     "comet",
@@ -69,7 +63,7 @@ func Commands[
 		VersionCmd(),
 		cmtcmd.ResetAllCmd,
 		cmtcmd.ResetStateCmd,
-		BootstrapStateCmd[T](appCreator),
+		BootstrapStateCmd(appCreator),
 	)
 
 	return cometCmd
@@ -230,11 +224,8 @@ which this app has been compiled.`,
 	}
 }
 
-func BootstrapStateCmd[T interface {
-	Start(context.Context) error
-	CommitMultiStore() store.CommitMultiStore
-}](
-	appCreator types.AppCreator[T],
+func BootstrapStateCmd(
+	appCreator types.AppCreator,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "bootstrap-state",

--- a/node-core/builder/builder.go
+++ b/node-core/builder/builder.go
@@ -27,7 +27,7 @@ import (
 	servertypes "github.com/berachain/beacon-kit/cli/commands/server/types"
 	"github.com/berachain/beacon-kit/config"
 	"github.com/berachain/beacon-kit/log/phuslu"
-	"github.com/berachain/beacon-kit/node-core/types"
+	nodetypes "github.com/berachain/beacon-kit/node-core/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	dbm "github.com/cosmos/cosmos-db"
 )
@@ -37,14 +37,14 @@ import (
 // TODO: #Make nodebuilder build a node. Currently this is just a builder for
 // the AppCreator function, which is eventually called by cosmos to build a
 // node.
-type NodeBuilder[NodeT types.Node] struct {
+type NodeBuilder struct {
 	// components is a list of components to provide.
 	components []any
 }
 
 // New returns a new NodeBuilder.
-func New[NodeT types.Node](opts ...Opt[NodeT]) *NodeBuilder[NodeT] {
-	nb := &NodeBuilder[NodeT]{}
+func New(opts ...Opt) *NodeBuilder {
+	nb := &NodeBuilder{}
 	for _, opt := range opts {
 		opt(nb)
 	}
@@ -54,20 +54,20 @@ func New[NodeT types.Node](opts ...Opt[NodeT]) *NodeBuilder[NodeT] {
 // Build uses the node builder options and runtime parameters to
 // build a new instance of the node.
 // It is necessary to adhere to the types.AppCreator[T] interface.
-func (nb *NodeBuilder[NodeT]) Build(
+func (nb *NodeBuilder) Build(
 	logger *phuslu.Logger,
 	db dbm.DB,
 	_ io.Writer,
 	cmtCfg *cmtcfg.Config,
 	appOpts servertypes.AppOptions,
-) NodeT {
+) nodetypes.Node {
 	// variables to hold the components needed to set up BeaconApp
 	var (
 		apiBackend interface {
-			AttachQueryBackend(types.ConsensusService)
+			AttachQueryBackend(nodetypes.ConsensusService)
 		}
-		beaconNode NodeT
-		cmtService types.ConsensusService
+		beaconNode nodetypes.Node
+		cmtService nodetypes.ConsensusService
 		config     *config.Config
 	)
 

--- a/node-core/builder/builder.go
+++ b/node-core/builder/builder.go
@@ -27,7 +27,7 @@ import (
 	servertypes "github.com/berachain/beacon-kit/cli/commands/server/types"
 	"github.com/berachain/beacon-kit/config"
 	"github.com/berachain/beacon-kit/log/phuslu"
-	nodetypes "github.com/berachain/beacon-kit/node-core/types"
+	"github.com/berachain/beacon-kit/node-core/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	dbm "github.com/cosmos/cosmos-db"
 )
@@ -60,14 +60,14 @@ func (nb *NodeBuilder) Build(
 	_ io.Writer,
 	cmtCfg *cmtcfg.Config,
 	appOpts servertypes.AppOptions,
-) nodetypes.Node {
+) types.Node {
 	// variables to hold the components needed to set up BeaconApp
 	var (
 		apiBackend interface {
-			AttachQueryBackend(nodetypes.ConsensusService)
+			AttachQueryBackend(types.ConsensusService)
 		}
-		beaconNode nodetypes.Node
-		cmtService nodetypes.ConsensusService
+		beaconNode types.Node
+		cmtService types.ConsensusService
 		config     *config.Config
 	)
 

--- a/node-core/builder/options.go
+++ b/node-core/builder/options.go
@@ -20,16 +20,12 @@
 
 package builder
 
-import (
-	"github.com/berachain/beacon-kit/node-core/types"
-)
-
 // Opt is a type that defines a function that modifies NodeBuilder.
-type Opt[NodeT types.Node] func(*NodeBuilder[NodeT])
+type Opt func(*NodeBuilder)
 
 // WithComponents is a function that sets the components for the NodeBuilder.
-func WithComponents[NodeT types.Node](components []any) Opt[NodeT] {
-	return func(nb *NodeBuilder[NodeT]) {
+func WithComponents(components []any) Opt {
+	return func(nb *NodeBuilder) {
 		nb.components = components
 	}
 }


### PR DESCRIPTION
Cleans up the generics from the node building process which was an eyesore