### PR TITLE
chore(abci): Add FATAL errors for app

### DIFF
--- a/consensus/cometbft/service/process_proposal.go
+++ b/consensus/cometbft/service/process_proposal.go
@@ -23,6 +23,7 @@ package cometbft
 import (
 	"context"
 	"fmt"
+	"github.com/berachain/beacon-kit/errors"
 	"time"
 
 	cmtabci "github.com/cometbft/cometbft/abci/types"
@@ -68,20 +69,23 @@ func (s *Service) processProposal(
 	// errors to consensus indicate that the node was not able to understand
 	// whether the block was valid or not. Viceversa, we signal that a block
 	// is invalid by its status, but we do return nil error in such a case.
-	status := cmtabci.PROCESS_PROPOSAL_STATUS_ACCEPT
 	err := s.Blockchain.ProcessProposal(
 		s.processProposalState.Context(),
 		req,
 	)
-	if err != nil {
-		status = cmtabci.PROCESS_PROPOSAL_STATUS_REJECT
+	switch {
+	case errors.IsFatal(err):
+		return &cmtabci.ProcessProposalResponse{Status: cmtabci.PROCESS_PROPOSAL_STATUS_UNKNOWN}, err
+	case err != nil:
 		s.logger.Error(
-			"failed to process proposal",
+			"proposal rejected",
 			"height", req.Height,
 			"time", req.Time,
 			"hash", fmt.Sprintf("%X", req.Hash),
 			"err", err,
 		)
+		return &cmtabci.ProcessProposalResponse{Status: cmtabci.PROCESS_PROPOSAL_STATUS_REJECT}, nil
+	default:
+		return &cmtabci.ProcessProposalResponse{Status: cmtabci.PROCESS_PROPOSAL_STATUS_ACCEPT}, nil
 	}
-	return &cmtabci.ProcessProposalResponse{Status: status}, nil
 }

--- a/errors/mod.go
+++ b/errors/mod.go
@@ -58,12 +58,14 @@ type DetailedError struct {
 	fatal bool
 }
 
-// WrapNonFatal returns the error message.
-func WrapNonFatal(err error) error {
-	return &DetailedError{
-		error: err,
-		fatal: false,
-	}
+// Error returns a string representation.
+func (e *DetailedError) Error() string {
+	return e.error.Error()
+}
+
+// Unwrap returns the wrapped error.
+func (e *DetailedError) Unwrap() error {
+	return e.error
 }
 
 // WrapFatal creates a new DetailedError with the
@@ -78,7 +80,7 @@ func WrapFatal(err error) error {
 // IsFatal checks if the provided error is a
 // DetailedError and if it is fatal.
 func IsFatal(err error) bool {
-	// If the error is nil, obviouisly it is not fatal.
+	// If the error is nil, obviously it is not fatal.
 	if err == nil {
 		return false
 	}
@@ -100,23 +102,6 @@ func IsFatal(err error) bool {
 		return customErr.fatal
 	}
 
-	// All other errors are fatal.
-	return true
-}
-
-// JoinFatal checks if any of the provided errors is a
-// DetailedError and if it is fatal.
-func JoinFatal(errs ...error) error {
-	fatal := false
-	for _, err := range errs {
-		if IsFatal(err) {
-			fatal = true
-			break
-		}
-	}
-	retErr := stderrors.Join(errs...)
-	if fatal {
-		return WrapFatal(retErr)
-	}
-	return WrapNonFatal(retErr)
+	// Only declared fatal errors are fatal.
+	return false
 }

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -140,7 +140,7 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 					"err", err,
 				)
 				ee.metrics.markForkchoiceUpdateFatalError(err)
-				return nil, backoff.Permanent(err)
+				return nil, backoff.Permanent(errors.WrapFatal(err))
 
 			default:
 				ee.logger.Info(
@@ -248,7 +248,7 @@ func (ee *Engine) NotifyNewPayload(
 					lastValidHash = &common.ExecutionHash{}
 				}
 				ee.metrics.markNewPayloadFatalError(payloadHash, *lastValidHash, err)
-				return nil, backoff.Permanent(err)
+				return nil, backoff.Permanent(errors.WrapFatal(err))
 			default:
 				ee.logger.Error(
 					"NotifyNewPayload: EL returns unknown error.",


### PR DESCRIPTION
This adds FATAL errors to the ABCI app. This makes the response to Fatal Engine API errors consistent across `PrepareProposal`, `ProcessProposal`, and `FinalizeBlock`.