### PR TITLE
chore(ci): Set go version to `1.23.5` in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.23"
+          go-version: "1.23.5"
         env:
           GOOS: ${{ matrix.configs.target-os }}
           GOARCH: ${{ matrix.configs.arch }}


### PR DESCRIPTION
In the `release.yaml` file, the `go-version` was set as "^1.23". This was resulting in the release build using go version 1.24, as seen in this build output:
```
Run actions/setup-go@v3
Setup go version spec ^1.23
Attempting to download ^1.23...
matching ^1.23...
Acquiring 1.24.0 from https://github.com/actions/go-versions/releases/download/1.24.0-[13](https://github.com/berachain/beacon-kit/actions/runs/13409006323/job/37487094322#step:3:14)277276272/go-1.24.0-linux-arm64.tar.gz
Extracting Go...
```

This PR sets it to explicitly 1.23.5