### PR TITLE
chore(testing): modified start-reth to enforce persistence

### DIFF
--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -86,7 +86,10 @@ start-reth: ## start an ephemeral `reth` node
 	--authrpc.addr "0.0.0.0" \
 	--authrpc.jwtsecret $(JWT_PATH) \
 	--datadir ${ETH_DATA_DIR} \
-	--ipcpath ${IPC_PATH}
+	--ipcpath ${IPC_PATH} \
+	-vvvvv \
+	--engine.persistence-threshold 0 \
+	--engine.memory-block-buffer-target 0
 
 start-reth-bartio:
 	$(call ask_reset_dir_func, $(ETH_DATA_DIR))


### PR DESCRIPTION
By default, `reth` does not persist every finalized block. Instead it stores blocks up to a certain threshold (by default 2 heights below tip, which in our case means a finalized block may be not persisted).
This may cause an issue while syncing Beacond, since we have SSF and we assume finalized blocks are duly persisted.

This PR setup configs in order to duly persist all the blocks we need