### PR TITLE
fix(pectra): Spec Alignment for ExpectedWithdrawals

### DIFF
--- a/state-transition/core/state/statedb.go
+++ b/state-transition/core/state/statedb.go
@@ -251,6 +251,15 @@ func (s *StateDB) consumePendingPartialWithdrawals(
 		if err != nil {
 			return nil, 0, 0, err
 		}
+
+		var totalWithdrawn math.Gwei
+		for _, w := range withdrawals {
+			if w.Validator == withdrawal.ValidatorIndex {
+				totalWithdrawn += w.Amount
+			}
+		}
+		balance -= totalWithdrawn
+
 		hasExcessBalance := balance > minActivationBalance
 		isWithdrawable := validator.GetExitEpoch() == constants.FarFutureEpoch && hasSufficientEffectiveBalance && hasExcessBalance
 		if isWithdrawable {

--- a/state-transition/core/state/statedb.go
+++ b/state-transition/core/state/statedb.go
@@ -150,6 +150,11 @@ func (s *StateDB) ExpectedWithdrawals(timestamp math.U64) (engineprimitives.With
 			return nil, 0, err
 		}
 
+		balance, err = s.GetBalance(validatorIndex)
+		if err != nil {
+			return nil, 0, err
+		}
+
 		// [Modified in Electra:EIP7251]
 		var partiallyWithdrawnBalance math.Gwei
 		for _, withdrawal := range withdrawals {
@@ -157,12 +162,6 @@ func (s *StateDB) ExpectedWithdrawals(timestamp math.U64) (engineprimitives.With
 				partiallyWithdrawnBalance += withdrawal.Amount
 			}
 		}
-
-		balance, err = s.GetBalance(validatorIndex)
-		if err != nil {
-			return nil, 0, err
-		}
-
 		// After electra, partiallyWithdrawnBalance can be non-zero, which we must account for.
 		balance -= partiallyWithdrawnBalance
 

--- a/state-transition/core/state/statedb.go
+++ b/state-transition/core/state/statedb.go
@@ -156,14 +156,14 @@ func (s *StateDB) ExpectedWithdrawals(timestamp math.U64) (engineprimitives.With
 		}
 
 		if version.EqualsOrIsAfter(forkVersion, version.Electra()) {
-			var partiallyWithdrawnBalance math.Gwei
+			var totalWithdrawn math.Gwei
 			for _, withdrawal := range withdrawals {
 				if withdrawal.Validator == validatorIndex {
-					partiallyWithdrawnBalance += withdrawal.Amount
+					totalWithdrawn += withdrawal.Amount
 				}
 			}
 			// After electra, partiallyWithdrawnBalance can be non-zero, which we must account for.
-			balance -= partiallyWithdrawnBalance
+			balance -= totalWithdrawn
 		}
 
 		// Set the amount of the withdrawal depending on the balance of the validator.

--- a/state-transition/core/state/statedb.go
+++ b/state-transition/core/state/statedb.go
@@ -211,6 +211,7 @@ func (s *StateDB) ExpectedWithdrawals(timestamp math.U64) (engineprimitives.With
 	return withdrawals, processedPartialWithdrawals, nil
 }
 
+//nolint:gocognit // Spec aligned.
 func (s *StateDB) consumePendingPartialWithdrawals(
 	epoch math.Epoch,
 	withdrawals engineprimitives.Withdrawals,

--- a/state-transition/core/state/statedb.go
+++ b/state-transition/core/state/statedb.go
@@ -155,15 +155,16 @@ func (s *StateDB) ExpectedWithdrawals(timestamp math.U64) (engineprimitives.With
 			return nil, 0, err
 		}
 
-		// [Modified in Electra:EIP7251]
-		var partiallyWithdrawnBalance math.Gwei
-		for _, withdrawal := range withdrawals {
-			if withdrawal.Validator == validatorIndex {
-				partiallyWithdrawnBalance += withdrawal.Amount
+		if version.EqualsOrIsAfter(forkVersion, version.Electra()) {
+			var partiallyWithdrawnBalance math.Gwei
+			for _, withdrawal := range withdrawals {
+				if withdrawal.Validator == validatorIndex {
+					partiallyWithdrawnBalance += withdrawal.Amount
+				}
 			}
+			// After electra, partiallyWithdrawnBalance can be non-zero, which we must account for.
+			balance -= partiallyWithdrawnBalance
 		}
-		// After electra, partiallyWithdrawnBalance can be non-zero, which we must account for.
-		balance -= partiallyWithdrawnBalance
 
 		// Set the amount of the withdrawal depending on the balance of the validator.
 		if validator.IsFullyWithdrawable(balance, epoch) {

--- a/state-transition/core/state/statedb.go
+++ b/state-transition/core/state/statedb.go
@@ -96,7 +96,7 @@ func (s *StateDB) DecreaseBalance(idx math.ValidatorIndex, delta math.Gwei) erro
 // NOTE for caller: ProcessSlots must be called before this function as the "current" slot is
 // retrieved from the state in this function.
 //
-//nolint:gocognit // Spec aligned.
+//nolint:gocognit,funlen // Spec aligned.
 func (s *StateDB) ExpectedWithdrawals(timestamp math.U64) (engineprimitives.Withdrawals, uint64, error) {
 	var (
 		validator         *ctypes.Validator
@@ -164,7 +164,7 @@ func (s *StateDB) ExpectedWithdrawals(timestamp math.U64) (engineprimitives.With
 		}
 
 		// After electra, partiallyWithdrawnBalance can be non-zero, which we must account for.
-		balance = balance - partiallyWithdrawnBalance
+		balance -= partiallyWithdrawnBalance
 
 		// Set the amount of the withdrawal depending on the balance of the validator.
 		if validator.IsFullyWithdrawable(balance, epoch) {


### PR DESCRIPTION
Addresses an edge case and gets us closer to spec alignment

Gating by fork is not strictly necessary but is better for posterity and aligns with prysm