### PR TITLE
chore(debug): fixed launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,7 +68,7 @@
             },
         },
         {
-            "name": "Genesis execution payload",
+            "name": "Set deposit storage",
             "type": "go",
             "request": "launch",
             "preLaunchTask": "build",
@@ -76,7 +76,7 @@
             "program": "${workspaceFolder}/build/bin/beacond",
             "args": [
                 "genesis",
-                "execution-payload",
+                "set-deposit-storage",
                 "${workspaceFolder}/testing/files/eth-genesis.json",
                 "--home=${workspaceFolder}/.tmp/beacond",
             ],
@@ -87,6 +87,28 @@
             "presentation": {
                 "group": "initialize",
                 "order": 4
+            },
+        },
+        {
+            "name": "Genesis execution payload",
+            "type": "go",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "mode": "exec",
+            "program": "${workspaceFolder}/build/bin/beacond",
+            "args": [
+                "genesis",
+                "execution-payload",
+                "${workspaceFolder}/.tmp/beacond/eth-genesis.json",
+                "--home=${workspaceFolder}/.tmp/beacond",
+            ],
+            "env": {
+                "CHAIN_SPEC": "devnet"
+            },
+            "internalConsoleOptions": "openOnSessionStart",
+            "presentation": {
+                "group": "initialize",
+                "order": 5
             },
         },
         {


### PR DESCRIPTION
Some changes were made to `make start` which were not reflected into out `launch.json`.
Specifically:
- `set-deposit-storage` command was missing, which creates a `eth-genesis.json` file in `$BEACOND_HOME`
- `genesis execution payload` should reference the newly created `eth-genesis.json`, not the one in `.testing/files/eth-genesis.json`
This PR fixes it.
