### PR TITLE
fix(node-api): Fix param in validator endpoint

### DIFF
--- a/node-api/handlers/beacon/types/request.go
+++ b/node-api/handlers/beacon/types/request.go
@@ -57,7 +57,7 @@ type PostStateValidatorsRequest struct {
 
 type GetStateValidatorRequest struct {
 	types.StateIDRequest
-	ValidatorID string `query:"validator_id" validate:"required,validator_id"`
+	ValidatorID string `param:"validator_id" validate:"required,validator_id"`
 }
 
 type GetValidatorBalancesRequest struct {


### PR DESCRIPTION
Makes the validator by id API endpoint work. Example test with `curl -X 'GET' \
  'http://localhost:3500/eth/v1/beacon/states/head/validators/0' \
  -H 'accept: application/json'`