### PR TITLE
chore(ci): Remove requirement for Dockerhub Login

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -143,12 +143,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          registry: https://index.docker.io/v1/
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Community PRs cannot run E2E CI because the action requires login. There is no reason we should require login as the CI action does not require any private images. 