### PR TITLE
chore(node-api): slot fix and correct slot usage in error

### DIFF
--- a/node-api/backend/block.go
+++ b/node-api/backend/block.go
@@ -30,15 +30,11 @@ import (
 
 // BlockHeader returns the block header at the given slot.
 func (b Backend) BlockHeaderAtSlot(slot math.Slot) (*ctypes.BeaconBlockHeader, error) {
-	var blockHeader *ctypes.BeaconBlockHeader
-
 	st, _, err := b.stateFromSlot(slot)
 	if err != nil {
-		return blockHeader, errors.Wrapf(err, "failed to get state from slot %d", slot)
+		return nil, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}
-
-	blockHeader, err = st.GetLatestBlockHeader()
-	return blockHeader, err
+	return st.GetLatestBlockHeader()
 }
 
 // GetBlockRoot returns the root of the block at the given stateID.

--- a/node-api/backend/block.go
+++ b/node-api/backend/block.go
@@ -22,6 +22,7 @@ package backend
 
 import (
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
+	"github.com/berachain/beacon-kit/errors"
 	types "github.com/berachain/beacon-kit/node-api/handlers/beacon/types"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
@@ -33,7 +34,7 @@ func (b Backend) BlockHeaderAtSlot(slot math.Slot) (*ctypes.BeaconBlockHeader, e
 
 	st, _, err := b.stateFromSlot(slot)
 	if err != nil {
-		return blockHeader, err
+		return blockHeader, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}
 
 	blockHeader, err = st.GetLatestBlockHeader()
@@ -42,14 +43,14 @@ func (b Backend) BlockHeaderAtSlot(slot math.Slot) (*ctypes.BeaconBlockHeader, e
 
 // GetBlockRoot returns the root of the block at the given stateID.
 func (b Backend) BlockRootAtSlot(slot math.Slot) (common.Root, error) {
-	st, slot, err := b.stateFromSlot(slot)
+	st, resolvedSlot, err := b.stateFromSlot(slot)
 	if err != nil {
-		return common.Root{}, err
+		return common.Root{}, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}
 
 	// As calculated by the beacon chain. Ideally, this logic
 	// should be abstracted by the beacon chain.
-	return st.GetBlockRootAtIndex(slot.Unwrap() % b.cs.SlotsPerHistoricalRoot())
+	return st.GetBlockRootAtIndex(resolvedSlot.Unwrap() % b.cs.SlotsPerHistoricalRoot())
 }
 
 // TODO: Implement this.

--- a/node-api/backend/genesis.go
+++ b/node-api/backend/genesis.go
@@ -21,6 +21,7 @@
 package backend
 
 import (
+	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
 )
@@ -30,7 +31,7 @@ func (b Backend) GenesisValidatorsRoot(slot math.Slot) (common.Root, error) {
 	// needs genesis_time and gensis_fork_version
 	st, _, err := b.stateFromSlot(slot)
 	if err != nil {
-		return common.Root{}, err
+		return common.Root{}, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}
 	return st.GetGenesisValidatorsRoot()
 }

--- a/node-api/backend/genesis.go
+++ b/node-api/backend/genesis.go
@@ -28,7 +28,7 @@ import (
 
 // GetGenesis returns the genesis state of the beacon chain.
 func (b Backend) GenesisValidatorsRoot(slot math.Slot) (common.Root, error) {
-	// needs genesis_time and gensis_fork_version
+	// needs genesis_time and genesis_fork_version
 	st, _, err := b.stateFromSlot(slot)
 	if err != nil {
 		return common.Root{}, errors.Wrapf(err, "failed to get state from slot %d", slot)

--- a/node-api/backend/randao.go
+++ b/node-api/backend/randao.go
@@ -21,18 +21,19 @@
 package backend
 
 import (
+	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
 )
 
 func (b Backend) RandaoAtEpoch(slot math.Slot, epoch math.Epoch) (common.Bytes32, error) {
-	st, slot, err := b.stateFromSlot(slot)
+	st, resolvedSlot, err := b.stateFromSlot(slot)
 	if err != nil {
-		return common.Bytes32{}, err
+		return common.Bytes32{}, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}
 	// Infer the epoch if not provided.
 	if epoch == 0 {
-		epoch = b.cs.SlotToEpoch(slot)
+		epoch = b.cs.SlotToEpoch(resolvedSlot)
 	}
 	index := epoch.Unwrap() % b.cs.EpochsPerHistoricalVector()
 	return st.GetRandaoMixAtIndex(index)

--- a/node-api/backend/state.go
+++ b/node-api/backend/state.go
@@ -36,14 +36,14 @@ func (b *Backend) StateFromSlotForProof(slot math.Slot) (*statedb.StateDB, math.
 
 // GetStateRoot returns the root of the state at the given slot.
 func (b Backend) StateRootAtSlot(slot math.Slot) (common.Root, error) {
-	st, slot, err := b.stateFromSlot(slot)
+	st, resolvedSlot, err := b.stateFromSlot(slot)
 	if err != nil {
 		return common.Root{}, err
 	}
 
 	// As calculated by the beacon chain. Ideally, this logic
 	// should be abstracted by the beacon chain.
-	return st.StateRootAtIndex(slot.Unwrap() % b.cs.SlotsPerHistoricalRoot())
+	return st.StateRootAtIndex(resolvedSlot.Unwrap() % b.cs.SlotsPerHistoricalRoot())
 }
 
 // StateAtSlot returns the beacon state at a particular slot.

--- a/node-api/backend/validator.go
+++ b/node-api/backend/validator.go
@@ -80,7 +80,7 @@ func (f *validatorFilters) parseID(id string) {
 func (b Backend) FilteredValidators(
 	slot math.Slot, ids []string, statuses []string,
 ) ([]*beacontypes.ValidatorData, error) {
-	st, slot, err := b.stateFromSlot(slot)
+	st, resolvedSlot, err := b.stateFromSlot(slot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}
@@ -92,7 +92,7 @@ func (b Backend) FilteredValidators(
 
 	// Parse all IDs and pubkeys once at the start
 	filters := parseValidatorIDs(ids)
-	epoch := b.cs.SlotToEpoch(slot)
+	epoch := b.cs.SlotToEpoch(resolvedSlot)
 
 	return filterAndBuildValidatorData(st, validators, filters, epoch, statuses)
 }
@@ -196,7 +196,7 @@ func buildValidatorData(
 }
 
 func (b Backend) ValidatorByID(slot math.Slot, id string) (*beacontypes.ValidatorData, error) {
-	st, slot, err := b.stateFromSlot(slot)
+	st, resolvedSlot, err := b.stateFromSlot(slot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}
@@ -222,7 +222,7 @@ func (b Backend) ValidatorByID(slot math.Slot, id string) (*beacontypes.Validato
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get validator balance for validator pubkey %s and index %d", validator.GetPubkey(), index)
 	}
-	status, err := validator.Status(b.cs.SlotToEpoch(slot))
+	status, err := validator.Status(b.cs.SlotToEpoch(resolvedSlot))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get validator status for validator pubkey %s and index %d", validator.GetPubkey(), index)
 	}
@@ -237,7 +237,7 @@ func (b Backend) ValidatorByID(slot math.Slot, id string) (*beacontypes.Validato
 }
 
 func (b Backend) ValidatorBalancesByIDs(slot math.Slot, ids []string) ([]*beacontypes.ValidatorBalanceData, error) {
-	st, slot, err := b.stateFromSlot(slot)
+	st, _, err := b.stateFromSlot(slot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get state from slot %d", slot)
 	}


### PR DESCRIPTION
Extending [slot fix](https://github.com/berachain/beacon-kit/pull/2538/files), noticed that due to redefining the same variable name, the error message is not printing the correct slot. 

Please note : Will make the error message verbose in other places as and when we implement them.