### PR TITLE
fix(pectra): Add Versionable to SignedBeaconBlock

### DIFF
--- a/consensus-types/types/body_test.go
+++ b/consensus-types/types/body_test.go
@@ -138,18 +138,23 @@ func TestBeaconBlockBody_SetDeposits(t *testing.T) {
 
 func TestBeaconBlockBody_MarshalSSZ(t *testing.T) {
 	t.Parallel()
-	body := types.BeaconBlockBody{
-		RandaoReveal:       [96]byte{1, 2, 3},
-		Eth1Data:           &types.Eth1Data{},
-		Graffiti:           [32]byte{4, 5, 6},
-		Deposits:           []*types.Deposit{},
-		ExecutionPayload:   &types.ExecutionPayload{},
-		BlobKzgCommitments: []eip4844.KZGCommitment{},
-	}
-	data, err := body.MarshalSSZ()
-
-	require.NoError(t, err)
-	require.NotNil(t, data)
+	runForAllSupportedVersions(t, func(t *testing.T, v common.Version) {
+		ver := types.NewVersionable(v)
+		body := types.BeaconBlockBody{
+			Versionable:  ver,
+			RandaoReveal: [96]byte{1, 2, 3},
+			Eth1Data:     &types.Eth1Data{},
+			Graffiti:     [32]byte{4, 5, 6},
+			Deposits:     []*types.Deposit{},
+			ExecutionPayload: &types.ExecutionPayload{
+				Versionable: ver,
+			},
+			BlobKzgCommitments: []eip4844.KZGCommitment{},
+		}
+		data, err := body.MarshalSSZ()
+		require.NoError(t, err)
+		require.NotNil(t, data)
+	})
 }
 
 func TestBeaconBlockBody_GetTopLevelRoots(t *testing.T) {

--- a/consensus-types/types/signed_beacon_block_test.go
+++ b/consensus-types/types/signed_beacon_block_test.go
@@ -56,8 +56,9 @@ func generateFakeSignedBeaconBlock(t *testing.T, version common.Version) *types.
 	blk := generateValidBeaconBlock(t, version)
 	signature := crypto.BLSSignature{}
 	return &types.SignedBeaconBlock{
-		Message:   blk,
-		Signature: signature,
+		Versionable: types.NewVersionable(version),
+		Message:     blk,
+		Signature:   signature,
 	}
 }
 
@@ -183,21 +184,33 @@ func TestSignedBeaconBlock_SizeSSZ(t *testing.T) {
 
 func TestSignedBeaconBlock_EmptySerialization(t *testing.T) {
 	t.Parallel()
-	orig := &types.SignedBeaconBlock{}
-	data, err := orig.MarshalSSZ()
-	require.NoError(t, err)
-	require.NotNil(t, data)
+	runForAllSupportedVersions(t, func(t *testing.T, v common.Version) {
+		ver := types.NewVersionable(v)
+		orig := &types.SignedBeaconBlock{
+			Message: &types.BeaconBlock{
+				Versionable: ver,
+				Body: &types.BeaconBlockBody{
+					Versionable: ver,
+					ExecutionPayload: &types.ExecutionPayload{
+						Versionable: ver,
+					},
+				},
+			},
+		}
+		data, err := orig.MarshalSSZ()
+		require.NoError(t, err)
+		require.NotNil(t, data)
 
-	var unmarshalled *types.SignedBeaconBlock
-	unmarshalled, err = unmarshalled.NewFromSSZ(data)
-	require.NoError(t, err)
-	require.NotNil(t, unmarshalled.GetMessage())
-	require.NotNil(t, unmarshalled.GetSignature())
+		unmarshalled, err := types.NewSignedBeaconBlockFromSSZ(data, v)
+		require.NoError(t, err)
+		require.NotNil(t, unmarshalled.GetMessage())
+		require.NotNil(t, unmarshalled.GetSignature())
 
-	buf := make([]byte, ssz.Size(orig))
-	err = ssz.EncodeToBytes(buf, orig)
-	require.NoError(t, err)
+		buf := make([]byte, ssz.Size(orig))
+		err = ssz.EncodeToBytes(buf, orig)
+		require.NoError(t, err)
 
-	// The two byte slices should be equal
-	require.Equal(t, data, buf)
+		// The two byte slices should be equal
+		require.Equal(t, data, buf)
+	})
 }


### PR DESCRIPTION
We need `Versionable` for `SignedBeaconBlock` specifically for `NewFromSSZ` as otherwise we cannot unmarshal from SSZ correctly. 