### PR TITLE
chore(pectra): Partial withdrawal failure metrics

### DIFF
--- a/state-transition/core/metrics.go
+++ b/state-transition/core/metrics.go
@@ -38,24 +38,6 @@ func newStateProcessorMetrics(
 	}
 }
 
-func (s *stateProcessorMetrics) gaugeTimestamps(
-	payloadTimestamp uint64,
-	consensusTimestamp uint64,
-) {
-	// the diff can be positive or negative depending on whether the payload
-	// timestamp is ahead or behind the consensus timestamp
-	diff := int64(payloadTimestamp) - int64(consensusTimestamp) // #nosec G115
-	s.sink.SetGauge("beacon_kit.state.payload_consensus_timestamp_diff", diff)
-}
-
-func (s *stateProcessorMetrics) incrementValidatorNotWithdrawable() {
-	s.sink.IncrementCounter("beacon_kit.state.validator_not_withdrawable")
-}
-
-func (s *stateProcessorMetrics) incrementDepositStakeLost() {
-	s.sink.IncrementCounter("beacon_kit.state.deposit_stake_lost")
-}
-
 func (s *stateProcessorMetrics) gaugeBlockGasUsed(
 	blockNumber math.U64,
 	txGasUsed math.U64,
@@ -74,4 +56,30 @@ func (s *stateProcessorMetrics) gaugeBlockGasUsed(
 		"block_number",
 		blockNumberStr,
 	)
+}
+
+func (s *stateProcessorMetrics) gaugeTimestamps(
+	payloadTimestamp uint64,
+	consensusTimestamp uint64,
+) {
+	// the diff can be positive or negative depending on whether the payload
+	// timestamp is ahead or behind the consensus timestamp
+	diff := int64(payloadTimestamp) - int64(consensusTimestamp) // #nosec G115
+	s.sink.SetGauge("beacon_kit.state.payload_consensus_timestamp_diff", diff)
+}
+
+func (s *stateProcessorMetrics) incrementDepositStakeLost() {
+	s.sink.IncrementCounter("beacon_kit.state.deposit_stake_lost")
+}
+
+func (s *stateProcessorMetrics) incrementPartialWithdrawalRequestDropped() {
+	s.sink.IncrementCounter("beacon_kit.state.partial_withdrawal_request_dropped")
+}
+
+func (s *stateProcessorMetrics) incrementPartialWithdrawalFailed() {
+	s.sink.IncrementCounter("beacon_kit.state.partial_withdrawal_failed")
+}
+
+func (s *stateProcessorMetrics) incrementValidatorNotWithdrawable() {
+	s.sink.IncrementCounter("beacon_kit.state.validator_not_withdrawable")
 }

--- a/state-transition/core/state_processor_withdrawals.go
+++ b/state-transition/core/state_processor_withdrawals.go
@@ -167,11 +167,11 @@ func (sp *StateProcessor) processWithdrawalRequest(
 
 	// If partial withdrawal queue is full, only full exits are processed
 	if len(pendingPartialWithdrawals) == constants.PendingPartialWithdrawalsLimit && !isFullExitRequest {
-		// TODO(pectra): add metrics here.
 		sp.logger.Warn(
 			"skipping processing of withdrawal request as partial withdrawal queue is full",
 			withdrawalFields(withdrawalRequest, nil)...,
 		)
+		sp.metrics.incrementPartialWithdrawalRequestDropped()
 		return nil
 	}
 
@@ -242,7 +242,6 @@ func (sp *StateProcessor) processPartialWithdrawal(
 
 	isWithdrawable := validator.HasCompoundingWithdrawalCredential() && hasSufficient && hasExcess
 	if !isWithdrawable {
-		// TODO(pectra): add metrics here.
 		sp.logger.Info("validator cannot withdraw partial balance",
 			"validator_index", index,
 			"validator_pubkey", validator.GetPubkey().String(),
@@ -251,6 +250,7 @@ func (sp *StateProcessor) processPartialWithdrawal(
 			"has_sufficient", hasSufficient,
 			"has_excess", hasExcess,
 		)
+		sp.metrics.incrementPartialWithdrawalFailed()
 		return nil
 	}
 


### PR DESCRIPTION
Need to add to prometheus collectors / grafana dashboards. 

New metric keys:
`beacon_kit.state.partial_withdrawal_request_dropped `: When the withdrawal queue is full, we drop any validators' partial withdrawal requests.

`beacon_kit.state.partial_withdrawal_failed`: When the validator's partial withdrawal request doesn't go through because the validators is _not_ partially withdrawable.