### PR TITLE
chore(state-transition): cleaned up state in state-transition UTs

### DIFF
--- a/testing/state-transition/state-transition.go
+++ b/testing/state-transition/state-transition.go
@@ -65,14 +65,15 @@ func (kvs *testKVStoreService) OpenKVStore(ctx context.Context) corestore.KVStor
 	return storage.NewKVStore(store)
 }
 
-//nolint:gochecknoglobals // unexported and use only in tests
+//nolint:gochecknoglobals // unexported and used only in tests
 var testStoreKey = storetypes.NewKVStoreKey("state-transition-tests")
 
 func BuildTestStores() (
 	storetypes.CommitMultiStore,
 	*beacondb.KVStore,
 	*depositstore.KVStore,
-	error) {
+	error,
+) {
 	db, err := db.OpenDB("", dbm.MemDBBackend)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed opening mem db: %w", err)
@@ -122,8 +123,8 @@ func SetupTestState(t *testing.T, cs chain.Spec) (
 	cms, kvStore, depositStore, err := BuildTestStores()
 	require.NoError(t, err)
 
-	ms := sdk.NewContext(cms.CacheMultiStore(), true, log.NewNopLogger())
-	beaconState := statedb.NewBeaconStateFromDB(kvStore.WithContext(ms), cs)
+	sdkCtx := sdk.NewContext(cms.CacheMultiStore(), true, log.NewNopLogger())
+	beaconState := statedb.NewBeaconStateFromDB(kvStore.WithContext(sdkCtx), cs)
 
 	sp := core.NewStateProcessor(
 		noop.NewLogger[any](),
@@ -138,7 +139,7 @@ func SetupTestState(t *testing.T, cs chain.Spec) (
 	)
 
 	ctx := transition.NewTransitionCtx(
-		ms,
+		sdkCtx,
 		0, // time
 		dummyProposerAddr,
 	).

--- a/testing/state-transition/state-transition.go
+++ b/testing/state-transition/state-transition.go
@@ -58,23 +58,24 @@ type (
 	TestStateProcessorT          = core.StateProcessor
 )
 
-type testKVStoreService struct {
-	ctx sdk.Context
-}
+type testKVStoreService struct{}
 
-func (kvs *testKVStoreService) OpenKVStore(context.Context) corestore.KVStore {
-	//nolint:contextcheck // fine with tests
-	store := sdk.UnwrapSDKContext(kvs.ctx).KVStore(testStoreKey)
+func (kvs *testKVStoreService) OpenKVStore(ctx context.Context) corestore.KVStore {
+	store := sdk.UnwrapSDKContext(ctx).KVStore(testStoreKey)
 	return storage.NewKVStore(store)
 }
 
 //nolint:gochecknoglobals // unexported and use only in tests
 var testStoreKey = storetypes.NewKVStoreKey("state-transition-tests")
 
-func initTestStores() (*beacondb.KVStore, *depositstore.KVStore, error) {
+func BuildTestStores() (
+	storetypes.CommitMultiStore,
+	*beacondb.KVStore,
+	*depositstore.KVStore,
+	error) {
 	db, err := db.OpenDB("", dbm.MemDBBackend)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed opening mem db: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed opening mem db: %w", err)
 	}
 	var (
 		nopLog        = log.NewNopLogger()
@@ -90,12 +91,12 @@ func initTestStores() (*beacondb.KVStore, *depositstore.KVStore, error) {
 
 	cms.MountStoreWithDB(testStoreKey, storetypes.StoreTypeIAVL, nil)
 	if err = cms.LoadLatestVersion(); err != nil {
-		return nil, nil, fmt.Errorf("failed to load latest version: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to load latest version: %w", err)
 	}
 
-	ctx := sdk.NewContext(cms, true, nopLog)
-	testStoreService := &testKVStoreService{ctx: ctx}
-	return beacondb.New(testStoreService),
+	testStoreService := &testKVStoreService{}
+	return cms,
+		beacondb.New(testStoreService),
 		depositstore.NewStore(testStoreService, noopCloseFunc, nopLog),
 		nil
 }
@@ -118,9 +119,11 @@ func SetupTestState(t *testing.T, cs chain.Spec) (
 
 	dummyProposerAddr := []byte{0xff}
 
-	kvStore, depositStore, err := initTestStores()
+	cms, kvStore, depositStore, err := BuildTestStores()
 	require.NoError(t, err)
-	beaconState := statedb.NewBeaconStateFromDB(kvStore, cs)
+
+	ms := sdk.NewContext(cms.CacheMultiStore(), true, log.NewNopLogger())
+	beaconState := statedb.NewBeaconStateFromDB(kvStore.WithContext(ms), cs)
 
 	sp := core.NewStateProcessor(
 		noop.NewLogger[any](),
@@ -135,7 +138,7 @@ func SetupTestState(t *testing.T, cs chain.Spec) (
 	)
 
 	ctx := transition.NewTransitionCtx(
-		context.Background(),
+		ms,
 		0, // time
 		dummyProposerAddr,
 	).


### PR DESCRIPTION
Made state handling closer to what we have in production.
I need this to keep building unit tests in both state-transition (see ongoing https://github.com/berachain/beacon-kit/pull/2516) or other packages (validators APIs, not yet pushed)