### PR TITLE
Only login to Docker Hub for internal use

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -143,8 +143,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Check if Docker Hub credentials exist
+        id: check-docker-credentials
+        run: |
+          if [ "${{ secrets.DOCKERHUB_USERNAME }}" != "" ] && [ "${{ secrets.DOCKERHUB_PASSWORD }}" != "" ]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        if: steps.check-docker-credentials.outputs.has_credentials == 'true'
         with:
           registry: https://index.docker.io/v1/
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
An alternative to https://github.com/berachain/beacon-kit/pull/2606 

We may want to continue authenticating with Docker Hub as otherwise we risk frequent rate limiting when pulling images,see  https://docs.docker.com/docker-hub/usage/pulls/