### PR TITLE
fix(state-processor): log deneb1 only once

### DIFF
--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -23,6 +23,7 @@ package core
 import (
 	"bytes"
 	"fmt"
+	"sync"
 
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
 	"github.com/berachain/beacon-kit/errors"
@@ -54,6 +55,8 @@ type StateProcessor struct {
 	ds *depositdb.KVStore
 	// metrics is the metrics for the service.
 	metrics *stateProcessorMetrics
+	// logDeneb1Once enforces logging the Deneb1 fork information at most once.
+	logDeneb1Once sync.Once
 }
 
 // NewStateProcessor creates a new state processor.

--- a/state-transition/core/state_processor_forks.go
+++ b/state-transition/core/state_processor_forks.go
@@ -22,7 +22,6 @@ package core
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/berachain/beacon-kit/consensus-types/types"
 	"github.com/berachain/beacon-kit/primitives/common"
@@ -136,7 +135,7 @@ func (sp *StateProcessor) logDeneb1Fork(
 	// Since state fork is not updating to Deneb1, every block observes Deneb1 as "new fork" during
 	// Deneb1. Hence, we must wrap this in a OnceFunc to ensure it is logged only the first time
 	// we process a Deneb1 block.
-	sync.OnceFunc(func() {
+	sp.logDeneb1Once.Do(func() {
 		sp.logger.Info(fmt.Sprintf(`
 
 
@@ -157,7 +156,7 @@ func (sp *StateProcessor) logDeneb1Fork(
 			slot.Unwrap(), timestamp.Unwrap(),
 			sp.cs.SlotToEpoch(slot).Unwrap(),
 		))
-	})()
+	})
 }
 
 // upgradeToElectra upgrades the state to the Electra fork version. It is modified from the ETH 2.0


### PR DESCRIPTION
Fixes a bug where Deneb1 was being logged every time a Deneb1 block was processed. 