### PR TITLE
chore(payload): clean fcu signature

### DIFF
--- a/beacon/blockchain/execution_engine.go
+++ b/beacon/blockchain/execution_engine.go
@@ -57,7 +57,7 @@ func (s *Service) sendPostBlockFCU(
 		},
 		s.chainSpec.ActiveForkVersionForSlot(beaconBlk.GetSlot()),
 	)
-	if _, _, err = s.executionEngine.NotifyForkchoiceUpdate(ctx, req); err != nil {
+	if _, err = s.executionEngine.NotifyForkchoiceUpdate(ctx, req); err != nil {
 		return fmt.Errorf("failed forkchoice update, head %s: %w",
 			lph.GetBlockHash().String(),
 			err,

--- a/beacon/blockchain/payload.go
+++ b/beacon/blockchain/payload.go
@@ -104,7 +104,7 @@ func (s *Service) forceSyncUponFinalize(
 		s.chainSpec.ActiveForkVersionForSlot(beaconBlock.GetSlot()),
 	)
 
-	switch _, _, err := s.executionEngine.NotifyForkchoiceUpdate(ctx, req); {
+	switch _, err := s.executionEngine.NotifyForkchoiceUpdate(ctx, req); {
 	case err == nil:
 		return nil
 

--- a/beacon/blockchain/types.go
+++ b/beacon/blockchain/types.go
@@ -70,7 +70,7 @@ type ExecutionEngine interface {
 	NotifyForkchoiceUpdate(
 		ctx context.Context,
 		req *ctypes.ForkchoiceUpdateRequest,
-	) (*engineprimitives.PayloadID, *common.ExecutionHash, error)
+	) (*engineprimitives.PayloadID, error)
 }
 
 // ExecutionPayload is the interface for the execution payload.

--- a/execution/client/engine.go
+++ b/execution/client/engine.go
@@ -87,7 +87,7 @@ func (s *EngineClient) ForkchoiceUpdated(
 	state *engineprimitives.ForkchoiceStateV1,
 	attrs *engineprimitives.PayloadAttributes,
 	forkVersion common.Version,
-) (*engineprimitives.PayloadID, *common.ExecutionHash, error) {
+) (*engineprimitives.PayloadID, error) {
 	var (
 		startTime    = time.Now()
 		cctx, cancel = s.createContextWithTimeout(ctx)
@@ -109,17 +109,17 @@ func (s *EngineClient) ForkchoiceUpdated(
 		if errors.Is(err, engineerrors.ErrEngineAPITimeout) {
 			s.metrics.incrementForkchoiceUpdateTimeout()
 		}
-		return nil, nil, s.handleRPCError(err)
+		return nil, s.handleRPCError(err)
 	}
 	if result == nil {
-		return nil, nil, engineerrors.ErrNilForkchoiceResponse
+		return nil, engineerrors.ErrNilForkchoiceResponse
 	}
 
-	latestValidHash, err := processPayloadStatusResult(&result.PayloadStatus)
+	_, err = processPayloadStatusResult(&result.PayloadStatus)
 	if err != nil {
-		return nil, latestValidHash, err
+		return nil, err
 	}
-	return result.PayloadID, latestValidHash, nil
+	return result.PayloadID, nil
 }
 
 /* -------------------------------------------------------------------------- */

--- a/execution/client/helpers.go
+++ b/execution/client/helpers.go
@@ -47,14 +47,14 @@ func processPayloadStatusResult(
 	result *engineprimitives.PayloadStatusV1,
 ) (*common.ExecutionHash, error) {
 	switch result.Status {
+	case engineprimitives.PayloadStatusValid:
+		return result.LatestValidHash, nil
 	case engineprimitives.PayloadStatusAccepted:
 		return nil, engineerrors.ErrAcceptedPayloadStatus
 	case engineprimitives.PayloadStatusSyncing:
 		return nil, engineerrors.ErrSyncingPayloadStatus
 	case engineprimitives.PayloadStatusInvalid:
-		return result.LatestValidHash, engineerrors.ErrInvalidPayloadStatus
-	case engineprimitives.PayloadStatusValid:
-		return result.LatestValidHash, nil
+		return nil, engineerrors.ErrInvalidPayloadStatus
 	default:
 		return nil, engineerrors.ErrUnknownPayloadStatus
 	}

--- a/payload/builder/payload.go
+++ b/payload/builder/payload.go
@@ -77,7 +77,7 @@ func (pb *PayloadBuilder) RequestPayloadAsync(
 		attrs,
 		pb.chainSpec.ActiveForkVersionForSlot(slot),
 	)
-	payloadID, _, err := pb.ee.NotifyForkchoiceUpdate(ctx, req)
+	payloadID, err := pb.ee.NotifyForkchoiceUpdate(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("RequestPayloadAsync failed sending forkchoice update: %w", err)
 	}
@@ -230,7 +230,7 @@ func (pb *PayloadBuilder) SendForceHeadFCU(
 		},
 		pb.chainSpec.ActiveForkVersionForSlot(slot),
 	)
-	if _, _, err = pb.ee.NotifyForkchoiceUpdate(ctx, req); err != nil {
+	if _, err = pb.ee.NotifyForkchoiceUpdate(ctx, req); err != nil {
 		return fmt.Errorf("SendForceHeadFCU failed sending forkchoice update: %w", err)
 	}
 	return nil

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -167,8 +167,8 @@ func (ee *stubExecutionEngine) GetPayload(
 
 func (ee *stubExecutionEngine) NotifyForkchoiceUpdate(
 	context.Context, *ctypes.ForkchoiceUpdateRequest,
-) (*engineprimitives.PayloadID, *common.ExecutionHash, error) {
-	return nil, nil, errStubNotImplemented
+) (*engineprimitives.PayloadID, error) {
+	return nil, errStubNotImplemented
 }
 
 type stubAttributesFactory struct{}

--- a/payload/builder/types.go
+++ b/payload/builder/types.go
@@ -87,5 +87,5 @@ type ExecutionEngine interface {
 	NotifyForkchoiceUpdate(
 		ctx context.Context,
 		req *ctypes.ForkchoiceUpdateRequest,
-	) (*engineprimitives.PayloadID, *common.ExecutionHash, error)
+	) (*engineprimitives.PayloadID, error)
 }


### PR DESCRIPTION
`NotifyForkchoiceUpdate` returns `latestValidHash` which is never used. This PR drops it.
Extracted from https://github.com/berachain/beacon-kit/pull/2490 to reduce diff