### PR TITLE
chore(ssz): Define SSZ offset/content once for safe reuse

### DIFF
--- a/consensus-types/types/payload.go
+++ b/consensus-types/types/payload.go
@@ -25,7 +25,6 @@ import (
 	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/primitives/bytes"
 	"github.com/berachain/beacon-kit/primitives/common"
-	"github.com/berachain/beacon-kit/primitives/constants"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/version"
@@ -126,24 +125,14 @@ func (p *ExecutionPayload) DefineSSZ(codec *ssz.Codec) {
 	ssz.DefineDynamicBytesOffset(codec, (*[]byte)(&p.ExtraData), 32)
 	ssz.DefineUint256(codec, &p.BaseFeePerGas)
 	ssz.DefineStaticBytes(codec, &p.BlockHash)
-	ssz.DefineSliceOfDynamicBytesOffset(
-		codec,
-		(*[][]byte)(&p.Transactions),
-		constants.MaxTxsPerPayload,
-		constants.MaxBytesPerTx,
-	)
+	p.Transactions.DefineSSZOffset(codec)
 	ssz.DefineSliceOfStaticObjectsOffset(codec, &p.Withdrawals, 16)
 	ssz.DefineUint64(codec, &p.BlobGasUsed)
 	ssz.DefineUint64(codec, &p.ExcessBlobGas)
 
 	// Define the dynamic data (fields)
 	ssz.DefineDynamicBytesContent(codec, (*[]byte)(&p.ExtraData), 32)
-	ssz.DefineSliceOfDynamicBytesContent(
-		codec,
-		(*[][]byte)(&p.Transactions),
-		constants.MaxTxsPerPayload,
-		constants.MaxBytesPerTx,
-	)
+	p.Transactions.DefineSSZContent(codec)
 	ssz.DefineSliceOfStaticObjectsContent(codec, &p.Withdrawals, 16)
 
 	// Note that at this state we don't have any guarantee that

--- a/engine-primitives/engine-primitives/transactions.go
+++ b/engine-primitives/engine-primitives/transactions.go
@@ -39,34 +39,36 @@ func (txs Transactions) SizeSSZ(siz *ssz.Sizer, _ bool) uint32 {
 	return ssz.SizeSliceOfDynamicBytes(siz, txs)
 }
 
-// DefineSSZ defines the SSZ encoding for the Transactions object.
-// TODO: This can accidentally decouple from the definition in
-// ExecutionPayload and we should be cognizant of that and/or
-// make a PR to allow for them to be defined in one place.
+// DefineSSZOffset defines the SSZ offset for the Transactions object.
+func (txs Transactions) DefineSSZOffset(c *ssz.Codec) {
+	ssz.DefineSliceOfDynamicBytesOffset(
+		c,
+		(*[][]byte)(&txs),
+		constants.MaxTxsPerPayload,
+		constants.MaxBytesPerTx,
+	)
+}
+
+// DefineSSZContent defines the SSZ content for the Transactions object.
+func (txs Transactions) DefineSSZContent(c *ssz.Codec) {
+	ssz.DefineSliceOfDynamicBytesContent(
+		c,
+		(*[][]byte)(&txs),
+		constants.MaxTxsPerPayload,
+		constants.MaxBytesPerTx,
+	)
+}
+
+// DefineSSZ defines the SSZ (en/de)coding and hashing for the Transactions object.
 func (txs Transactions) DefineSSZ(codec *ssz.Codec) {
 	codec.DefineEncoder(func(*ssz.Encoder) {
-		ssz.DefineSliceOfDynamicBytesContent(
-			codec,
-			(*[][]byte)(&txs),
-			constants.MaxTxsPerPayload,
-			constants.MaxBytesPerTx,
-		)
+		txs.DefineSSZContent(codec)
 	})
 	codec.DefineDecoder(func(*ssz.Decoder) {
-		ssz.DefineSliceOfDynamicBytesContent(
-			codec,
-			(*[][]byte)(&txs),
-			constants.MaxTxsPerPayload,
-			constants.MaxBytesPerTx,
-		)
+		txs.DefineSSZContent(codec)
 	})
 	codec.DefineHasher(func(*ssz.Hasher) {
-		ssz.DefineSliceOfDynamicBytesOffset(
-			codec,
-			(*[][]byte)(&txs),
-			constants.MaxTxsPerPayload,
-			constants.MaxBytesPerTx,
-		)
+		txs.DefineSSZOffset(codec)
 	})
 }
 


### PR DESCRIPTION
Resolves the TODO around `Transactions` type. Relevant now as we refactor types for multiple fork version handling.

```golang
// TODO: This can accidentally decouple from the definition in
// ExecutionPayload and we should be cognizant of that and/or
// make a PR to allow for them to be defined in one place.
```