### PR TITLE
fix(tests): Override Electra timestamp in Simulation Tests.

### DIFF
--- a/testing/simulated/components.go
+++ b/testing/simulated/components.go
@@ -104,6 +104,7 @@ func ProvideSimulationChainSpec() (chain.Spec, error) {
 	specData.GenesisTime = 0
 	// Arbitrary number
 	specData.Deneb1ForkTime = 30
+	// High number as we don't want to activate electra.
 	specData.ElectraForkTime = 9999999999999999
 	chainSpec, err := chain.NewSpec(specData)
 	if err != nil {

--- a/testing/simulated/components.go
+++ b/testing/simulated/components.go
@@ -104,6 +104,7 @@ func ProvideSimulationChainSpec() (chain.Spec, error) {
 	specData.GenesisTime = 0
 	// Arbitrary number
 	specData.Deneb1ForkTime = 30
+	specData.ElectraForkTime = 9999999999999999
 	chainSpec, err := chain.NewSpec(specData)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Some tests by default used the testnet chainspec. Since testnet timestamp is now passed, the tests started failing as behaviour changed.