### PR TITLE
fix(API): fix slot selection in validator API

### DIFF
--- a/node-api/backend/validator.go
+++ b/node-api/backend/validator.go
@@ -77,7 +77,7 @@ func (f *validatorFilters) parseID(id string) {
 func (b Backend) FilteredValidators(
 	slot math.Slot, ids []string, statuses []string,
 ) ([]*beacontypes.ValidatorData, error) {
-	st, _, err := b.stateFromSlot(slot)
+	st, slot, err := b.stateFromSlot(slot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}

--- a/node-api/backend/validator.go
+++ b/node-api/backend/validator.go
@@ -195,7 +195,7 @@ func buildValidatorData(
 func (b Backend) ValidatorByID(
 	slot math.Slot, id string,
 ) (*beacontypes.ValidatorData, error) {
-	st, _, err := b.stateFromSlot(slot)
+	st, slot, err := b.stateFromSlot(slot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}
@@ -229,7 +229,7 @@ func (b Backend) ValidatorBalancesByIDs(
 	slot math.Slot, ids []string,
 ) ([]*beacontypes.ValidatorBalanceData, error) {
 	var index math.U64
-	st, _, err := b.stateFromSlot(slot)
+	st, slot, err := b.stateFromSlot(slot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}


### PR DESCRIPTION
`slot` parameter in `FilteredValidators` can be set to zero to indicate user is requesting tip of the chain.
In such a case, we need to fetch the proper `slot`, which `stateFromSlot` returns