### PR TITLE
chore(primitives): consolidated `ParseUint` usage into `U64FromString`

### DIFF
--- a/node-api/backend/utils/validator.go
+++ b/node-api/backend/utils/validator.go
@@ -21,8 +21,6 @@
 package utils
 
 import (
-	"strconv"
-
 	"github.com/berachain/beacon-kit/primitives/crypto"
 	"github.com/berachain/beacon-kit/primitives/math"
 	statedb "github.com/berachain/beacon-kit/state-transition/core/state"
@@ -31,9 +29,9 @@ import (
 // ValidatorIndexByID parses a validator index from a string.
 // The string can be either a validator index or a validator pubkey.
 func ValidatorIndexByID(st *statedb.StateDB, keyOrIndex string) (math.U64, error) {
-	index, err := strconv.ParseUint(keyOrIndex, 10, 64)
+	index, err := math.U64FromString(keyOrIndex)
 	if err == nil {
-		return math.U64(index), nil
+		return index, nil
 	}
 	var key crypto.BLSPubkey
 	if err = key.UnmarshalText([]byte(keyOrIndex)); err != nil {

--- a/node-api/backend/validator.go
+++ b/node-api/backend/validator.go
@@ -22,7 +22,6 @@ package backend
 
 import (
 	"slices"
-	"strconv"
 
 	"github.com/berachain/beacon-kit/consensus-types/types"
 	"github.com/berachain/beacon-kit/errors"
@@ -59,8 +58,8 @@ func parseValidatorIDs(ids []string) *validatorFilters {
 // parseID attempts to parse a single ID as either a numeric ID or pubkey
 func (f *validatorFilters) parseID(id string) {
 	// Try parsing as numeric ID first
-	if index, err := strconv.ParseUint(id, 10, 64); err == nil {
-		f.numericIDs = append(f.numericIDs, index)
+	if index, err := math.U64FromString(id); err == nil {
+		f.numericIDs = append(f.numericIDs, index.Unwrap())
 		return
 	}
 

--- a/node-api/engines/echo/validator.go
+++ b/node-api/engines/echo/validator.go
@@ -116,7 +116,7 @@ func ValidateTimestampID(fl validator.FieldLevel) bool {
 }
 
 func ValidateUint64Dec(value string) bool {
-	if value == "" { // TODO ABEAR: CHECK IF THIS CAN BE ABSORBED INTO U64FromString
+	if value == "" {
 		return true
 	}
 	_, err := math.U64FromString(value)

--- a/node-api/engines/echo/validator.go
+++ b/node-api/engines/echo/validator.go
@@ -24,12 +24,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/berachain/beacon-kit/node-api/handlers/utils"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/constants"
 	"github.com/berachain/beacon-kit/primitives/crypto"
+	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 )
@@ -116,13 +116,11 @@ func ValidateTimestampID(fl validator.FieldLevel) bool {
 }
 
 func ValidateUint64Dec(value string) bool {
-	if value == "" {
+	if value == "" { // TODO ABEAR: CHECK IF THIS CAN BE ABSORBED INTO U64FromString
 		return true
 	}
-	if _, err := strconv.ParseUint(value, 10, 64); err == nil {
-		return true
-	}
-	return false
+	_, err := math.U64FromString(value)
+	return err == nil
 }
 
 func ValidateUint64(fl validator.FieldLevel) bool {

--- a/node-api/handlers/beacon/blobs.go
+++ b/node-api/handlers/beacon/blobs.go
@@ -21,11 +21,10 @@
 package beacon
 
 import (
-	"strconv"
-
 	"github.com/berachain/beacon-kit/node-api/handlers"
 	apitypes "github.com/berachain/beacon-kit/node-api/handlers/beacon/types"
 	"github.com/berachain/beacon-kit/node-api/handlers/utils"
+	"github.com/berachain/beacon-kit/primitives/math"
 )
 
 // GetBlobSidecars provides an implementation for the
@@ -46,11 +45,13 @@ func (h *Handler) GetBlobSidecars(c handlers.Context) (any, error) {
 
 	// Convert indices to uint64.
 	indices := make([]uint64, len(req.Indices))
-	for i, idx := range req.Indices {
-		indices[i], err = strconv.ParseUint(idx, 10, 64)
+	for i, idxS := range req.Indices {
+		var idx math.U64
+		idx, err = math.U64FromString(idxS)
 		if err != nil {
 			return nil, err
 		}
+		indices[i] = idx.Unwrap()
 	}
 
 	// Grab the blob sidecars from the backend.

--- a/node-api/handlers/beacon/header.go
+++ b/node-api/handlers/beacon/header.go
@@ -24,6 +24,7 @@ import (
 	"github.com/berachain/beacon-kit/node-api/handlers"
 	beacontypes "github.com/berachain/beacon-kit/node-api/handlers/beacon/types"
 	"github.com/berachain/beacon-kit/node-api/handlers/utils"
+	"github.com/berachain/beacon-kit/primitives/math"
 )
 
 func (h *Handler) GetBlockHeaders(c handlers.Context) (any, error) {
@@ -33,7 +34,7 @@ func (h *Handler) GetBlockHeaders(c handlers.Context) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	slot, err := utils.U64FromString(req.Slot)
+	slot, err := math.U64FromString(req.Slot)
 	if err != nil {
 		return nil, err
 	}

--- a/node-api/handlers/beacon/randao.go
+++ b/node-api/handlers/beacon/randao.go
@@ -25,6 +25,7 @@ import (
 	beacontypes "github.com/berachain/beacon-kit/node-api/handlers/beacon/types"
 	"github.com/berachain/beacon-kit/node-api/handlers/utils"
 	"github.com/berachain/beacon-kit/primitives/constants"
+	"github.com/berachain/beacon-kit/primitives/math"
 )
 
 func (h *Handler) GetRandao(c handlers.Context) (any, error) {
@@ -41,7 +42,7 @@ func (h *Handler) GetRandao(c handlers.Context) (any, error) {
 	}
 	epoch := constants.GenesisEpoch
 	if req.Epoch != "" {
-		epoch, err = utils.U64FromString(req.Epoch)
+		epoch, err = math.U64FromString(req.Epoch)
 		if err != nil {
 			return nil, err
 		}

--- a/node-api/handlers/beacon/types/conversions.go
+++ b/node-api/handlers/beacon/types/conversions.go
@@ -86,34 +86,34 @@ func ValidatorToConsensus(v *Validator) (*ctypes.Validator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing withdrawals: %w", err)
 	}
-	eb, err := strconv.ParseUint(v.EffectiveBalance, 10, 64)
+	eb, err := math.U64FromString(v.EffectiveBalance)
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing effective balance: %w", err)
 	}
-	aee, err := strconv.ParseUint(v.ActivationEligibilityEpoch, 10, 64)
+	aee, err := math.U64FromString(v.ActivationEligibilityEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing activation eligibility epoch: %w", err)
 	}
-	ae, err := strconv.ParseUint(v.ActivationEpoch, 10, 64)
+	ae, err := math.U64FromString(v.ActivationEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing activation epoch: %w", err)
 	}
-	ee, err := strconv.ParseUint(v.ExitEpoch, 10, 64)
+	ee, err := math.U64FromString(v.ExitEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing exit epoch: %w", err)
 	}
-	we, err := strconv.ParseUint(v.WithdrawableEpoch, 10, 64)
+	we, err := math.U64FromString(v.WithdrawableEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing withdrawable epoch: %w", err)
 	}
 	return &ctypes.Validator{
 		Pubkey:                     pk,
 		WithdrawalCredentials:      wc,
-		EffectiveBalance:           math.Gwei(eb),
+		EffectiveBalance:           eb,
 		Slashed:                    v.Slashed,
-		ActivationEligibilityEpoch: math.Epoch(aee),
-		ActivationEpoch:            math.Epoch(ae),
-		ExitEpoch:                  math.Epoch(ee),
-		WithdrawableEpoch:          math.Epoch(we),
+		ActivationEligibilityEpoch: aee,
+		ActivationEpoch:            ae,
+		ExitEpoch:                  ee,
+		WithdrawableEpoch:          we,
 	}, nil
 }

--- a/node-api/handlers/utils/id.go
+++ b/node-api/handlers/utils/id.go
@@ -21,7 +21,6 @@
 package utils
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/berachain/beacon-kit/errors"
@@ -91,7 +90,7 @@ func ParentSlotFromTimestampID[StorageBackendT interface {
 	}
 
 	// Parse the timestamp from the timestampID.
-	timestamp, err := U64FromString(timestampID[1:])
+	timestamp, err := math.U64FromString(timestampID[1:])
 	if err != nil {
 		return 0, errors.Wrapf(
 			err, "failed to parse timestamp from timestampID: %s", timestampID,
@@ -106,17 +105,6 @@ func IsTimestampIDPrefix(timestampID string) bool {
 	return strings.HasPrefix(timestampID, TimestampIDPrefix)
 }
 
-// U64FromString returns a math.U64 from the given string. Errors if the given
-// string is not in proper decimal notation.
-func U64FromString(id string) (math.U64, error) {
-	u64, err := strconv.ParseUint(id, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-
-	return math.U64(u64), nil
-}
-
 // slotFromStateID returns a slot number from the given state ID.
 // TODO: This pattern does not allow us to query block 0. Genesis points to block 1.
 func slotFromStateID(id string) (math.Slot, error) {
@@ -126,6 +114,6 @@ func slotFromStateID(id string) (math.Slot, error) {
 	case StateIDGenesis:
 		return Genesis, nil
 	default:
-		return U64FromString(id)
+		return math.U64FromString(id)
 	}
 }

--- a/primitives/encoding/ssz/schema/definitions.go
+++ b/primitives/encoding/ssz/schema/definitions.go
@@ -23,9 +23,9 @@ package schema
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/berachain/beacon-kit/primitives/encoding/ssz/constants"
+	"github.com/berachain/beacon-kit/primitives/math"
 )
 
 /* -------------------------------------------------------------------------- */
@@ -76,11 +76,11 @@ func (v vector) ID() ID { return Vector }
 func (v vector) ItemLength() uint64 { return constants.BytesPerChunk }
 
 func (v vector) ItemPosition(p string) (uint64, uint8, uint8, error) {
-	i, err := strconv.ParseUint(p, 10, 64)
+	i, err := math.U64FromString(p)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("expected index, got name %s", p)
 	}
-	start := i * v.elementType.ItemLength()
+	start := i.Unwrap() * v.elementType.ItemLength()
 	return start / constants.BytesPerChunk,
 		uint8(start % constants.BytesPerChunk), // #nosec G115 -- can't overflow.
 		uint8(start%constants.BytesPerChunk + v.ItemLength()), // #nosec G115 -- can't overflow.
@@ -141,11 +141,11 @@ func (l list) Length() uint64 {
 
 // ItemPosition returns the chunk index and offset for a given list index.
 func (l list) ItemPosition(p string) (uint64, uint8, uint8, error) {
-	i, err := strconv.ParseUint(p, 10, 64)
+	i, err := math.U64FromString(p)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("expected index, got name %s", p)
 	}
-	start := i * l.elementType.ItemLength()
+	start := i.Unwrap() * l.elementType.ItemLength()
 	return start / constants.BytesPerChunk,
 		uint8(start % constants.BytesPerChunk), // #nosec G115 -- can't overflow.
 		uint8(start%constants.BytesPerChunk + l.ItemLength()), // #nosec G115 -- can't overflow.

--- a/primitives/math/u64.go
+++ b/primitives/math/u64.go
@@ -75,6 +75,15 @@ func (u *U64) UnmarshalJSON(input []byte) error {
 	return u.UnmarshalText(strippedInput)
 }
 
+func U64FromString(id string) (U64, error) {
+	u64, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return U64(u64), nil
+}
+
 // ---------------------------------- Hex ----------------------------------
 
 // UnmarshalText implements encoding.TextUnmarshaler.

--- a/storage/filedb/range_db.go
+++ b/storage/filedb/range_db.go
@@ -25,12 +25,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/primitives/encoding/hex"
+	"github.com/berachain/beacon-kit/primitives/math"
 	db "github.com/berachain/beacon-kit/storage/interfaces"
 	"github.com/berachain/beacon-kit/storage/pruner"
 	"github.com/spf13/afero"
@@ -203,10 +203,10 @@ func ExtractIndex(prefixedKey []byte) (uint64, error) {
 	}
 
 	indexStr := string(parts[0])
-	index, err := strconv.ParseUint(indexStr, 10, 64)
+	index, err := math.U64FromString(indexStr)
 	if err != nil {
 		return 0, err
 	}
 
-	return index, nil
+	return index.Unwrap(), nil
 }


### PR DESCRIPTION
We have a de facto way to turn strings into u64 but this is not consolidated in the code.
The PR removes the code duplication