### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/testing/e2e/suite/types/tx/eip4844.go
+++ b/testing/e2e/suite/types/tx/eip4844.go
@@ -110,10 +110,7 @@ func encodeBlobs(data []byte) []kzg4844.Blob {
 			blobIndex++
 			fieldIndex = 0
 		}
-		maxSize := i + 31
-		if maxSize > len(data) {
-			maxSize = len(data)
-		}
+		maxSize := min(i+31, len(data))
 		copy(blobs[blobIndex][fieldIndex*32+1:], data[i:maxSize])
 	}
 	return blobs


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.
