### PR TITLE
do not reject PRs based on missing period in a comment

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -265,7 +265,6 @@ linters:
     - goconst # finds repeated strings that could be replaced by a constant
     - gocritic # provides diagnostics that check for bugs, performance and style issues
     - gocyclo # computes and checks the cyclomatic complexity of functions
-    - godot # checks if comments end in a period
     - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
     # - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
@@ -355,8 +354,6 @@ issues:
   max-same-issues: 50
 
   exclude-rules:
-    - source: "(noinspection|TODO)"
-      linters: [ godot ]
     - source: "//noinspection"
       linters: [ gocritic ]
     - path: "_test\\.go"


### PR DESCRIPTION
I don't see the value of rejecting perfectly fine PRs just because they having missing periods within their comments.