### PR TITLE
chore(types): Fix error type and clean up interface definition

### DIFF
--- a/consensus/cometbft/service/encoding/encoding.go
+++ b/consensus/cometbft/service/encoding/encoding.go
@@ -101,12 +101,12 @@ func UnmarshalBlobSidecarsFromABCIRequest(
 
 	txs := req.GetTxs()
 	if len(txs) == 0 || bzIndex >= uint(len(txs)) {
-		return sidecars, ErrNoBeaconBlockInRequest
+		return sidecars, ErrNoBlobSidecarInRequest
 	}
 
 	sidecarBz := txs[bzIndex]
 	if sidecarBz == nil {
-		return sidecars, ErrNilBeaconBlockInRequest
+		return sidecars, ErrNilBlobSidecarInRequest
 	}
 
 	// TODO: Do some research to figure out how to make this more

--- a/consensus/cometbft/service/encoding/errors.go
+++ b/consensus/cometbft/service/encoding/errors.go
@@ -31,6 +31,14 @@ var (
 	// there is no beacon block in an abci request.
 	ErrNoBeaconBlockInRequest = errors.New("no beacon block in abci request")
 
+	// ErrNilBlobSidecarInRequest is an error for when
+	// the blob sidecar in an abci request is nil.
+	ErrNilBlobSidecarInRequest = errors.New("nil blob sidecar in abci request")
+
+	// ErrNoBlobSidecarInRequest is an error for when
+	// there is no blob sidecar in an abci request.
+	ErrNoBlobSidecarInRequest = errors.New("no blob sidecar in abci request")
+
 	// ErrBzIndexOutOfBounds is an error for when the index
 	// is out of bounds.
 	ErrBzIndexOutOfBounds = errors.New("bzIndex out of bounds")

--- a/node-core/types/node.go
+++ b/node-core/types/node.go
@@ -40,9 +40,7 @@ type Node interface {
 
 // ConsensusService defines everything we utilise externally from CometBFT.
 type ConsensusService interface {
-	Start(ctx context.Context) error
-	Stop() error
-	Name() string
+	service.Basic
 	CreateQueryContext(
 		height int64,
 		prove bool,


### PR DESCRIPTION
Error message for Blobs decoding was incorrectly using messages meant for beacon blocks