### PR TITLE
fix(errors): Ignore requests Txs + RPC Error Handlings Fixes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,16 @@ func (c Config) GetEngine() *engineclient.Config {
 	return &c.Engine
 }
 
+// GetPayloadBuilder returns the block store configuration.
+func (c Config) GetPayloadBuilder() *builder.Config {
+	return &c.PayloadBuilder
+}
+
+// GetBlockStoreService returns the block store configuration.
+func (c Config) GetBlockStoreService() *blockstore.Config {
+	return &c.BlockStoreService
+}
+
 // GetLogger returns the logger configuration.
 func (c Config) GetLogger() *log.Config {
 	return &c.Logger

--- a/consensus/cometbft/service/encoding/encoding.go
+++ b/consensus/cometbft/service/encoding/encoding.go
@@ -39,7 +39,7 @@ func ExtractBlobsAndBlockFromRequest(
 	}
 
 	blk, err := UnmarshalBeaconBlockFromABCIRequest(
-		req,
+		req.GetTxs(),
 		beaconBlkIndex,
 		forkVersion,
 	)
@@ -48,7 +48,7 @@ func ExtractBlobsAndBlockFromRequest(
 	}
 
 	blobs, err := UnmarshalBlobSidecarsFromABCIRequest(
-		req,
+		req.GetTxs(),
 		blobSidecarsIndex,
 	)
 
@@ -58,16 +58,11 @@ func ExtractBlobsAndBlockFromRequest(
 // UnmarshalBeaconBlockFromABCIRequest extracts a beacon block from an ABCI
 // request.
 func UnmarshalBeaconBlockFromABCIRequest(
-	req ABCIRequest,
+	txs [][]byte,
 	bzIndex uint,
 	forkVersion common.Version,
 ) (*ctypes.SignedBeaconBlock, error) {
 	var signedBlk *ctypes.SignedBeaconBlock
-	if req == nil {
-		return signedBlk, ErrNilABCIRequest
-	}
-
-	txs := req.GetTxs()
 	lenTxs := uint(len(txs))
 
 	// Ensure there are transactions in the request and that the request is
@@ -91,15 +86,10 @@ func UnmarshalBeaconBlockFromABCIRequest(
 // UnmarshalBlobSidecarsFromABCIRequest extracts blob sidecars from an ABCI
 // request.
 func UnmarshalBlobSidecarsFromABCIRequest(
-	req ABCIRequest,
+	txs [][]byte,
 	bzIndex uint,
 ) (datypes.BlobSidecars, error) {
 	var sidecars datypes.BlobSidecars
-	if req == nil {
-		return sidecars, ErrNilABCIRequest
-	}
-
-	txs := req.GetTxs()
 	if len(txs) == 0 || bzIndex >= uint(len(txs)) {
 		return sidecars, ErrNoBlobSidecarInRequest
 	}

--- a/consensus/cometbft/service/prepare_proposal.go
+++ b/consensus/cometbft/service/prepare_proposal.go
@@ -77,7 +77,7 @@ func (s *Service) prepareProposal(
 			"time", req.Time,
 			"err", err,
 		)
-		return &cmtabci.PrepareProposalResponse{Txs: req.Txs}, nil
+		return &cmtabci.PrepareProposalResponse{Txs: [][]byte{}}, nil
 	}
 
 	return &cmtabci.PrepareProposalResponse{

--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -23,7 +23,6 @@ package client
 import (
 	"context"
 	"math/big"
-	"strings"
 	"sync"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	ethclientrpc "github.com/berachain/beacon-kit/execution/client/ethclient/rpc"
 	"github.com/berachain/beacon-kit/log"
 	"github.com/berachain/beacon-kit/primitives/math"
+	"github.com/berachain/beacon-kit/primitives/net/http"
 	"github.com/berachain/beacon-kit/primitives/net/jwt"
 )
 
@@ -167,7 +167,7 @@ func (s *EngineClient) verifyChainIDAndConnection(
 	// After the initial dial, check to make sure the chain ID is correct.
 	chainID, err = s.Client.ChainID(ctx)
 	if err != nil {
-		if strings.Contains(err.Error(), "401 Unauthorized") {
+		if errors.Is(err, http.ErrUnauthorized) {
 			// We always log this error as it is a critical error.
 			s.logger.Error(UnauthenticatedConnectionErrorStr)
 		}

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -62,8 +62,7 @@ func (s *EngineClient) handleRPCError(
 		return err
 	}
 
-	// Check for timeout errors.
-	if http.IsTimeoutError(err) {
+	if errors.Is(err, http.ErrTimeout) {
 		s.metrics.incrementHTTPTimeoutCounter()
 		return http.ErrTimeout
 	}
@@ -71,7 +70,8 @@ func (s *EngineClient) handleRPCError(
 		return err
 	}
 	// Check for connection errors.
-	e, ok := err.(jsonrpc.Error)
+	var e jsonrpc.Error
+	ok := errors.As(err, &e)
 	if !ok {
 		return errors.Wrapf(
 			err,

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -67,15 +67,12 @@ func (s *EngineClient) handleRPCError(
 		s.metrics.incrementHTTPTimeoutCounter()
 		return http.ErrTimeout
 	}
-
+	if errors.Is(err, http.ErrUnauthorized) {
+		return err
+	}
 	// Check for connection errors.
-	//
-	//nolint:errorlint // from prysm.
 	e, ok := err.(jsonrpc.Error)
 	if !ok {
-		if jsonrpc.IsUnauthorizedError(e) {
-			return http.ErrUnauthorized
-		}
 		return errors.Wrapf(
 			err,
 			"got an unexpected server error in JSON-RPC response "+

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -27,26 +27,13 @@ import (
 	jsonrpc "github.com/berachain/beacon-kit/primitives/net/json-rpc"
 )
 
-// ErrUnauthenticatedConnection indicates that the connection is not
-// authenticated.
 const (
 	UnauthenticatedConnectionErrorStr = `could not verify execution chain ID as your
 	connection is not authenticated. If connecting to your execution client via HTTP, you
 	will need to set up JWT authentication...`
-
-	AuthErrMsg = "HTTP authentication to your execution client " +
-		"is not working. Please ensure you are setting a correct " +
-		"value for the JWT secret path" +
-		"is set correctly, or use an IPC " +
-		"connection if on the same machine."
 )
 
 var (
-	// ErrNotStarted indicates that the execution client is not started.
-	ErrNotStarted = errors.New("engine client is not started")
-
-	// ErrFailedToRefreshJWT indicates that the JWT could not be refreshed.
-	ErrFailedToRefreshJWT = errors.New("failed to refresh auth token")
 
 	// ErrMismatchedEth1ChainID is returned when the chainID does not
 	// match the expected chain ID.

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -50,6 +50,10 @@ func (s *EngineClient) handleRPCError(
 	}
 
 	// Check for timeout errors.
+	if errors.Is(err, engineerrors.ErrEngineAPITimeout) {
+		s.metrics.incrementEngineAPITimeout()
+		return err
+	}
 	if http.IsTimeoutError(err) {
 		s.metrics.incrementHTTPTimeoutCounter()
 		return http.ErrTimeout

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -49,10 +49,12 @@ func (s *EngineClient) handleRPCError(
 		return err
 	}
 
+	// Check for timeout errors.
 	if http.IsTimeoutError(err) {
 		s.metrics.incrementHTTPTimeoutCounter()
 		return http.ErrTimeout
 	}
+	// Check for authorization errors
 	if errors.Is(err, http.ErrUnauthorized) {
 		return err
 	}

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -72,7 +72,7 @@ func (s *EngineClient) handleRPCError(
 	// Check for connection errors.
 	var e jsonrpc.Error
 	ok := errors.As(err, &e)
-	if !ok {
+	if !ok || e == nil {
 		return errors.Wrapf(
 			err,
 			"got an unexpected server error in JSON-RPC response "+

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -49,7 +49,7 @@ func (s *EngineClient) handleRPCError(
 		return err
 	}
 
-	if errors.Is(err, http.ErrTimeout) {
+	if http.IsTimeoutError(err) {
 		s.metrics.incrementHTTPTimeoutCounter()
 		return http.ErrTimeout
 	}

--- a/execution/client/ethclient/rpc/client.go
+++ b/execution/client/ethclient/rpc/client.go
@@ -23,12 +23,12 @@ package rpc
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"sync"
 	"time"
 
-	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
 	"github.com/berachain/beacon-kit/primitives/net/jwt"
 )
@@ -183,10 +183,13 @@ func (rpc *client) callRaw(
 		return nil, err
 	}
 
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("")
+	}
+
 	resp := new(Response)
 	if err = json.Unmarshal(data, resp); err != nil {
-		// We want the response as part of the error as responses such as 'Unauthorized' do not unmarshal correctly.
-		return nil, errors.Wrapf(err, "failed to unmarshal execution client response: %s", string(data))
+		return nil, err
 	}
 
 	if resp.Error != nil {

--- a/execution/client/ethclient/rpc/client.go
+++ b/execution/client/ethclient/rpc/client.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
+	beaconhttp "github.com/berachain/beacon-kit/primitives/net/http"
 	"github.com/berachain/beacon-kit/primitives/net/jwt"
 )
 
@@ -183,8 +184,14 @@ func (rpc *client) callRaw(
 		return nil, err
 	}
 
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("")
+	switch response.StatusCode {
+	case http.StatusOK:
+		// OK: just proceed (no return)
+	case http.StatusUnauthorized:
+		return nil, beaconhttp.ErrUnauthorized
+	default:
+		// Return a default error
+		return nil, fmt.Errorf("unexpected status code %d: %s", response.StatusCode, string(data))
 	}
 
 	resp := new(Response)

--- a/execution/client/ethclient/rpc/client.go
+++ b/execution/client/ethclient/rpc/client.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
 	"github.com/berachain/beacon-kit/primitives/net/jwt"
 )
@@ -184,7 +185,8 @@ func (rpc *client) callRaw(
 
 	resp := new(Response)
 	if err = json.Unmarshal(data, resp); err != nil {
-		return nil, err
+		// We want the response as part of the error as responses such as 'Unauthorized' do not unmarshal correctly.
+		return nil, errors.Wrapf(err, "failed to unmarshal execution client response: %s", string(data))
 	}
 
 	if resp.Error != nil {

--- a/execution/client/metrics.go
+++ b/execution/client/metrics.go
@@ -73,6 +73,13 @@ func (cm *clientMetrics) measureGetPayloadDuration(startTime time.Time) {
 	)
 }
 
+// incrementEngineAPITimeout increments the timeout counter for
+// general engine api timeouts.
+func (cm *clientMetrics) incrementEngineAPITimeout() {
+	cm.incrementTimeoutCounter(
+		"beacon_kit.execution.client.engine_api")
+}
+
 // incrementForkchoiceUpdateTimeout increments the timeout counter
 // for forkchoice update.
 func (cm *clientMetrics) incrementForkchoiceUpdateTimeout() {

--- a/primitives/net/http/errors.go
+++ b/primitives/net/http/errors.go
@@ -44,10 +44,7 @@ type TimeoutError interface {
 // status.
 // Returns true if the error is a timeout error, false otherwise.
 func IsTimeoutError(e error) bool {
-	if e == nil {
-		return false
-	}
-	//nolint:errorlint // by design.
-	t, ok := e.(TimeoutError)
+	var t TimeoutError
+	ok := errors.As(e, &t)
 	return ok && t.Timeout()
 }

--- a/primitives/net/http/errors.go
+++ b/primitives/net/http/errors.go
@@ -46,5 +46,5 @@ type TimeoutError interface {
 func IsTimeoutError(e error) bool {
 	var t TimeoutError
 	ok := errors.As(e, &t)
-	return ok && t.Timeout()
+	return ok && t != nil && t.Timeout()
 }

--- a/primitives/net/http/errors.go
+++ b/primitives/net/http/errors.go
@@ -29,3 +29,25 @@ var (
 	// ErrUnauthorized indicates an unauthorized error from http.Client.
 	ErrUnauthorized = errors.New("401 unauthorized request")
 )
+
+// TimeoutError defines an interface for timeout errors.
+// It includes methods for error message retrieval and timeout status checking.
+type TimeoutError interface {
+	// Error returns the error message.
+	Error() string
+	// Timeout indicates whether the error is a timeout error.
+	Timeout() bool
+}
+
+// IsTimeoutError checks if the given error is a timeout error.
+// It asserts the error to the httpTimeoutError interface and checks its Timeout
+// status.
+// Returns true if the error is a timeout error, false otherwise.
+func IsTimeoutError(e error) bool {
+	if e == nil {
+		return false
+	}
+	//nolint:errorlint // by design.
+	t, ok := e.(TimeoutError)
+	return ok && t.Timeout()
+}

--- a/primitives/net/http/errors.go
+++ b/primitives/net/http/errors.go
@@ -29,25 +29,3 @@ var (
 	// ErrUnauthorized indicates an unauthorized error from http.Client.
 	ErrUnauthorized = errors.New("401 unauthorized request")
 )
-
-// TimeoutError defines an interface for timeout errors.
-// It includes methods for error message retrieval and timeout status checking.
-type TimeoutError interface {
-	// Error returns the error message.
-	Error() string
-	// Timeout indicates whether the error is a timeout error.
-	Timeout() bool
-}
-
-// IsTimeoutError checks if the given error is a timeout error.
-// It asserts the error to the httpTimeoutError interface and checks its Timeout
-// status.
-// Returns true if the error is a timeout error, false otherwise.
-func IsTimeoutError(e error) bool {
-	if e == nil {
-		return false
-	}
-	//nolint:errorlint // by design.
-	t, ok := e.(TimeoutError)
-	return ok && t.Timeout()
-}

--- a/primitives/net/json-rpc/errors.go
+++ b/primitives/net/json-rpc/errors.go
@@ -21,8 +21,6 @@
 package jsonrpc
 
 import (
-	"strings"
-
 	"github.com/berachain/beacon-kit/errors"
 )
 
@@ -88,21 +86,3 @@ var (
 		"an error occurred on the server while parsing the JSON text (code: -32700)",
 	)
 )
-
-// IsUnauthorizedError defines an interface for unauthorized errors.
-func IsUnauthorizedError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	//nolint:errorlint // its'ok.
-	e, ok := err.(Error)
-	if !ok {
-		if strings.Contains(
-			e.Error(), "401 Unauthorized",
-		) {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
- For some reason, in the error case we were returning `req.Txs`. That is the only time it is used and from what I can tell - it's always empty. This minor change makes it more clear that we do not use req.Txs

- Our error handling from the RPC was also borked. We did not check status codes and immediately tried to unmarshal which mean that any unmarshalling errors masked the real issue which was the status code. This occurred most frequently for unauthorized errors. There was also bugs with the handling of Unauthorized Errors