### PR TITLE
fix(deposits): Remove verification of deposits in FinalizeBlock

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,10 +47,8 @@ env:
   GCP_SERVICE_ACCOUNT: "sa-apps-deployment@prj-berachain-automation-st-01.iam.gserviceaccount.com"
   GCP_REGISTRY: northamerica-northeast1-docker.pkg.dev
   GHCR_REGISTRY: ghcr.io
-  # temporarily set to true to create image
-  PUSH_DOCKER_IMAGE: true
-  # PUSH_DOCKER_IMAGE: ${{ (github.base_ref == github.head_ref && github.event_name == 'push') || github.ref == 'refs/tags/v*'}}
-  VERSION: ${{ github.sha }}
+  PUSH_DOCKER_IMAGE: ${{ (github.base_ref == github.head_ref && github.event_name == 'push') || github.ref == 'refs/tags/v*'}}
+  VERSION: ${{ github.ref_name }}
 
 jobs:
   # -------------------------------------------------------------------------- #

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,7 +47,9 @@ env:
   GCP_SERVICE_ACCOUNT: "sa-apps-deployment@prj-berachain-automation-st-01.iam.gserviceaccount.com"
   GCP_REGISTRY: northamerica-northeast1-docker.pkg.dev
   GHCR_REGISTRY: ghcr.io
-  PUSH_DOCKER_IMAGE: ${{ (github.base_ref == github.head_ref && github.event_name == 'push') || github.ref == 'refs/tags/v*'}}
+  # temporarily set to true to create image
+  PUSH_DOCKER_IMAGE: true
+  # PUSH_DOCKER_IMAGE: ${{ (github.base_ref == github.head_ref && github.event_name == 'push') || github.ref == 'refs/tags/v*'}}
   VERSION: ${{ github.ref_name }}
 
 jobs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -50,7 +50,7 @@ env:
   # temporarily set to true to create image
   PUSH_DOCKER_IMAGE: true
   # PUSH_DOCKER_IMAGE: ${{ (github.base_ref == github.head_ref && github.event_name == 'push') || github.ref == 'refs/tags/v*'}}
-  VERSION: ${{ github.ref_name }}
+  VERSION: ${{ github.sha }}
 
 jobs:
   # -------------------------------------------------------------------------- #

