### PR TITLE
chore(abci): Pass the context parameter

### DIFF
--- a/consensus/cometbft/service/abci.go
+++ b/consensus/cometbft/service/abci.go
@@ -46,7 +46,7 @@ func (s *Service) InitChain(
 		return &cmtabci.InitChainResponse{}, s.ctx.Err()
 	}
 	//nolint:contextcheck // see s.ctx comment for more details
-	return s.initChain(req) // internally this uses s.ctx
+	return s.initChain(s.ctx, req)
 }
 
 // PrepareProposal implements the PrepareProposal ABCI method and returns a
@@ -102,7 +102,7 @@ func (s *Service) ProcessProposal(
 		return nil, s.ctx.Err()
 	}
 	//nolint:contextcheck // see s.ctx comment for more details
-	return s.processProposal(req) // internally this uses s.ctx
+	return s.processProposal(s.ctx, req)
 }
 
 func (s *Service) FinalizeBlock(
@@ -115,7 +115,8 @@ func (s *Service) FinalizeBlock(
 		// We expect this to happen and do not want to finalize any incomplete or invalid state.
 		return nil, s.ctx.Err()
 	}
-	return s.finalizeBlock(req) // internally this uses s.ctx
+	//nolint:contextcheck // see s.ctx comment for more details
+	return s.finalizeBlock(s.ctx, req)
 }
 
 // Commit implements the ABCI interface. It will commit all state that exists in

--- a/consensus/cometbft/service/finalize_block.go
+++ b/consensus/cometbft/service/finalize_block.go
@@ -21,6 +21,7 @@
 package cometbft
 
 import (
+	"context"
 	"fmt"
 
 	cmtabci "github.com/cometbft/cometbft/abci/types"
@@ -28,9 +29,10 @@ import (
 )
 
 func (s *Service) finalizeBlock(
+	ctx context.Context,
 	req *cmtabci.FinalizeBlockRequest,
 ) (*cmtabci.FinalizeBlockResponse, error) {
-	res, err := s.finalizeBlockInternal(req)
+	res, err := s.finalizeBlockInternal(ctx, req)
 	if res != nil {
 		res.AppHash = s.workingHash()
 	}
@@ -39,6 +41,7 @@ func (s *Service) finalizeBlock(
 }
 
 func (s *Service) finalizeBlockInternal(
+	ctx context.Context,
 	req *cmtabci.FinalizeBlockRequest,
 ) (*cmtabci.FinalizeBlockResponse, error) {
 	if err := s.validateFinalizeBlockHeight(req); err != nil {
@@ -50,10 +53,10 @@ func (s *Service) finalizeBlockInternal(
 	// here given that during block replay ProcessProposal is not executed by
 	// CometBFT.
 	if s.finalizeBlockState == nil {
-		s.finalizeBlockState = s.resetState(s.ctx)
+		s.finalizeBlockState = s.resetState(ctx)
 	} else {
 		// Preserve the CosmosSDK context while using the correct base ctx.
-		s.finalizeBlockState.SetContext(s.finalizeBlockState.Context().WithContext(s.ctx))
+		s.finalizeBlockState.SetContext(s.finalizeBlockState.Context().WithContext(ctx))
 	}
 
 	// Iterate over all raw transactions in the proposal and attempt to execute

--- a/consensus/cometbft/service/init_chain.go
+++ b/consensus/cometbft/service/init_chain.go
@@ -21,6 +21,7 @@
 package cometbft
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
@@ -30,6 +31,7 @@ import (
 )
 
 func (s *Service) initChain(
+	ctx context.Context,
 	req *cmtabci.InitChainRequest,
 ) (*cmtabci.InitChainResponse, error) {
 	if req.ChainId != s.chainID {
@@ -81,8 +83,9 @@ func (s *Service) initChain(
 		}
 	}
 
-	s.finalizeBlockState = s.resetState(s.ctx)
+	s.finalizeBlockState = s.resetState(ctx)
 
+	//nolint:contextcheck // ctx already passed via resetState
 	resValidators, err := s.initChainer(
 		s.finalizeBlockState.Context(),
 		req.AppStateBytes,

--- a/consensus/cometbft/service/process_proposal.go
+++ b/consensus/cometbft/service/process_proposal.go
@@ -21,6 +21,7 @@
 package cometbft
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 )
 
 func (s *Service) processProposal(
+	ctx context.Context,
 	req *cmtabci.ProcessProposalRequest,
 ) (*cmtabci.ProcessProposalResponse, error) {
 	startTime := time.Now()
@@ -50,11 +52,12 @@ func (s *Service) processProposal(
 	// processed the first block, as we want to avoid overwriting the
 	// finalizeState
 	// after state changes during InitChain.
-	s.processProposalState = s.resetState(s.ctx)
+	s.processProposalState = s.resetState(ctx)
 	if req.Height > s.initialHeight {
-		s.finalizeBlockState = s.resetState(s.ctx)
+		s.finalizeBlockState = s.resetState(ctx)
 	}
 
+	//nolint:contextcheck // ctx already passed via resetState
 	s.processProposalState.SetContext(
 		s.getContextForProposal(
 			s.processProposalState.Context(),

--- a/consensus/cometbft/service/service.go
+++ b/consensus/cometbft/service/service.go
@@ -174,7 +174,7 @@ func (s *Service) Start(
 		return err
 	}
 
-	s.ctx = ctx
+	s.ResetAppCtx(ctx)
 	s.node, err = node.NewNode(
 		ctx,
 		cfg,


### PR DESCRIPTION
Passing the beacond App's `s.ctx` context field as a parameter to the ABCI functions imitates the functionality of using the `ctx` from CometBFT. This makes it so that the arguments in each ABCI function call are easily swappable between `s.ctx` and `ctx`, should CometBFT ever fully implement their `ctx`.