### PR TITLE
Make shutdown-timeout configurable

### DIFF
--- a/cli/flags/flags.go
+++ b/cli/flags/flags.go
@@ -27,9 +27,8 @@ import (
 
 const (
 	// Beacon Kit Root Flag.
-	beaconKitRoot      = "beacon-kit."
-	BeaconKitAcceptTos = beaconKitRoot + "accept-tos"
-	ShutdownTimeout    = beaconKitRoot + "shutdown-timeout"
+	beaconKitRoot   = "beacon-kit."
+	ShutdownTimeout = beaconKitRoot + "shutdown-timeout"
 
 	// Builder Config.
 	builderRoot           = beaconKitRoot + "payload-builder."

--- a/cli/flags/flags.go
+++ b/cli/flags/flags.go
@@ -29,6 +29,7 @@ const (
 	// Beacon Kit Root Flag.
 	beaconKitRoot      = "beacon-kit."
 	BeaconKitAcceptTos = beaconKitRoot + "accept-tos"
+	ShutdownTimeout    = beaconKitRoot + "shutdown-timeout"
 
 	// Builder Config.
 	builderRoot           = beaconKitRoot + "payload-builder."
@@ -82,6 +83,11 @@ const (
 // AddBeaconKitFlags implements servertypes.ModuleInitFlags interface.
 func AddBeaconKitFlags(startCmd *cobra.Command) {
 	defaultCfg := config.DefaultConfig()
+	startCmd.Flags().Duration(
+		ShutdownTimeout,
+		defaultCfg.ShutdownTimeout,
+		"maximum time to wait for the chain to gracefully shutdown before forcing an exit",
+	)
 	startCmd.Flags().String(
 		JWTSecretPath,
 		defaultCfg.Engine.JWTSecretPath,

--- a/cli/flags/flags.go
+++ b/cli/flags/flags.go
@@ -85,7 +85,7 @@ func AddBeaconKitFlags(startCmd *cobra.Command) {
 	startCmd.Flags().Duration(
 		ShutdownTimeout,
 		defaultCfg.ShutdownTimeout,
-		"maximum time to wait for the chain to gracefully shutdown before forcing an exit",
+		"maximum time to wait for the node to gracefully shutdown before forcing an exit",
 	)
 	startCmd.Flags().String(
 		JWTSecretPath,

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/berachain/beacon-kit/beacon/validator"
 	"github.com/berachain/beacon-kit/config/template"
 	viperlib "github.com/berachain/beacon-kit/config/viper"
@@ -35,6 +37,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	defaultShutdownTimeout = 5 * time.Minute
+)
+
 // AppOptions is from the SDK, we should look to remove its usage.
 type AppOptions interface {
 	Get(string) interface{}
@@ -43,6 +49,7 @@ type AppOptions interface {
 // DefaultConfig returns the default configuration for a BeaconKit chain.
 func DefaultConfig() *Config {
 	return &Config{
+		ShutdownTimeout:   defaultShutdownTimeout,
 		Engine:            engineclient.DefaultConfig(),
 		Logger:            log.DefaultConfig(),
 		KZG:               kzg.DefaultConfig(),
@@ -55,6 +62,8 @@ func DefaultConfig() *Config {
 
 // Config is the main configuration struct for the BeaconKit chain.
 type Config struct {
+	// ShutdownTimeout is the maximum time to wait for the chain to gracefully shutdown before forcing an exit.
+	ShutdownTimeout time.Duration `mapstructure:"shutdown-timeout"`
 	// Engine is the configuration for the execution client.
 	Engine engineclient.Config `mapstructure:"engine"`
 	// Logger is the configuration for the logger.

--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ func DefaultConfig() *Config {
 
 // Config is the main configuration struct for the BeaconKit chain.
 type Config struct {
-	// ShutdownTimeout is the maximum time to wait for the chain to gracefully shutdown before forcing an exit.
+	// ShutdownTimeout is the maximum time to wait for the node to gracefully shutdown before forcing an exit.
 	ShutdownTimeout time.Duration `mapstructure:"shutdown-timeout"`
 	// Engine is the configuration for the execution client.
 	Engine engineclient.Config `mapstructure:"engine"`

--- a/config/config.go
+++ b/config/config.go
@@ -37,9 +37,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const (
-	defaultShutdownTimeout = 5 * time.Minute
-)
+const defaultShutdownTimeout = 5 * time.Minute
 
 // AppOptions is from the SDK, we should look to remove its usage.
 type AppOptions interface {

--- a/config/template/template.go
+++ b/config/template/template.go
@@ -25,6 +25,11 @@ const TomlTemplate = `
 ###                                BeaconKit                                ###
 ###############################################################################
 
+[beacon-kit]
+# ShutdownTimeout is the duration to wait for the application to gracefully
+# shutdown before killing the process.
+shutdown-timeout = "{{ .BeaconKit.ShutdownTimeout }}"
+
 [beacon-kit.engine]
 # HTTP url of the execution client JSON-RPC endpoint.
 rpc-dial-url = "{{ .BeaconKit.Engine.RPCDialURL }}"

--- a/config/template/template.go
+++ b/config/template/template.go
@@ -26,8 +26,8 @@ const TomlTemplate = `
 ###############################################################################
 
 [beacon-kit]
-# ShutdownTimeout is the duration to wait for the application to gracefully
-# shutdown before killing the process.
+# ShutdownTimeout is the maximum time to wait for the node to gracefully
+# shutdown before forcing an exit.
 shutdown-timeout = "{{ .BeaconKit.ShutdownTimeout }}"
 
 [beacon-kit.engine]

--- a/node-core/components/node.go
+++ b/node-core/components/node.go
@@ -21,16 +21,23 @@
 package components
 
 import (
+	"cosmossdk.io/depinject"
+	"github.com/berachain/beacon-kit/config"
 	"github.com/berachain/beacon-kit/log/phuslu"
 	"github.com/berachain/beacon-kit/node-core/node"
 	service "github.com/berachain/beacon-kit/node-core/services/registry"
 	"github.com/berachain/beacon-kit/node-core/types"
 )
 
+type ProvideNodeInputs struct {
+	depinject.In
+
+	Config   *config.Config
+	Registry *service.Registry
+	Logger   *phuslu.Logger
+}
+
 // ProvideNode is a function that provides the module to the.
-func ProvideNode(
-	registry *service.Registry,
-	logger *phuslu.Logger,
-) types.Node {
-	return node.New[types.Node](registry, logger)
+func ProvideNode(in ProvideNodeInputs) types.Node {
+	return node.New[types.Node](in.Config.ShutdownTimeout, in.Registry, in.Logger)
 }

--- a/node-core/components/node.go
+++ b/node-core/components/node.go
@@ -37,7 +37,7 @@ type ProvideNodeInputs struct {
 	Logger   *phuslu.Logger
 }
 
-// ProvideNode is a function that provides the module to the.
+// ProvideNode returns a new node with the given options.
 func ProvideNode(in ProvideNodeInputs) types.Node {
 	return node.New[types.Node](in.Config.ShutdownTimeout, in.Registry, in.Logger)
 }

--- a/node-core/node/node.go
+++ b/node-core/node/node.go
@@ -40,23 +40,22 @@ import (
 // Compile-time assertion that node implements the NodeI interface.
 var _ types.Node = (*node)(nil)
 
-// if the node does not shutdown within a very reasonable time (5min) then we force exit.
-const shutdownTimeout = 5 * time.Minute
-
 // node is the hard-type representation of the beacon-kit node.
 type node struct {
 	// logger is the node's logger.
 	logger log.Logger
 	// registry is the node's service registry.
 	registry *service.Registry
+	// shutdownTimeout is the maximum time we will wait for a clean shutdown before forcing an exit
+	shutdownTimeout time.Duration
 }
 
 // New returns a new node.
-func New[NodeT types.Node](
-	registry *service.Registry, logger log.Logger) NodeT {
+func New[NodeT types.Node](shutdownTimeout time.Duration, registry *service.Registry, logger log.Logger) NodeT {
 	n := &node{
-		registry: registry,
-		logger:   logger,
+		shutdownTimeout: shutdownTimeout,
+		registry:        registry,
+		logger:          logger,
 	}
 
 	//nolint:errcheck // should be safe
@@ -93,8 +92,8 @@ func (n *node) Start(
 	go func() {
 		sig := <-sigc
 
-		timeout := time.AfterFunc(shutdownTimeout, func() {
-			n.logger.Error("Shutdown timeout exceeded, forcing exit", "timeout", shutdownTimeout.String())
+		timeout := time.AfterFunc(n.shutdownTimeout, func() {
+			n.logger.Error("Shutdown timeout exceeded, forcing exit", "timeout", n.shutdownTimeout.String())
 			os.Exit(1)
 		})
 		defer timeout.Stop()

--- a/node-core/node/node.go
+++ b/node-core/node/node.go
@@ -79,7 +79,7 @@ func (n *node) Start(
 
 	shutdownFunc := func(err error) {
 		now := time.Now()
-		n.logger.Error("Shutdown initiated", "error", err)
+		n.logger.Error("Shutdown initiated", "timeout", n.shutdownTimeout.String(), "error", err)
 
 		cancelFn()
 		n.registry.StopAll()

--- a/node-core/node/node.go
+++ b/node-core/node/node.go
@@ -46,7 +46,7 @@ type node struct {
 	logger log.Logger
 	// registry is the node's service registry.
 	registry *service.Registry
-	// shutdownTimeout is the maximum time we will wait for a clean shutdown before forcing an exit
+	// shutdownTimeout is the maximum time to wait for the node to gracefully shutdown before forcing an exit.
 	shutdownTimeout time.Duration
 }
 

--- a/testing/networks/80069/app.toml
+++ b/testing/networks/80069/app.toml
@@ -114,6 +114,11 @@ datadog-hostname = "my_beacond_node"
 ###                                BeaconKit                                ###
 ###############################################################################
 
+[beacon-kit]
+# ShutdownTimeout is the duration to wait for the application to gracefully
+# shutdown before killing the process.
+shutdown-timeout = "5m0s"
+
 [beacon-kit.engine]
 # HTTP url of the execution client JSON-RPC endpoint.
 rpc-dial-url = "http://localhost:8551"

--- a/testing/networks/80069/app.toml
+++ b/testing/networks/80069/app.toml
@@ -117,7 +117,7 @@ datadog-hostname = "my_beacond_node"
 [beacon-kit]
 # ShutdownTimeout is the maximum time to wait for the node to gracefully
 # shutdown before forcing an exit.
-shutdown-timeout = "5m0s"
+shutdown-timeout = "5m"
 
 [beacon-kit.engine]
 # HTTP url of the execution client JSON-RPC endpoint.

--- a/testing/networks/80069/app.toml
+++ b/testing/networks/80069/app.toml
@@ -115,8 +115,8 @@ datadog-hostname = "my_beacond_node"
 ###############################################################################
 
 [beacon-kit]
-# ShutdownTimeout is the duration to wait for the application to gracefully
-# shutdown before killing the process.
+# ShutdownTimeout is the maximum time to wait for the node to gracefully
+# shutdown before forcing an exit.
 shutdown-timeout = "5m0s"
 
 [beacon-kit.engine]

--- a/testing/networks/80069/app.toml
+++ b/testing/networks/80069/app.toml
@@ -117,7 +117,7 @@ datadog-hostname = "my_beacond_node"
 [beacon-kit]
 # ShutdownTimeout is the maximum time to wait for the node to gracefully
 # shutdown before forcing an exit.
-shutdown-timeout = "5m"
+shutdown-timeout = "5m0s"
 
 [beacon-kit.engine]
 # HTTP url of the execution client JSON-RPC endpoint.

--- a/testing/networks/80094/app.toml
+++ b/testing/networks/80094/app.toml
@@ -114,6 +114,11 @@ datadog-hostname = "my_beacond_node"
 ###                                BeaconKit                                ###
 ###############################################################################
 
+[beacon-kit]
+# ShutdownTimeout is the duration to wait for the application to gracefully
+# shutdown before killing the process.
+shutdown-timeout = "5m0s"
+
 [beacon-kit.engine]
 # HTTP url of the execution client JSON-RPC endpoint.
 rpc-dial-url = "http://localhost:8551"

--- a/testing/networks/80094/app.toml
+++ b/testing/networks/80094/app.toml
@@ -117,7 +117,7 @@ datadog-hostname = "my_beacond_node"
 [beacon-kit]
 # ShutdownTimeout is the maximum time to wait for the node to gracefully
 # shutdown before forcing an exit.
-shutdown-timeout = "5m0s"
+shutdown-timeout = "5m"
 
 [beacon-kit.engine]
 # HTTP url of the execution client JSON-RPC endpoint.

--- a/testing/networks/80094/app.toml
+++ b/testing/networks/80094/app.toml
@@ -115,8 +115,8 @@ datadog-hostname = "my_beacond_node"
 ###############################################################################
 
 [beacon-kit]
-# ShutdownTimeout is the duration to wait for the application to gracefully
-# shutdown before killing the process.
+# ShutdownTimeout is the maximum time to wait for the node to gracefully
+# shutdown before forcing an exit.
 shutdown-timeout = "5m0s"
 
 [beacon-kit.engine]

--- a/testing/networks/80094/app.toml
+++ b/testing/networks/80094/app.toml
@@ -117,7 +117,7 @@ datadog-hostname = "my_beacond_node"
 [beacon-kit]
 # ShutdownTimeout is the maximum time to wait for the node to gracefully
 # shutdown before forcing an exit.
-shutdown-timeout = "5m"
+shutdown-timeout = "5m0s"
 
 [beacon-kit.engine]
 # HTTP url of the execution client JSON-RPC endpoint.


### PR DESCRIPTION
This PR adds a new config value `beacon-kit.shutdown-timeout` which is used to determine how long the `shutdown.Service` package waits for beacon-kit to gracefully shutdown before forcing an exit (SIGKILL).

**Test plan**

Set a very short shutdown timeout via `beacon-kit.shutdown-timeout` param and then sent a SIGTERM signal

```
beacond start --beacon-kit.shutdown-timeout 0s20ms ...
...
2025-03-17T10:31:41Z ERRR Shutdown initiated timeout=20ms error=shutdown initiated by signal: interrupt
2025-03-17T10:31:41Z INFO Stopping services num=8
2025-03-17T10:31:41Z INFO Stopping service type=beacond
2025-03-17T10:31:41Z INFO Stopping CometBFT Node
2025-03-17T10:31:41Z INFO Stopping Node service impl=Node
2025-03-17T10:31:41Z INFO Stopping Node
2025-03-17T10:31:41Z INFO Stopping Pruner service module=state impl=Pruner
2025-03-17T10:31:41Z INFO Stopping EventBus service module=events impl=EventBus
...
2025-03-17T10:31:41Z INFO Closing evidencestore
2025-03-17T10:31:41Z INFO Waiting for CometBFT Node to stop
2025-03-17T10:31:41Z INFO Closing application.db
2025-03-17T10:31:41Z ERRR Shutdown timeout exceeded, forcing exit timeout=20ms
```

Set the shutdown timeout via `app.toml` file 
```
[beacon-kit]
# ShutdownTimeout is the maximum time to wait for the node to gracefully
# shutdown before forcing an exit.
shutdown-timeout = "17s"
```

Observed it was used correctly when sent a SIGTERM signal
```
beacond start  ...
...
C2025-03-17T10:52:30Z ERRR Shutdown initiated timeout=17s error=shutdown initiated by signal: interrupt
...
``` 
