### PR TITLE
fix(testnet): Activate Deneb1 for EVM inflation

### DIFF
--- a/config/spec/chain_ids.go
+++ b/config/spec/chain_ids.go
@@ -27,8 +27,6 @@ const (
 	// MainnetEth1ChainID is the chain ID for the Berachain mainnet.
 	MainnetEth1ChainID uint64 = 80094
 
-	// TestnetEth1ChainID is the chain ID for the public Dartio testnet.
-	//
-	// TODO: correctly set the chain name and ID.
+	// TestnetEth1ChainID is the chain ID for the Berachain public testnet.
 	TestnetEth1ChainID uint64 = 80069
 )

--- a/config/spec/testnet.go
+++ b/config/spec/testnet.go
@@ -30,12 +30,12 @@ func TestnetChainSpecData() *chain.SpecData {
 	specData := MainnetChainSpecData()
 	specData.DepositEth1ChainID = TestnetEth1ChainID
 
-	// Genesis values of inflation are unused since Deneb1 fork is activated at block 1 (epoch 0).
+	// Genesis values of EVM inflation are consistent with Deneb1 to keep BERA minting on.
 	specData.EVMInflationAddressGenesis = common.NewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1)
 	specData.EVMInflationPerBlockGenesis = mainnetEVMInflationPerBlockDeneb1
 
-	// Unlike mainnet, testnet activates Deneb1 (Bera minting) at block 1 (epoch 0).
-	specData.Deneb1ForkEpoch = 0
+	// Unlike mainnet, testnet activates Deneb1 at epoch 1.
+	specData.Deneb1ForkEpoch = 1
 	specData.EVMInflationAddressDeneb1 = common.NewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1)
 	specData.EVMInflationPerBlockDeneb1 = mainnetEVMInflationPerBlockDeneb1
 

--- a/config/spec/testnet.go
+++ b/config/spec/testnet.go
@@ -26,18 +26,19 @@ import (
 )
 
 // TestnetChainSpecData is the chain.SpecData for Berachain's public testnet.
-//
-// TODO: adjust values before testnet genesis.
 func TestnetChainSpecData() *chain.SpecData {
 	specData := MainnetChainSpecData()
 	specData.DepositEth1ChainID = TestnetEth1ChainID
 
-	// Unlike mainnet, testnet activates Bera minting at block 1
-	specData.EVMInflationAddressDeneb1 = common.NewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1)
+	// Genesis values of inflation are unused since Deneb1 fork is activated at block 1 (epoch 0).
 	specData.EVMInflationAddressGenesis = common.NewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1)
-
-	specData.EVMInflationPerBlockDeneb1 = mainnetEVMInflationPerBlockDeneb1
 	specData.EVMInflationPerBlockGenesis = mainnetEVMInflationPerBlockDeneb1
+
+	// Unlike mainnet, testnet activates Deneb1 (Bera minting) at block 1 (epoch 0).
+	specData.Deneb1ForkEpoch = 0
+	specData.EVMInflationAddressDeneb1 = common.NewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1)
+	specData.EVMInflationPerBlockDeneb1 = mainnetEVMInflationPerBlockDeneb1
+
 	return specData
 }
 

--- a/config/spec/testnet.go
+++ b/config/spec/testnet.go
@@ -20,24 +20,18 @@
 
 package spec
 
-import (
-	"github.com/berachain/beacon-kit/chain"
-	"github.com/berachain/beacon-kit/primitives/common"
-)
+import "github.com/berachain/beacon-kit/chain"
 
 // TestnetChainSpecData is the chain.SpecData for Berachain's public testnet.
 func TestnetChainSpecData() *chain.SpecData {
 	specData := MainnetChainSpecData()
+
+	// Testnet uses chain ID of 80069.
 	specData.DepositEth1ChainID = TestnetEth1ChainID
 
 	// Genesis values of EVM inflation are consistent with those of mainnet.
-	specData.EVMInflationAddressGenesis = common.NewExecutionAddressFromHex(mainnetEVMInflationAddress)
-	specData.EVMInflationPerBlockGenesis = mainnetEVMInflationPerBlock
-
-	// Unlike mainnet, testnet activates Deneb1 for BERA minting at epoch 1.
+	// Testnet activates Deneb1 for BERA minting at epoch 1.
 	specData.Deneb1ForkEpoch = 1
-	specData.EVMInflationAddressDeneb1 = common.NewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1)
-	specData.EVMInflationPerBlockDeneb1 = mainnetEVMInflationPerBlockDeneb1
 
 	return specData
 }

--- a/config/spec/testnet.go
+++ b/config/spec/testnet.go
@@ -30,11 +30,11 @@ func TestnetChainSpecData() *chain.SpecData {
 	specData := MainnetChainSpecData()
 	specData.DepositEth1ChainID = TestnetEth1ChainID
 
-	// Genesis values of EVM inflation are consistent with Deneb1 to keep BERA minting on.
-	specData.EVMInflationAddressGenesis = common.NewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1)
-	specData.EVMInflationPerBlockGenesis = mainnetEVMInflationPerBlockDeneb1
+	// Genesis values of EVM inflation are consistent with those of mainnet.
+	specData.EVMInflationAddressGenesis = common.NewExecutionAddressFromHex(mainnetEVMInflationAddress)
+	specData.EVMInflationPerBlockGenesis = mainnetEVMInflationPerBlock
 
-	// Unlike mainnet, testnet activates Deneb1 at epoch 1.
+	// Unlike mainnet, testnet activates Deneb1 for BERA minting at epoch 1.
 	specData.Deneb1ForkEpoch = 1
 	specData.EVMInflationAddressDeneb1 = common.NewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1)
 	specData.EVMInflationPerBlockDeneb1 = mainnetEVMInflationPerBlockDeneb1


### PR DESCRIPTION
## Previously
- EVM inflation turned on at genesis.
- Deneb1 was never set to turn on, but the values were set.

## New Behavior
- To keep fork versions consistent with mainnet, we shall activate Deneb1 at epoch 1 (slot 192). Genesis fork version will remain as Deneb, as is on mainnet.
- EVM inflation can be kept on or off at genesis. As BGT contracts and minting will not be live until well after block 192, choosing to keep it off at genesis (prevents minting more BERA than we need).