--- a/beacon/blockchain/deposit.go
+++ b/beacon/blockchain/deposit.go
@@ -34,6 +34,7 @@ import (
 const defaultRetryInterval = 20 * time.Second
 
 // depositFetcher fetches the blocks at blockNum-s.eth1FollowDistance so that they can be included in blockNum+1.
+// It also writes them to the deposit store.
 func (s *Service) depositFetcher(
 	ctx context.Context,
 	blockNum math.U64,

--- a/beacon/blockchain/deposit.go
+++ b/beacon/blockchain/deposit.go
@@ -33,6 +33,7 @@ import (
 // defaultRetryInterval processes a deposit event.
 const defaultRetryInterval = 20 * time.Second
 
+// depositFetcher fetches the blocks at blockNum-s.eth1FollowDistance so that they can be included in blockNum+1.
 func (s *Service) depositFetcher(
 	ctx context.Context,
 	blockNum math.U64,

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -98,7 +98,21 @@ func (s *Service) FinalizeBlock(
 
 	// fetch and store the deposit for the block
 	blockNum := blk.GetBody().GetExecutionPayload().GetNumber()
-	s.depositFetcher(ctx, blockNum)
+
+	if isSyncing(req.Height, req.SyncingToHeight) {
+		s.logger.Info(
+			"Syncing in finalize_block, skipping deposit fetcher",
+			"height", req.Height, "syncing_to_height", req.SyncingToHeight,
+		)
+		// If we're syncing, we just use the consensus finalized block deposits as an optimization
+		// The DepositStore does not get included in AppHash calculation and hence introducing this will not result in AppHash.
+		if err = s.storageBackend.DepositStore().EnqueueDeposits(ctx, blk.GetBody().GetDeposits()); err != nil {
+			return nil, fmt.Errorf("failed to enqueue deposits: %w", err)
+		}
+	} else {
+		// If we're NOT syncing we want to run the deposit fetcher as we want to have our own view of the deposits which we can validate in ProcessProposal.
+		s.depositFetcher(ctx, blockNum)
+	}
 
 	// store the finalized block in the KVStore.
 	// TODO: Store full SignedBeaconBlock with all data in storage
@@ -194,4 +208,9 @@ func (s *Service) executeStateTransition(
 		st,
 		blk.GetBeaconBlock(),
 	)
+}
+
+// isSyncing returns true if we are catching up and replaying blocks, i.e. only running FinalizeBlock.
+func isSyncing(height, syncingToHeight int64) bool {
+	return height < syncingToHeight
 }

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -110,7 +110,8 @@ func (s *Service) FinalizeBlock(
 			return nil, fmt.Errorf("failed to enqueue deposits: %w", err)
 		}
 	} else {
-		// If we're NOT syncing we want to run the deposit fetcher as we want to have our own view of the deposits which we can validate in ProcessProposal.
+		// If we're NOT syncing we want to run the deposit fetcher as we want to have our own view
+		// of the deposits which we can validate in ProcessProposal.
 		s.depositFetcher(ctx, blockNum)
 	}
 

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -34,6 +34,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+//nolint:funlen // fine for now, refactor later
 func (s *Service) FinalizeBlock(
 	ctx sdk.Context,
 	req *cmtabci.FinalizeBlockRequest,

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -105,7 +105,8 @@ func (s *Service) FinalizeBlock(
 			"Syncing in finalize_block, skipping deposit fetcher",
 			"height", req.Height, "syncing_to_height", req.SyncingToHeight,
 		)
-		// If we're syncing, we just use the consensus finalized block deposits as an optimization
+		// If we're syncing we do not expect the EL state to be up to date, and so we don't pull deposits from it.
+		// Instead, we store the deposits contained in the finalized block.
 		// The DepositStore does not get included in AppHash calculation and hence introducing this will not result in AppHash.
 		if err = s.storageBackend.DepositStore().EnqueueDeposits(ctx, blk.GetBody().GetDeposits()); err != nil {
 			return nil, fmt.Errorf("failed to enqueue deposits: %w", err)

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -186,6 +186,7 @@ func (s *Service) executeStateTransition(
 		WithVerifyPayload(true).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
+		WithVerifyDeposits(false).
 		WithMeterGas(true)
 
 	return s.stateProcessor.Transition(

--- a/beacon/blockchain/finalize_block.go
+++ b/beacon/blockchain/finalize_block.go
@@ -34,7 +34,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-//nolint:funlen // fine for now, refactor later
 func (s *Service) FinalizeBlock(
 	ctx sdk.Context,
 	req *cmtabci.FinalizeBlockRequest,
@@ -98,8 +97,6 @@ func (s *Service) FinalizeBlock(
 	// STEP 4: Post Finalizations cleanups
 
 	// fetch and store the deposit for the block
-	blockNum := blk.GetBody().GetExecutionPayload().GetNumber()
-
 	if isSyncing(req.Height, req.SyncingToHeight) {
 		s.logger.Info(
 			"Syncing in finalize_block, skipping deposit fetcher",
@@ -114,7 +111,7 @@ func (s *Service) FinalizeBlock(
 	} else {
 		// If we're NOT syncing we want to run the deposit fetcher as we want to have our own view
 		// of the deposits which we can validate in ProcessProposal.
-		s.depositFetcher(ctx, blockNum)
+		s.depositFetcher(ctx, blk.GetBody().GetExecutionPayload().GetNumber())
 	}
 
 	// store the finalized block in the KVStore.

--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -348,6 +348,7 @@ func (s *Service) verifyStateRoot(
 		WithVerifyPayload(true).
 		WithVerifyRandao(true).
 		WithVerifyResult(true).
+		WithVerifyDeposits(true).
 		WithMeterGas(false)
 
 	_, err := s.stateProcessor.Transition(txCtx, st, blk)

--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -380,6 +380,7 @@ func (s *Service) computeStateRoot(
 		WithVerifyPayload(false).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
+		WithVerifyDeposits(true).
 		WithMeterGas(false)
 
 	if _, err := s.stateProcessor.Transition(txCtx, st, blk); err != nil {

--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -380,7 +380,7 @@ func (s *Service) computeStateRoot(
 		WithVerifyPayload(false).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
-		WithVerifyDeposits(true).
+		WithVerifyDeposits(false).
 		WithMeterGas(false)
 
 	if _, err := s.stateProcessor.Transition(txCtx, st, blk); err != nil {

--- a/primitives/transition/context.go
+++ b/primitives/transition/context.go
@@ -47,7 +47,7 @@ type Context struct {
 	// verifyResult indicates whether to validate the result of
 	// the state transition.
 	verifyResult bool
-	// verifyDeposits indicated whether to validate the deposits included within a block
+	// verifyDeposits indicates whether to validate the deposits included within a block
 	verifyDeposits bool
 	// meterGas controls whether gas data related to the execution
 	// layer payload should be meter or not. We currently meter only

--- a/primitives/transition/context.go
+++ b/primitives/transition/context.go
@@ -47,7 +47,8 @@ type Context struct {
 	// verifyResult indicates whether to validate the result of
 	// the state transition.
 	verifyResult bool
-
+	// verifyDeposits indicated whether to validate the deposits included within a block
+	verifyDeposits bool
 	// meterGas controls whether gas data related to the execution
 	// layer payload should be meter or not. We currently meter only
 	// finalized blocks.
@@ -69,9 +70,10 @@ func NewTransitionCtx(
 		meterGas: false,
 
 		// by default we keep all verification
-		verifyPayload: true,
-		verifyRandao:  true,
-		verifyResult:  true,
+		verifyPayload:  true,
+		verifyRandao:   true,
+		verifyResult:   true,
+		verifyDeposits: true,
 	}
 }
 
@@ -93,6 +95,11 @@ func (c *Context) WithVerifyRandao(verifyRandao bool) *Context {
 
 func (c *Context) WithVerifyResult(verifyResult bool) *Context {
 	c.verifyResult = verifyResult
+	return c
+}
+
+func (c *Context) WithVerifyDeposits(verifyDeposits bool) *Context {
+	c.verifyDeposits = verifyDeposits
 	return c
 }
 
@@ -119,6 +126,9 @@ func (c *Context) VerifyRandao() bool {
 
 func (c *Context) VerifyResult() bool {
 	return c.verifyResult
+}
+func (c *Context) VerifyDeposits() bool {
+	return c.verifyDeposits
 }
 
 func (c *Context) MeterGas() bool {

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -64,6 +64,7 @@ func (sp *StateProcessor) processOperations(
 		}
 	} else {
 		// If we're not validating the deposits, we want to add the deposits to our Deposit Store to keep it up to date.
+		// This is a performance gain over fetching from the execution client.
 		// The DepositStore also does not get included in AppHash calculation and hence introducing this will not result in AppHash.
 		err := sp.ds.EnqueueDeposits(ctx.ConsensusCtx(), deposits)
 		if err != nil {

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -64,6 +64,7 @@ func (sp *StateProcessor) processOperations(
 		}
 	} else {
 		// If we're not validating the deposits, we want to add the deposits to our Deposit Store to keep it up to date.
+		// The DepositStore also does not get included in AppHash calculation and hence introducing this will not result in AppHash.
 		err := sp.ds.EnqueueDeposits(ctx.ConsensusCtx(), deposits)
 		if err != nil {
 			return err

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -53,7 +53,7 @@ func (sp *StateProcessor) processOperations(
 	// When we're finalizing a block, given that consensus majority has already agreed to the block deposits, we
 	// assume it is correct. However, in ProcessProposal, we do not make this assumption and verify the deposits.
 	if ctx.VerifyDeposits() {
-		// 	Instead we directly compare block deposits with our local store ones.
+		// Instead we directly compare block deposits with our local store ones.
 		if err := sp.validateNonGenesisDeposits(
 			ctx.ConsensusCtx(),
 			st,

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -71,7 +71,6 @@ func (sp *StateProcessor) processOperations(
 	}
 
 	for _, dep := range deposits {
-		// We want to update our local state regardless as `processDeposit` is idempotent
 		if err := sp.processDeposit(st, dep); err != nil {
 			return err
 		}

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -62,14 +62,6 @@ func (sp *StateProcessor) processOperations(
 		); err != nil {
 			return err
 		}
-	} else {
-		// If we're not validating the deposits, we want to add the deposits to our Deposit Store to keep it up to date.
-		// This is a performance gain over fetching from the execution client.
-		// The DepositStore also does not get included in AppHash calculation and hence introducing this will not result in AppHash.
-		err := sp.ds.EnqueueDeposits(ctx.ConsensusCtx(), deposits)
-		if err != nil {
-			return err
-		}
 	}
 
 	for _, dep := range deposits {

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -85,6 +85,7 @@ func (sp *StateProcessor) processDeposit(st *state.StateDB, dep *ctypes.Deposit)
 	if err != nil {
 		return err
 	}
+	
 	if err = st.SetEth1DepositIndex(eth1DepositIndex + 1); err != nil {
 		return err
 	}

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -62,6 +62,12 @@ func (sp *StateProcessor) processOperations(
 		); err != nil {
 			return err
 		}
+	} else {
+		// If we're not validating the deposits, we want to add the deposits to our Deposit Store to keep it up to date.
+		err := sp.ds.EnqueueDeposits(ctx.ConsensusCtx(), deposits)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, dep := range deposits {
@@ -80,7 +86,6 @@ func (sp *StateProcessor) processDeposit(st *state.StateDB, dep *ctypes.Deposit)
 	if err != nil {
 		return err
 	}
-
 	if err = st.SetEth1DepositIndex(eth1DepositIndex + 1); err != nil {
 		return err
 	}

--- a/state-transition/core/state_processor_staking.go
+++ b/state-transition/core/state_processor_staking.go
@@ -85,7 +85,7 @@ func (sp *StateProcessor) processDeposit(st *state.StateDB, dep *ctypes.Deposit)
 	if err != nil {
 		return err
 	}
-	
+
 	if err = st.SetEth1DepositIndex(eth1DepositIndex + 1); err != nil {
 		return err
 	}

--- a/state-transition/core/types.go
+++ b/state-transition/core/types.go
@@ -41,6 +41,7 @@ type ReadOnlyContext interface {
 	VerifyPayload() bool
 	VerifyRandao() bool
 	VerifyResult() bool
+	VerifyDeposits() bool
 	MeterGas() bool
 }
 

--- a/storage/deposit/store.go
+++ b/storage/deposit/store.go
@@ -134,7 +134,7 @@ func (kv *KVStore) EnqueueDeposits(ctx context.Context, deposits []*ctypes.Depos
 	}
 
 	if len(deposits) > 0 {
-		kv.logger.Debug(
+		kv.logger.Info(
 			"EnqueueDeposit", "enqueued", len(deposits),
 			"start", deposits[0].GetIndex(), "end", deposits[len(deposits)-1].GetIndex(),
 		)

--- a/storage/deposit/store.go
+++ b/storage/deposit/store.go
@@ -121,7 +121,7 @@ func (kv *KVStore) GetDepositsByIndex(
 	return deposits, nil
 }
 
-// EnqueueDeposits pushes multiple deposits to the queue.
+// EnqueueDeposits pushes multiple deposits to the queue. EnqueueDeposits is idempotent.
 func (kv *KVStore) EnqueueDeposits(ctx context.Context, deposits []*ctypes.Deposit) error {
 	kv.mu.Lock()
 	defer kv.mu.Unlock()

--- a/testing/state-transition/state-transition.go
+++ b/testing/state-transition/state-transition.go
@@ -142,6 +142,7 @@ func SetupTestState(t *testing.T, cs chain.Spec) (
 		WithVerifyPayload(false).
 		WithVerifyRandao(false).
 		WithVerifyResult(false).
+		WithVerifyDeposits(true).
 		WithMeterGas(false)
 
 	return sp, beaconState, depositStore, ctx


### PR DESCRIPTION
This PR modifies the deposit logic such that we trust the deposits in the block in Finalize, which helps users avoid syncing issues.
However, once at the tip of the chain, users may still encounter deposit issues with this approach but this is less likely due to the lower relative frequency of deposits at the tip of the chain vs historical deposits.