### PR TITLE
feat(pectra): Add `engine_getPayloadV4`

### DIFF
--- a/execution/client/ethclient/constants.go
+++ b/execution/client/ethclient/constants.go
@@ -25,8 +25,10 @@ package ethclient
 func BeaconKitSupportedCapabilities() []string {
 	return []string{
 		NewPayloadMethodV3,
+		NewPayloadMethodV4,
 		ForkchoiceUpdatedMethodV3,
 		GetPayloadMethodV3,
+		GetPayloadMethodV4,
 		GetClientVersionV1,
 	}
 }
@@ -41,6 +43,7 @@ const (
 	ForkchoiceUpdatedMethodV3 = "engine_forkchoiceUpdatedV3"
 	// GetPayloadMethodV3 for retrieving a payload in Deneb.
 	GetPayloadMethodV3 = "engine_getPayloadV3"
+	GetPayloadMethodV4 = "engine_getPayloadV4"
 	// BlockByHashMethod for retrieving a block by its hash.
 	BlockByHashMethod = "eth_getBlockByHash"
 	// BlockByNumberMethod for retrieving a block by its number.

--- a/execution/client/ethclient/engine.go
+++ b/execution/client/ethclient/engine.go
@@ -40,11 +40,11 @@ func (s *Client) NewPayload(
 	ctx context.Context,
 	req ctypes.NewPayloadRequest,
 ) (*engineprimitives.PayloadStatusV1, error) {
+	forkVersion := req.GetForkVersion()
 	// Versions before Deneb are not supported for calling NewPayload.
-	if version.IsBefore(req.GetForkVersion(), version.Deneb()) {
+	if version.IsBefore(forkVersion, version.Deneb()) {
 		return nil, ErrInvalidVersion
 	}
-	forkVersion := req.GetForkVersion()
 	if version.Equals(forkVersion, version.Deneb()) || version.Equals(forkVersion, version.Deneb1()) {
 		return s.NewPayloadV3(ctx, req.GetExecutionPayload(), req.GetVersionedHashes(), req.GetParentBeaconBlockRoot())
 	}
@@ -151,9 +151,13 @@ func (s *Client) GetPayload(
 	if version.IsBefore(forkVersion, version.Deneb()) {
 		return nil, ErrInvalidVersion
 	}
-
-	// V3 is used for beacon versions Deneb and onwards.
-	return s.GetPayloadV3(ctx, payloadID, forkVersion)
+	if version.Equals(forkVersion, version.Deneb()) || version.Equals(forkVersion, version.Deneb1()) {
+		return s.GetPayloadV3(ctx, payloadID, forkVersion)
+	}
+	if version.Equals(forkVersion, version.Electra()) {
+		return s.GetPayloadV4(ctx, payloadID, forkVersion)
+	}
+	return nil, ErrInvalidVersion
 }
 
 // GetPayloadV3 calls the engine_getPayloadV3 method via JSON-RPC.
@@ -165,6 +169,19 @@ func (s *Client) GetPayloadV3(
 	result := ctypes.NewEmptyExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1](forkVersion)
 	if err := s.Call(ctx, result, GetPayloadMethodV3, payloadID); err != nil {
 		return nil, fmt.Errorf("failed GetPayloadV3 call: %w", err)
+	}
+	return result, nil
+}
+
+// GetPayloadV4 calls the engine_getPayloadV4 method via JSON-RPC.
+func (s *Client) GetPayloadV4(
+	ctx context.Context,
+	payloadID engineprimitives.PayloadID,
+	forkVersion common.Version,
+) (ctypes.BuiltExecutionPayloadEnv, error) {
+	result := ctypes.NewEmptyExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1](forkVersion)
+	if err := s.Call(ctx, result, GetPayloadMethodV4, payloadID); err != nil {
+		return nil, fmt.Errorf("failed GetPayloadV4 call: %w", err)
 	}
 	return result, nil
 }


### PR DESCRIPTION
We MUST call `engine_getPayloadV4` when we are on the pectra fork according to [engine API spec updates](https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#update-the-methods-of-previous-forks), even if our implementation is able to discriminate engine api responses under the hood for different forks. For some reason, geth and reth do not enforce that you use `getPayloadV4` like the specs expect. Erigon, however, enforces the usage of `getPayloadV4`, so we might as well conform to spec.