### PR TITLE
chore(pectra): StateDB metrics

### DIFF
--- a/node-api/backend/backend_test.go
+++ b/node-api/backend/backend_test.go
@@ -29,6 +29,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"github.com/berachain/beacon-kit/chain"
 	"github.com/berachain/beacon-kit/errors"
+	"github.com/berachain/beacon-kit/node-core/components/metrics"
 	statedb "github.com/berachain/beacon-kit/state-transition/core/state"
 	"github.com/berachain/beacon-kit/storage/beacondb"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -48,7 +49,9 @@ func (t *testConsensusService) CreateQueryContext(height int64, _ bool) (sdk.Con
 	sdkCtx := sdk.NewContext(t.cms.CacheMultiStore(), false, log.NewNopLogger())
 
 	// there validations mimics consensus service, not sure if they are necessary
-	tmpState := statedb.NewBeaconStateFromDB(t.kvStore.WithContext(sdkCtx), t.cs, sdkCtx.Logger())
+	tmpState := statedb.NewBeaconStateFromDB(
+		t.kvStore.WithContext(sdkCtx), t.cs, sdkCtx.Logger(), metrics.NewNoOpTelemetrySink(),
+	)
 	slot, err := tmpState.GetSlot()
 	if err != nil {
 		return sdk.Context{}, sdkerrors.ErrInvalidHeight

--- a/node-api/backend/genesis_test.go
+++ b/node-api/backend/genesis_test.go
@@ -32,6 +32,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"github.com/berachain/beacon-kit/config/spec"
 	"github.com/berachain/beacon-kit/node-api/backend"
+	"github.com/berachain/beacon-kit/node-core/components/metrics"
 	"github.com/berachain/beacon-kit/node-core/components/storage"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
@@ -69,7 +70,9 @@ func TestGetGenesisData(t *testing.T) {
 
 	// Setup state for genesis tests.
 	setupStateWithGenesisValues(t, cms, kvStore)
-	sb := storage.NewBackend(cs, nil, kvStore, depositStore, nil, log.NewNopLogger())
+	sb := storage.NewBackend(
+		cs, nil, kvStore, depositStore, nil, log.NewNopLogger(), metrics.NewNoOpTelemetrySink(),
+	)
 
 	// Create a temporary directory for CometBFT config
 	tmpDir := t.TempDir()

--- a/node-api/backend/validator_test.go
+++ b/node-api/backend/validator_test.go
@@ -34,6 +34,7 @@ import (
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
 	"github.com/berachain/beacon-kit/node-api/backend"
 	types "github.com/berachain/beacon-kit/node-api/handlers/beacon/types"
+	"github.com/berachain/beacon-kit/node-core/components/metrics"
 	"github.com/berachain/beacon-kit/node-core/components/storage"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/constants"
@@ -57,7 +58,9 @@ func TestFilteredValidators(t *testing.T) {
 	require.NoError(t, err)
 	cms, kvStore, depositStore, err := statetransition.BuildTestStores()
 	require.NoError(t, err)
-	sb := storage.NewBackend(cs, nil, kvStore, depositStore, nil, log.NewNopLogger())
+	sb := storage.NewBackend(
+		cs, nil, kvStore, depositStore, nil, log.NewNopLogger(), metrics.NewNoOpTelemetrySink(),
+	)
 
 	// Create a temporary directory for CometBFT config
 	tmpDir := t.TempDir()
@@ -362,7 +365,9 @@ func setupTestFilteredValidatorsState(
 ) {
 	t.Helper()
 	sdkCtx := sdk.NewContext(cms.CacheMultiStore(), true, log.NewNopLogger())
-	st := statedb.NewBeaconStateFromDB(kvStore.WithContext(sdkCtx), cs, sdkCtx.Logger())
+	st := statedb.NewBeaconStateFromDB(
+		kvStore.WithContext(sdkCtx), cs, sdkCtx.Logger(), metrics.NewNoOpTelemetrySink(),
+	)
 
 	for _, in := range stateValidators {
 		val, err := types.ValidatorToConsensus(in.Validator)

--- a/node-core/components/backend.go
+++ b/node-core/components/backend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/berachain/beacon-kit/consensus-types/types"
 	dastore "github.com/berachain/beacon-kit/da/store"
 	"github.com/berachain/beacon-kit/log/phuslu"
+	"github.com/berachain/beacon-kit/node-core/components/metrics"
 	"github.com/berachain/beacon-kit/node-core/components/storage"
 	"github.com/berachain/beacon-kit/storage/beacondb"
 	"github.com/berachain/beacon-kit/storage/block"
@@ -41,6 +42,7 @@ type StorageBackendInput struct {
 	DepositStore      *depositdb.KVStore
 	BeaconStore       *beacondb.KVStore
 	Logger            *phuslu.Logger
+	TelemetrySink     *metrics.TelemetrySink
 }
 
 // ProvideStorageBackend is the depinject provider that returns a beacon storage
@@ -55,5 +57,6 @@ func ProvideStorageBackend(
 		in.DepositStore,
 		in.BlockStore,
 		in.Logger.With("service", "storage-backend"),
+		in.TelemetrySink,
 	)
 }

--- a/node-core/components/storage/storage.go
+++ b/node-core/components/storage/storage.go
@@ -61,6 +61,7 @@ func NewBackend(
 		depositStore:      depositStore,
 		blockStore:        blockStore,
 		logger:            logger,
+		telemetrySink:     telemetrySink,
 	}
 }
 

--- a/node-core/components/storage/storage.go
+++ b/node-core/components/storage/storage.go
@@ -42,6 +42,7 @@ type Backend struct {
 	depositStore      *depositdb.KVStore
 	blockStore        *block.KVStore[*types.BeaconBlock]
 	logger            log.Logger
+	telemetrySink     statedb.TelemetrySink
 }
 
 func NewBackend(
@@ -51,6 +52,7 @@ func NewBackend(
 	depositStore *depositdb.KVStore,
 	blockStore *block.KVStore[*types.BeaconBlock],
 	logger log.Logger,
+	telemetrySink statedb.TelemetrySink,
 ) *Backend {
 	return &Backend{
 		chainSpec:         chainSpec,
@@ -71,7 +73,12 @@ func (k Backend) AvailabilityStore() *dastore.Store {
 // StateFromContext returns the beacon state struct initialized with a given
 // context and the store key.
 func (k Backend) StateFromContext(ctx context.Context) *statedb.StateDB {
-	return statedb.NewBeaconStateFromDB(k.kvStore.WithContext(ctx), k.chainSpec, k.logger)
+	return statedb.NewBeaconStateFromDB(
+		k.kvStore.WithContext(ctx),
+		k.chainSpec,
+		k.logger,
+		k.telemetrySink,
+	)
 }
 
 // BeaconStore returns the beacon store struct.

--- a/state-transition/core/metrics.go
+++ b/state-transition/core/metrics.go
@@ -37,10 +37,6 @@ func newStateProcessorMetrics(sink TelemetrySink) *stateProcessorMetrics {
 }
 
 func (s *stateProcessorMetrics) gaugeBlockGasUsed(blockNumber, txGasUsed, blobGasUsed math.U64) {
-	if s.sink == nil {
-		return
-	}
-
 	blockNumberStr := blockNumber.Base10()
 	s.sink.SetGauge(
 		"beacon_kit.state.block_tx_gas_used",
@@ -57,18 +53,10 @@ func (s *stateProcessorMetrics) gaugeBlockGasUsed(blockNumber, txGasUsed, blobGa
 }
 
 func (s *stateProcessorMetrics) gaugePartialWithdrawalsEnqueued(count int) {
-	if s.sink == nil {
-		return
-	}
-
 	s.sink.SetGauge("beacon_kit.state.partial_withdrawals_enqueued", int64(count))
 }
 
 func (s *stateProcessorMetrics) gaugeTimestamps(payloadTimestamp, consensusTimestamp uint64) {
-	if s.sink == nil {
-		return
-	}
-
 	// the diff can be positive or negative depending on whether the payload
 	// timestamp is ahead or behind the consensus timestamp
 	diff := int64(payloadTimestamp) - int64(consensusTimestamp) // #nosec G115
@@ -76,33 +64,17 @@ func (s *stateProcessorMetrics) gaugeTimestamps(payloadTimestamp, consensusTimes
 }
 
 func (s *stateProcessorMetrics) incrementDepositStakeLost() {
-	if s.sink == nil {
-		return
-	}
-
 	s.sink.IncrementCounter("beacon_kit.state.deposit_stake_lost")
 }
 
 func (s *stateProcessorMetrics) incrementPartialWithdrawalRequestDropped() {
-	if s.sink == nil {
-		return
-	}
-
 	s.sink.IncrementCounter("beacon_kit.state.partial_withdrawal_request_dropped")
 }
 
 func (s *stateProcessorMetrics) incrementPartialWithdrawalRequestInvalid() {
-	if s.sink == nil {
-		return
-	}
-
 	s.sink.IncrementCounter("beacon_kit.state.partial_withdrawal_request_invalid")
 }
 
 func (s *stateProcessorMetrics) incrementValidatorNotWithdrawable() {
-	if s.sink == nil {
-		return
-	}
-
 	s.sink.IncrementCounter("beacon_kit.state.validator_not_withdrawable")
 }

--- a/state-transition/core/metrics.go
+++ b/state-transition/core/metrics.go
@@ -37,6 +37,10 @@ func newStateProcessorMetrics(sink TelemetrySink) *stateProcessorMetrics {
 }
 
 func (s *stateProcessorMetrics) gaugeBlockGasUsed(blockNumber, txGasUsed, blobGasUsed math.U64) {
+	if s.sink == nil {
+		return
+	}
+
 	blockNumberStr := blockNumber.Base10()
 	s.sink.SetGauge(
 		"beacon_kit.state.block_tx_gas_used",
@@ -53,10 +57,18 @@ func (s *stateProcessorMetrics) gaugeBlockGasUsed(blockNumber, txGasUsed, blobGa
 }
 
 func (s *stateProcessorMetrics) gaugePartialWithdrawalsEnqueued(count int) {
+	if s.sink == nil {
+		return
+	}
+
 	s.sink.SetGauge("beacon_kit.state.partial_withdrawals_enqueued", int64(count))
 }
 
 func (s *stateProcessorMetrics) gaugeTimestamps(payloadTimestamp, consensusTimestamp uint64) {
+	if s.sink == nil {
+		return
+	}
+
 	// the diff can be positive or negative depending on whether the payload
 	// timestamp is ahead or behind the consensus timestamp
 	diff := int64(payloadTimestamp) - int64(consensusTimestamp) // #nosec G115
@@ -64,17 +76,33 @@ func (s *stateProcessorMetrics) gaugeTimestamps(payloadTimestamp, consensusTimes
 }
 
 func (s *stateProcessorMetrics) incrementDepositStakeLost() {
+	if s.sink == nil {
+		return
+	}
+
 	s.sink.IncrementCounter("beacon_kit.state.deposit_stake_lost")
 }
 
 func (s *stateProcessorMetrics) incrementPartialWithdrawalRequestDropped() {
+	if s.sink == nil {
+		return
+	}
+
 	s.sink.IncrementCounter("beacon_kit.state.partial_withdrawal_request_dropped")
 }
 
 func (s *stateProcessorMetrics) incrementPartialWithdrawalRequestInvalid() {
+	if s.sink == nil {
+		return
+	}
+
 	s.sink.IncrementCounter("beacon_kit.state.partial_withdrawal_request_invalid")
 }
 
 func (s *stateProcessorMetrics) incrementValidatorNotWithdrawable() {
+	if s.sink == nil {
+		return
+	}
+
 	s.sink.IncrementCounter("beacon_kit.state.validator_not_withdrawable")
 }

--- a/state-transition/core/state/metrics.go
+++ b/state-transition/core/state/metrics.go
@@ -20,24 +20,10 @@
 
 package state
 
-import (
-	"github.com/berachain/beacon-kit/chain"
-	"github.com/berachain/beacon-kit/primitives/common"
-	"github.com/berachain/beacon-kit/primitives/math"
-)
+func (s *StateDB) incrementPartialWithdrawalRequestInvalid() {
+	if s.telemetrySink == nil {
+		return
+	}
 
-type ChainSpec interface {
-	chain.BerachainSpec
-	chain.WithdrawalsSpec
-	SlotToEpoch(slot math.Slot) math.Epoch
-	SlotsPerHistoricalRoot() uint64
-	MaxEffectiveBalance() math.Gwei
-	EpochsPerHistoricalVector() uint64
-	ActiveForkVersionForTimestamp(timestamp math.U64) common.Version
-	MinActivationBalance() math.Gwei
-}
-
-// TelemetrySink is an interface for sending metrics to a telemetry backend.
-type TelemetrySink interface {
-	IncrementCounter(key string, args ...string)
+	s.telemetrySink.IncrementCounter("beacon_kit.statedb.partial_withdrawal_request_invalid")
 }

--- a/state-transition/core/state/metrics.go
+++ b/state-transition/core/state/metrics.go
@@ -21,9 +21,5 @@
 package state
 
 func (s *StateDB) incrementPartialWithdrawalRequestInvalid() {
-	if s.telemetrySink == nil {
-		return
-	}
-
 	s.telemetrySink.IncrementCounter("beacon_kit.statedb.partial_withdrawal_request_invalid")
 }

--- a/state-transition/core/state_processor_payload_test.go
+++ b/state-transition/core/state_processor_payload_test.go
@@ -31,6 +31,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	payloadtime "github.com/berachain/beacon-kit/beacon/payload-time"
 	"github.com/berachain/beacon-kit/consensus-types/types"
+	"github.com/berachain/beacon-kit/node-core/components/metrics"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/transition"
@@ -127,7 +128,9 @@ func TestPayloadTimestampVerification(t *testing.T) {
 
 			// create independent states per each test
 			sdkCtx := sdk.NewContext(cms.CacheMultiStore(), true, log.NewNopLogger())
-			testSt := statedb.NewBeaconStateFromDB(st.KVStore.WithContext(sdkCtx), cs, sdkCtx.Logger())
+			testSt := statedb.NewBeaconStateFromDB(
+				st.KVStore.WithContext(sdkCtx), cs, sdkCtx.Logger(), metrics.NewNoOpTelemetrySink(),
+			)
 
 			tCtx := transition.NewTransitionCtx(
 				sdkCtx,

--- a/testing/state-transition/state-transition.go
+++ b/testing/state-transition/state-transition.go
@@ -128,7 +128,9 @@ func SetupTestState(t *testing.T, cs chain.Spec) (
 	require.NoError(t, err)
 
 	sdkCtx := sdk.NewContext(cms.CacheMultiStore(), true, log.NewNopLogger())
-	beaconState := statedb.NewBeaconStateFromDB(kvStore.WithContext(sdkCtx), cs, sdkCtx.Logger())
+	beaconState := statedb.NewBeaconStateFromDB(
+		kvStore.WithContext(sdkCtx), cs, sdkCtx.Logger(), nodemetrics.NewNoOpTelemetrySink(),
+	)
 
 	sp := core.NewStateProcessor(
 		noop.NewLogger[any](),


### PR DESCRIPTION
New metric key:
- `beacon_kit.statedb.partial_withdrawal_request_invalid`: When the validator's partial withdrawal request doesn't go through because the validators is _not_ partially withdrawable. Mainly for the case when a validator does multiple partial withdrawals in a row, resulting in partial withdrawals that cumulatively add up to more than their balance.