### PR TITLE
fix starlark error when geth is not set

### DIFF
--- a/kurtosis/main.star
+++ b/kurtosis/main.star
@@ -85,7 +85,8 @@ def run(plan, network_configuration = {}, node_settings = {}, eth_json_rpc_endpo
 
     # Execute only if geth is present
     # This is needed as we have a geth config file which needs to be templated
-    if node_modules["geth"] != None:
+    geth_config_artifact = None
+    if "geth" in node_modules and node_modules["geth"] != None:
         geth_config_artifact = node_modules["geth"].process_geth_config(plan, chain_id)
 
     # Start seed nodes


### PR DESCRIPTION
When I was running only `reth` client I got the following error when running `make start-devnet`

```
There was an error interpreting Starlark code 
Evaluation error: key "geth" not in dict
        at [github.com/berachain/beacon-kit/kurtosis/main.star:88:20]: run
```

This PR fixes this error by checking if `node_modules` contains the `"geth"` key.