### PR TITLE
refactor(pectra): Move ExpectedWithdrawals to StateProcessor

### DIFF
--- a/beacon/blockchain/interfaces.go
+++ b/beacon/blockchain/interfaces.go
@@ -71,6 +71,7 @@ type LocalBuilder interface {
 		parentBlockRoot common.Root,
 		headEth1BlockHash common.ExecutionHash,
 		finalEth1BlockHash common.ExecutionHash,
+		withdrawals engineprimitives.Withdrawals,
 	) (*engineprimitives.PayloadID, common.Version, error)
 }
 
@@ -103,6 +104,11 @@ type StateProcessor interface {
 		func(
 			blk *ctypes.BeaconBlock,
 			signature crypto.BLSSignature) error,
+		error,
+	)
+	ExpectedWithdrawals(st *statedb.StateDB, timestamp math.U64) (
+		engineprimitives.Withdrawals,
+		uint64,
 		error,
 	)
 }

--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -254,6 +254,11 @@ func (s *Service) retrieveExecutionPayload(
 		return nil, err
 	}
 
+	withdrawals, _, err := s.stateProcessor.ExpectedWithdrawals(st, nextPayloadTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
 	return s.localPayloadBuilder.RequestPayloadSync(
 		ctx,
 		st,
@@ -262,6 +267,7 @@ func (s *Service) retrieveExecutionPayload(
 		parentBlockRoot,
 		lph.GetBlockHash(),
 		lph.GetParentHash(),
+		withdrawals,
 	)
 }
 

--- a/beacon/validator/interfaces.go
+++ b/beacon/validator/interfaces.go
@@ -67,6 +67,7 @@ type PayloadBuilder interface {
 		parentBlockRoot common.Root,
 		headEth1BlockHash common.ExecutionHash,
 		finalEth1BlockHash common.ExecutionHash,
+		withdrawals engineprimitives.Withdrawals,
 	) (ctypes.BuiltExecutionPayloadEnv, error)
 }
 
@@ -86,6 +87,11 @@ type StateProcessor interface {
 		st *statedb.StateDB,
 		blk *ctypes.BeaconBlock,
 	) (transition.ValidatorUpdates, error)
+	ExpectedWithdrawals(st *statedb.StateDB, timestamp math.U64) (
+		engineprimitives.Withdrawals,
+		uint64,
+		error,
+	)
 }
 
 // StorageBackend is the interface for the storage backend.

--- a/node-core/components/interfaces.go
+++ b/node-core/components/interfaces.go
@@ -51,6 +51,7 @@ type (
 			slot math.Slot,
 			timestamp math.U64,
 			prevHeadRoot [32]byte,
+			withdrawals engineprimitives.Withdrawals,
 		) (*engineprimitives.PayloadAttributes, error)
 	}
 
@@ -85,6 +86,7 @@ type (
 			parentBlockRoot common.Root,
 			headEth1BlockHash common.ExecutionHash,
 			finalEth1BlockHash common.ExecutionHash,
+			withdrawals engineprimitives.Withdrawals,
 		) (*engineprimitives.PayloadID, common.Version, error)
 		// RetrievePayload retrieves the payload for the given slot.
 		RetrievePayload(
@@ -102,6 +104,7 @@ type (
 			parentBlockRoot common.Root,
 			headEth1BlockHash common.ExecutionHash,
 			finalEth1BlockHash common.ExecutionHash,
+			withdrawals engineprimitives.Withdrawals,
 		) (ctypes.BuiltExecutionPayloadEnv, error)
 	}
 
@@ -146,6 +149,11 @@ type (
 		) (transition.ValidatorUpdates, error)
 		GetSignatureVerifierFn(st *statedb.StateDB) (
 			func(blk *ctypes.BeaconBlock, signature crypto.BLSSignature) error,
+			error,
+		)
+		ExpectedWithdrawals(st *statedb.StateDB, timestamp math.U64) (
+			engineprimitives.Withdrawals,
+			uint64,
 			error,
 		)
 	}

--- a/payload/attributes/factory.go
+++ b/payload/attributes/factory.go
@@ -55,26 +55,16 @@ func NewAttributesFactory(
 // BuildPayloadAttributes creates a new instance of PayloadAttributes.
 func (f *Factory) BuildPayloadAttributes(
 	st *statedb.StateDB,
-	slot math.Slot,
+	slot math.U64,
 	timestamp math.U64,
 	prevHeadRoot [32]byte,
+	withdrawals engineprimitives.Withdrawals,
 ) (*engineprimitives.PayloadAttributes, error) {
 	var (
 		prevRandao [32]byte
-
-		epoch = f.chainSpec.SlotToEpoch(slot)
+		err        error
+		epoch      = f.chainSpec.SlotToEpoch(slot)
 	)
-
-	// Get the expected withdrawals to include in this payload.
-	withdrawals, _, err := st.ExpectedWithdrawals(timestamp)
-	if err != nil {
-		f.logger.Error(
-			"Could not get expected withdrawals to get payload attribute",
-			"error",
-			err,
-		)
-		return nil, err
-	}
 
 	// Get the previous randao mix.
 	if prevRandao, err = st.GetRandaoMixAtIndex(

--- a/payload/builder/interfaces.go
+++ b/payload/builder/interfaces.go
@@ -43,6 +43,7 @@ type AttributesFactory interface {
 		slot math.U64,
 		timestamp math.U64,
 		prevHeadRoot [32]byte,
+		withdrawals engineprimitives.Withdrawals,
 	) (*engineprimitives.PayloadAttributes, error)
 }
 

--- a/payload/builder/payload.go
+++ b/payload/builder/payload.go
@@ -42,6 +42,7 @@ func (pb *PayloadBuilder) RequestPayloadAsync(
 	parentBlockRoot common.Root,
 	headEth1BlockHash common.ExecutionHash,
 	finalEth1BlockHash common.ExecutionHash,
+	withdrawals engineprimitives.Withdrawals,
 ) (*engineprimitives.PayloadID, common.Version, error) {
 	if !pb.Enabled() {
 		return nil, common.Version{}, ErrPayloadBuilderDisabled
@@ -62,6 +63,7 @@ func (pb *PayloadBuilder) RequestPayloadAsync(
 		slot,
 		timestamp,
 		parentBlockRoot,
+		withdrawals,
 	)
 	if err != nil {
 		return nil, common.Version{}, err
@@ -101,6 +103,7 @@ func (pb *PayloadBuilder) RequestPayloadSync(
 	parentBlockRoot common.Root,
 	parentEth1Hash common.ExecutionHash,
 	finalBlockHash common.ExecutionHash,
+	withdrawals engineprimitives.Withdrawals,
 ) (ctypes.BuiltExecutionPayloadEnv, error) {
 	if !pb.Enabled() {
 		return nil, ErrPayloadBuilderDisabled
@@ -116,6 +119,7 @@ func (pb *PayloadBuilder) RequestPayloadSync(
 		parentBlockRoot,
 		parentEth1Hash,
 		finalBlockHash,
+		withdrawals,
 	)
 	if err != nil {
 		return nil, err

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -188,6 +188,7 @@ type stubAttributesFactory struct{}
 func (ee *stubAttributesFactory) BuildPayloadAttributes(
 	*statedb.StateDB, math.U64,
 	math.U64, [32]byte,
+	engineprimitives.Withdrawals,
 ) (*engineprimitives.PayloadAttributes, error) {
 	return nil, errStubNotImplemented
 }


### PR DESCRIPTION
This will allow us to access logging and metrics for behaviour in `StateProcessor.