### PR TITLE
chore(config): Fix error handling of empty `suggested-fee-recipient`

### DIFF
--- a/config/viper/parser.go
+++ b/config/viper/parser.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 
 	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/encoding/hex"
 	beaconurl "github.com/berachain/beacon-kit/primitives/net/url"
 	"github.com/mitchellh/mapstructure"
 )
@@ -34,7 +35,11 @@ import (
 func StringToExecutionAddressFunc() mapstructure.DecodeHookFunc {
 	return StringTo(
 		func(s string) (common.ExecutionAddress, error) {
-			return common.NewExecutionAddressFromHex(s), nil
+			bz, err := hex.ToBytes(s)
+			if err != nil {
+				return common.ExecutionAddress{}, err
+			}
+			return common.ExecutionAddress(bz), nil
 		},
 	)
 }


### PR DESCRIPTION
Closes #2699 

With an empty `suggested-fee-recipient` will instead fail to startup with this error message now:
```
panic: error calling provider github.com/berachain/beacon-kit/node-core/components.ProvideConfig (github.com/berachain/beacon-kit/node-core/components/config.go:36): 1 error(s) decoding:
	
	* error decoding 'beacon-kit.payload-builder.suggested-fee-recipient': empty hex string

goroutine 1 [running]:
github.com/berachain/beacon-kit/node-core/builder.(*NodeBuilder).Build(0x1400000f938, 0x14000d917d0, {0x1024c7e00, 0x14000522528}, {0x0?, 0x0?}, 0x14000a08780, {0x102491300, 0x14000a78380})
	github.com/berachain/beacon-kit/node-core/builder/builder.go:98 +0x438
github.com/berachain/beacon-kit/cli/commands/server.StartCmdWithOptions.func1(0x140006bec08, {0x101a46d7e?, 0x4?, 0x101a46c5e?})
	github.com/berachain/beacon-kit/cli/commands/server/start.go:99 +0xbc
github.com/spf13/cobra.(*Command).execute(0x140006bec08, {0x14000a6e6c0, 0xc, 0xc})
	github.com/spf13/cobra@v1.8.1/command.go:985 +0x834
github.com/spf13/cobra.(*Command).ExecuteC(0x140006a2308)
	github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.8.1/command.go:1034
github.com/berachain/beacon-kit/cli/commands/server/cmd.Execute(0x140006a2308, {0x0, 0x0}, {0x1400014edb0, 0x17})
	github.com/berachain/beacon-kit/cli/commands/server/cmd/execute.go:61 +0x270
github.com/berachain/beacon-kit/cli/commands.(*Root).Run(0x14000699e00?, {0x1400014edb0?, 0x101aacd8e?})
	github.com/berachain/beacon-kit/cli/commands/root.go:92 +0x34
main.run()
	./main.go:77 +0x2bc
main.main()
	./main.go:82 +0x1c
make: *** [start] Error 2
```
Would suggest keeping this behavior. i.e. if an operator goes out of their way to make this value empty (the default will set it to `"0x0000000000000000000000000000000000000000"`), it should fail imo. Lmk your thoughts @camembera.