### PR TITLE
dockerfile for e2e framework

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+#
+# Copyright (C) 2022, Berachain Foundation. All rights reserved.
+# See the file LICENSE for licensing terms.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#######################################################
+###           Stage 0 - Build Arguments             ###
+#######################################################
+
+ARG IMAGE_NAME=beacond
+ARG VERSION=local-version
+
+FROM ${IMAGE_NAME}:${VERSION}
+
+###########################################################################
+###         Stage 1 - Add entrypoint.sh requirements to beacond         ###
+###########################################################################
+
+# Copy beacond because entrypoint.sh searches in ./build/bin
+RUN mkdir -p /build/bin && cp /usr/bin/beacond /build/bin
+
+# Add files used by entrypoint.sh. Start the build process from the testing folder.
+COPY files/ /testing/files/
+COPY networks/ /testing/networks/
+COPY files/entrypoint.sh /usr/bin/entrypoint-builtin
+
+# Configure entrypoint.sh
+ENV RPC_PREFIX="http://"
+ENV RPC_DIAL_URL="host.docker.internal:8551"
+ENV NON_INTERACTIVE=1
+ENV JWT_SECRET_PATH="/testing/files/jwt.hex"
+
+###########################################################################
+###         Stage 2 - Add consensus e2e test details to beacond         ###
+###########################################################################
+
+# Add iputils-ping and iproute2 for simulated network delay.
+RUN apk add --no-cache iputils-ping iproute2
+
+# Set up runtime directory.
+WORKDIR /
+VOLUME /cometbft
+ENV CMTHOME=/cometbft
+ENV HOMEDIR=/cometbft
+ENV GORACE="halt_on_error=1"
+
+EXPOSE 26656 26657 26660 6060
+ENTRYPOINT ["/testing/files/entrypoint.sh"]
+CMD ["devnet"]
+STOPSIGNAL SIGTERM

--- a/scripts/build/build.mk
+++ b/scripts/build/build.mk
@@ -100,6 +100,7 @@ IMAGE_NAME ?= $(TESTAPP)
 
 # Docker Paths
 DOCKERFILE = ./Dockerfile
+DOCKERFILE_E2E = ./Dockerfile.e2e
 
 build-docker: ## build a docker image containing `beacond`
 	@echo "Build a release docker image for the Cosmos SDK chain..."
@@ -118,3 +119,10 @@ push-docker-github: ## push the docker image to the ghcr registry
 	@echo "Push the release docker image to the ghcr registry..."
 	docker tag $(IMAGE_NAME):$(VERSION) ghcr.io/berachain/beacon-kit:$(VERSION)
 	docker push ghcr.io/berachain/beacon-kit:$(VERSION)
+
+build-docker-e2e: ## build a docker image containing `beacond` used in the e2e tests
+	@echo "Build an e2e docker image..."
+	docker build \
+	-f ${DOCKERFILE_E2E} \
+	-t cometbft/e2e-node:local-version \
+	./testing # work around .dockerignore restrictions in the root folder


### PR DESCRIPTION
Create a dockerfile that works with the e2e framework.

This is an override of the beacond Dockerfile that sets up some configuration for the e2e framework. It does not build baecond by itself. It has minor modifications to `entrypoint.sh` so it can run in an automated environment. The changes are backwards-compatible.