### PR TITLE
Fix 2724 blockchain service error handling

### DIFF
--- a/beacon/blockchain/deposit.go
+++ b/beacon/blockchain/deposit.go
@@ -192,7 +192,7 @@ func (s *Service) depositCatchupFetcher(ctx context.Context) {
 			// for contiguous ranges of blocks
 			for _, blockNum := range failedBlks {
 				// Create a timeout context for each fetch operation to prevent blocking indefinitely
-				fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
 				err := s.fetchAndStoreDepositsWithErrorHandling(fetchCtx, blockNum)
 				cancel()
 


### PR DESCRIPTION
1.Improved error handling for background goroutines in the blockchain service
2.Extraction of the hard-coded timeout value (30*time.Second) into a named constant called fetchTimeout
3.Proper context management and cleanup in the service Stop() method
