### PR TITLE
chore(config): Remove RPC Retries

### DIFF
--- a/cli/flags/flags.go
+++ b/cli/flags/flags.go
@@ -43,7 +43,6 @@ const (
 	// Engine Config.
 	engineRoot              = beaconKitRoot + "engine."
 	RPCDialURL              = engineRoot + "rpc-dial-url"
-	RPCRetries              = engineRoot + "rpc-retries"
 	RPCRetryInterval        = engineRoot + "rpc-retry-interval"
 	RPCMaxRetryInterval     = engineRoot + "rpc-max-retry-interval"
 	RPCTimeout              = engineRoot + "rpc-timeout"
@@ -90,9 +89,6 @@ func AddBeaconKitFlags(startCmd *cobra.Command) {
 	)
 	startCmd.Flags().String(
 		RPCDialURL, defaultCfg.Engine.RPCDialURL.String(), "rpc dial url",
-	)
-	startCmd.Flags().Uint64(
-		RPCRetries, defaultCfg.Engine.RPCRetries, "rpc retries",
 	)
 	startCmd.Flags().Duration(
 		RPCRetryInterval, defaultCfg.Engine.RPCRetryInterval, "initial rpc retry interval",

--- a/config/template/template.go
+++ b/config/template/template.go
@@ -29,9 +29,6 @@ const TomlTemplate = `
 # HTTP url of the execution client JSON-RPC endpoint.
 rpc-dial-url = "{{ .BeaconKit.Engine.RPCDialURL }}"
 
-# Number of retries before shutting down consensus client.
-rpc-retries = "{{.BeaconKit.Engine.RPCRetries}}"
-
 # RPC timeout for execution client requests.
 rpc-timeout = "{{ .BeaconKit.Engine.RPCTimeout }}"
 

--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -228,10 +228,6 @@ func (s *EngineClient) verifyChainIDAndConnection(
 /*                                   Getters                                  */
 /* -------------------------------------------------------------------------- */
 
-func (s *EngineClient) GetRPCRetries() uint64 {
-	return s.cfg.RPCRetries
-}
-
 func (s *EngineClient) GetRPCRetryInterval() time.Duration {
 	return s.cfg.RPCRetryInterval
 }

--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -86,6 +86,10 @@ func New(
 	}
 	cfg.RPCTimeout = max(MinRPCTimeout, cfg.RPCTimeout)
 
+	if cfg.RPCRetries != 0 {
+		logger.Warn("rpc-retries in app.toml is deprecated and no longer supported")
+	}
+
 	return &EngineClient{
 		cfg:          cfg,
 		logger:       logger,

--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -86,8 +86,8 @@ func New(
 	}
 	cfg.RPCTimeout = max(MinRPCTimeout, cfg.RPCTimeout)
 
-	if cfg.RPCRetries != 0 {
-		logger.Warn("rpc-retries in app.toml is deprecated and no longer supported")
+	if cfg.DeprecatedRPCRetries != 0 {
+		logger.Warn("rpc-retries is deprecated and the configured value will be ignored")
 	}
 
 	return &EngineClient{

--- a/execution/client/config.go
+++ b/execution/client/config.go
@@ -30,7 +30,6 @@ const (
 	MinRPCTimeout = 2 * time.Second
 
 	defaultDialURL                 = "http://localhost:8551"
-	defaultRPCRetries              = 0
 	defaultRPCRetryInterval        = 100 * time.Millisecond
 	defaultRPCMaxRetryInterval     = 10 * time.Second
 	defaultRPCStartupCheckInterval = 3 * time.Second
@@ -45,7 +44,6 @@ func DefaultConfig() Config {
 	dialURL, _ := url.NewFromRaw(defaultDialURL)
 	return Config{
 		RPCDialURL:              dialURL,
-		RPCRetries:              defaultRPCRetries,
 		RPCRetryInterval:        defaultRPCRetryInterval,
 		RPCMaxRetryInterval:     defaultRPCMaxRetryInterval,
 		RPCTimeout:              MinRPCTimeout,
@@ -59,9 +57,6 @@ func DefaultConfig() Config {
 type Config struct {
 	// RPCDialURL is the HTTP url of the execution client JSON-RPC endpoint.
 	RPCDialURL *url.ConnectionURL `mapstructure:"rpc-dial-url"`
-	// RPCRetries is the number of retries before shutting down consensus
-	// client. A value of 0 will retry infinitely.
-	RPCRetries uint64 `mapstructure:"rpc-retries"`
 	// RPCRetryInterval is the initial RPC backoff for repeated execution client calls.
 	RPCRetryInterval time.Duration `mapstructure:"rpc-retry-interval"`
 	// MaxRPCRetryInterval is the maximum RPC backoff for repeated execution client calls.

--- a/execution/client/config.go
+++ b/execution/client/config.go
@@ -57,8 +57,8 @@ func DefaultConfig() Config {
 type Config struct {
 	// RPCDialURL is the HTTP url of the execution client JSON-RPC endpoint.
 	RPCDialURL *url.ConnectionURL `mapstructure:"rpc-dial-url"`
-	// RPCRetries is deprecated.
-	RPCRetries uint64 `mapstructure:"rpc-retries"`
+	// DeprecatedRPCRetries is deprecated.
+	DeprecatedRPCRetries uint64 `mapstructure:"rpc-retries"`
 	// RPCRetryInterval is the initial RPC backoff for repeated execution client calls.
 	RPCRetryInterval time.Duration `mapstructure:"rpc-retry-interval"`
 	// MaxRPCRetryInterval is the maximum RPC backoff for repeated execution client calls.

--- a/execution/client/config.go
+++ b/execution/client/config.go
@@ -57,6 +57,8 @@ func DefaultConfig() Config {
 type Config struct {
 	// RPCDialURL is the HTTP url of the execution client JSON-RPC endpoint.
 	RPCDialURL *url.ConnectionURL `mapstructure:"rpc-dial-url"`
+	// RPCRetries is deprecated.
+	RPCRetries uint64 `mapstructure:"rpc-retries"`
 	// RPCRetryInterval is the initial RPC backoff for repeated execution client calls.
 	RPCRetryInterval time.Duration `mapstructure:"rpc-retry-interval"`
 	// MaxRPCRetryInterval is the maximum RPC backoff for repeated execution client calls.

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -76,7 +76,6 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 ) (*engineprimitives.PayloadID, error) {
 	var (
 		engineAPIBackoff     = ee.newBackoff()
-		maxRetries           = uint(ee.ec.GetRPCRetries())
 		hasPayloadAttributes = !req.PayloadAttributes.IsNil()
 	)
 
@@ -152,8 +151,8 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 			}
 		},
 		backoff.WithBackOff(engineAPIBackoff),
-		backoff.WithMaxTries(maxRetries),
-		backoff.WithMaxElapsedTime(0), // Set 0 max elapsed time so we don't check it.
+		backoff.WithMaxTries(0),       // 0 for infinite retries.
+		backoff.WithMaxElapsedTime(0), // 0 for infinite max elapsed time.
 	)
 }
 
@@ -166,9 +165,7 @@ func (ee *Engine) NotifyNewPayload(
 	retryOnSyncingStatus bool,
 ) error {
 	var (
-		engineAPIBackoff = ee.newBackoff()
-		maxRetries       = uint(ee.ec.GetRPCRetries())
-
+		engineAPIBackoff  = ee.newBackoff()
 		payloadHash       = req.ExecutionPayload.GetBlockHash()
 		payloadParentHash = req.ExecutionPayload.GetParentHash()
 	)
@@ -260,8 +257,8 @@ func (ee *Engine) NotifyNewPayload(
 			}
 		},
 		backoff.WithBackOff(engineAPIBackoff),
-		backoff.WithMaxTries(maxRetries),
-		backoff.WithMaxElapsedTime(0), // Set 0 max elapsed time so we don't check it.
+		backoff.WithMaxTries(0),       // 0 for infinite retries.
+		backoff.WithMaxElapsedTime(0), // 0 for infinite max elapsed time.
 	)
 	return err
 }

--- a/testing/networks/80069/app.toml
+++ b/testing/networks/80069/app.toml
@@ -118,10 +118,6 @@ datadog-hostname = "my_beacond_node"
 # HTTP url of the execution client JSON-RPC endpoint.
 rpc-dial-url = "http://localhost:8551"
 
-# Number of retries before shutting down consensus client.
-# A value of 0 will retry infinitely.
-rpc-retries = "0"
-
 # RPC timeout for execution client requests.
 rpc-timeout = "2s"
 

--- a/testing/networks/80094/app.toml
+++ b/testing/networks/80094/app.toml
@@ -118,10 +118,6 @@ datadog-hostname = "my_beacond_node"
 # HTTP url of the execution client JSON-RPC endpoint.
 rpc-dial-url = "http://localhost:8551"
 
-# Number of retries before shutting down consensus client.
-# A value of 0 will retry infinitely.
-rpc-retries = "0"
-
 # RPC timeout for execution client requests.
 rpc-timeout = "2s"
 


### PR DESCRIPTION
Remove the RPC retries configuration. This was originally unused, then made to fit the engine API retry mechanism. However, we have determined that the default behavior of infinite retries should be the only behavior.

NOTE: Removing this from configuration does not REQUIRE node operators to remove it from theirs. The value in the `app.toml` will simply be ignored and will not result in any errors.