### PR TITLE
feat(node-api): [codex] Add validator balance proof endpoint

### DIFF
--- a/node-api/handlers/proof/merkle/generalized_indexes.go
+++ b/node-api/handlers/proof/merkle/generalized_indexes.go
@@ -77,6 +77,32 @@ const (
 	// GIndices. To get the GIndex of the withdrawal credentials of validator at index n, the formula is:
 	// GIndex = ZeroValidatorCredentialsGIndexElectraBlock + (ValidatorGIndexOffset * n)
 	ZeroValidatorCredentialsGIndexElectraBlock = 6350779162034177
+
+	// ZeroValidatorBalanceGIndexDenebState is the generalized index of the 0
+	// validator's balance in the beacon state in the Deneb forks. To get the
+	// GIndex of the balance of validator at index n, the formula is:
+	// GIndex = ZeroValidatorBalanceGIndexDenebState + (ValidatorGIndexOffset * n)
+	ZeroValidatorBalanceGIndexDenebState = 14293651161088
+
+	// ZeroValidatorBalanceGIndexDenebBlock is the generalized index of the 0
+	// validator's balance in the beacon block in the Deneb forks. This is
+	// calculated by concatenating the (ZeroValidatorBalanceGIndexDenebState, StateGIndexBlock)
+	// GIndices. To get the GIndex of the balance of validator at index n, the formula is:
+	// GIndex = ZeroValidatorBalanceGIndexDenebBlock + (ValidatorGIndexOffset * n)
+	ZeroValidatorBalanceGIndexDenebBlock = 102254581383168
+
+	// ZeroValidatorBalanceGIndexElectraState is the generalized index of the 0
+	// validator's balance in the beacon state in the Electra forks. To get the
+	// GIndex of the balance of validator at index n, the formula is:
+	// GIndex = ZeroValidatorBalanceGIndexElectraState + (ValidatorGIndexOffset * n)
+	ZeroValidatorBalanceGIndexElectraState = 23089744183296
+
+	// ZeroValidatorBalanceGIndexElectraBlock is the generalized index of the 0
+	// validator's balance in the beacon block in the Electra forks. This is
+	// calculated by concatenating the (ZeroValidatorBalanceGIndexElectraState, StateGIndexBlock)
+	// GIndices. To get the GIndex of the balance of validator at index n, the formula is:
+	// GIndex = ZeroValidatorBalanceGIndexElectraBlock + (ValidatorGIndexOffset * n)
+	ZeroValidatorBalanceGIndexElectraBlock = 199011604627456
 )
 
 // GetZeroValidatorPubkeyGIndexState determines the generalized index of the 0
@@ -117,6 +143,28 @@ func GetZeroValidatorCredentialsGIndexState(forkVersion common.Version) (int, er
 func GetZeroValidatorCredentialsGIndexBlock(forkVersion common.Version) (uint64, error) {
 	if version.EqualsOrIsAfter(forkVersion, version.Electra()) {
 		return ZeroValidatorCredentialsGIndexElectraBlock, nil
+	}
+	return 0, fmt.Errorf("unsupported fork version: %s", forkVersion)
+}
+
+// GetZeroValidatorBalanceGIndexState determines the generalized index of the 0
+// validator's balance in the beacon state based on the fork version.
+func GetZeroValidatorBalanceGIndexState(forkVersion common.Version) (int, error) {
+	if version.EqualsOrIsAfter(forkVersion, version.Electra()) {
+		return ZeroValidatorBalanceGIndexElectraState, nil
+	} else if version.EqualsOrIsAfter(forkVersion, version.Deneb()) {
+		return ZeroValidatorBalanceGIndexDenebState, nil
+	}
+	return 0, fmt.Errorf("unsupported fork version: %s", forkVersion)
+}
+
+// GetZeroValidatorBalanceGIndexBlock determines the generalized index of the 0
+// validator's balance in the beacon block based on the fork version.
+func GetZeroValidatorBalanceGIndexBlock(forkVersion common.Version) (uint64, error) {
+	if version.EqualsOrIsAfter(forkVersion, version.Electra()) {
+		return ZeroValidatorBalanceGIndexElectraBlock, nil
+	} else if version.EqualsOrIsAfter(forkVersion, version.Deneb()) {
+		return ZeroValidatorBalanceGIndexDenebBlock, nil
 	}
 	return 0, fmt.Errorf("unsupported fork version: %s", forkVersion)
 }

--- a/node-api/handlers/proof/merkle/validator_balance.go
+++ b/node-api/handlers/proof/merkle/validator_balance.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package merkle
+
+import (
+	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
+	"github.com/berachain/beacon-kit/errors"
+	"github.com/berachain/beacon-kit/node-api/handlers/proof/types"
+	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/math"
+	"github.com/berachain/beacon-kit/primitives/merkle"
+)
+
+// ProveValidatorBalanceInState generates a proof for a validator's balance in the
+// beacon state. The validatorOffset must be computed as (ValidatorGIndexOffset * validatorIndex).
+func ProveValidatorBalanceInState(
+	forkVersion common.Version,
+	bsm types.BeaconStateMarshallable,
+	validatorOffset math.U64,
+) ([]common.Root, common.Root, error) {
+	stateProofTree, err := bsm.GetTree()
+	if err != nil {
+		return nil, common.Root{}, err
+	}
+
+	zeroBalanceGIndexState, err := GetZeroValidatorBalanceGIndexState(forkVersion)
+	if err != nil {
+		return nil, common.Root{}, err
+	}
+
+	gIndex := zeroBalanceGIndexState + int(validatorOffset) // #nosec G115 -- bounded
+	balProof, err := stateProofTree.Prove(gIndex)
+	if err != nil {
+		return nil, common.Root{}, err
+	}
+
+	proof := make([]common.Root, len(balProof.Hashes))
+	for i, hash := range balProof.Hashes {
+		proof[i] = common.NewRootFromBytes(hash)
+	}
+	return proof, common.NewRootFromBytes(balProof.Leaf), nil
+}
+
+// ProveValidatorBalanceInBlock generates a proof for a validator's balance in the
+// beacon block. The proof is verified against the beacon block root and returned
+// alongside the beacon block root used for verification.
+func ProveValidatorBalanceInBlock(
+	validatorIndex math.U64,
+	bbh *ctypes.BeaconBlockHeader,
+	bsm types.BeaconStateMarshallable,
+) ([]common.Root, common.Root, error) {
+	forkVersion := bsm.GetForkVersion()
+	validatorOffset := ValidatorGIndexOffset * validatorIndex
+
+	balInStateProof, leaf, err := ProveValidatorBalanceInState(forkVersion, bsm, validatorOffset)
+	if err != nil {
+		return nil, common.Root{}, err
+	}
+
+	stateInBlockProof, err := ProveBeaconStateInBlock(bbh, false)
+	if err != nil {
+		return nil, common.Root{}, err
+	}
+
+	combinedProof := append(balInStateProof, stateInBlockProof...)
+	beaconRoot, err := verifyValidatorBalanceInBlock(forkVersion, bbh, validatorOffset, combinedProof, leaf)
+	if err != nil {
+		return nil, common.Root{}, err
+	}
+	return combinedProof, beaconRoot, nil
+}
+
+// verifyValidatorBalanceInBlock verifies the provided Merkle proof of a validator's
+// balance inside the beacon block and returns the beacon block root that the proof
+// was verified against.
+func verifyValidatorBalanceInBlock(
+	forkVersion common.Version,
+	bbh *ctypes.BeaconBlockHeader,
+	validatorOffset math.U64,
+	proof []common.Root,
+	leaf common.Root,
+) (common.Root, error) {
+	zeroBalanceGIndexBlock, err := GetZeroValidatorBalanceGIndexBlock(forkVersion)
+	if err != nil {
+		return common.Root{}, err
+	}
+
+	beaconRoot := bbh.HashTreeRoot()
+	if !merkle.VerifyProof(beaconRoot, leaf, zeroBalanceGIndexBlock+validatorOffset.Unwrap(), proof) {
+		return common.Root{}, errors.Wrapf(
+			errors.New("validator balance proof failed to verify against beacon root"),
+			"beacon root: 0x%s", beaconRoot,
+		)
+	}
+
+	return beaconRoot, nil
+}

--- a/node-api/handlers/proof/routes.go
+++ b/node-api/handlers/proof/routes.go
@@ -40,5 +40,10 @@ func (h *Handler) RegisterRoutes(logger log.Logger) {
 			Path:    "bkit/v1/proof/validator_credentials/:timestamp_id/:validator_index",
 			Handler: h.GetValidatorCredentials,
 		},
+		{
+			Method:  http.MethodGet,
+			Path:    "bkit/v1/proof/validator_balance/:timestamp_id/:validator_index",
+			Handler: h.GetValidatorBalance,
+		},
 	})
 }

--- a/node-api/handlers/proof/types/request.go
+++ b/node-api/handlers/proof/types/request.go
@@ -34,3 +34,10 @@ type ValidatorCredentialsRequest struct {
 	types.TimestampIDRequest
 	ValidatorIndex string `param:"validator_index" validate:"required,numeric"`
 }
+
+// ValidatorBalanceRequest is the request for the
+// `/proof/validator_balance/{timestamp_id}/{validator_index}` endpoint.
+type ValidatorBalanceRequest struct {
+	types.TimestampIDRequest
+	ValidatorIndex string `param:"validator_index" validate:"required,numeric"`
+}

--- a/node-api/handlers/proof/types/response.go
+++ b/node-api/handlers/proof/types/response.go
@@ -24,6 +24,7 @@ import (
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/crypto"
+	"github.com/berachain/beacon-kit/primitives/math"
 )
 
 // BlockProposerResponse is the response for the
@@ -68,4 +69,23 @@ type ValidatorWithdrawalCredentialsResponse struct {
 	// Generalized Index of the 0 validator withdrawal credentials in the beacon
 	// block. In the Electra fork, z is 6350779162034177.
 	WithdrawalCredentialsProof []common.Root `json:"withdrawal_credentials_proof"`
+}
+
+// ValidatorBalanceResponse is the response for the
+// `/proof/validator_balance/{timestamp_id}/{validator_index}` endpoint.
+type ValidatorBalanceResponse struct {
+	// BeaconBlockHeader is the block header of which the hash tree root is the
+	// beacon block root to verify against.
+	BeaconBlockHeader *ctypes.BeaconBlockHeader `json:"beacon_block_header"`
+
+	// BeaconBlockRoot is the beacon block root for this slot.
+	BeaconBlockRoot common.Root `json:"beacon_block_root"`
+
+	// Balance is the balance of the requested validator in gwei.
+	Balance math.Gwei `json:"balance,string"`
+
+	// BalanceProof can be verified against the beacon block root.
+	// Use a Generalized Index of `z + (8 * ValidatorIndex)`, where z is the
+	// Generalized Index of the 0 validator balance in the beacon block.
+	BalanceProof []common.Root `json:"balance_proof"`
 }

--- a/node-api/handlers/proof/validator_balance.go
+++ b/node-api/handlers/proof/validator_balance.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+package proof
+
+import (
+	"github.com/berachain/beacon-kit/node-api/handlers"
+	"github.com/berachain/beacon-kit/node-api/handlers/proof/merkle"
+	"github.com/berachain/beacon-kit/node-api/handlers/proof/types"
+	"github.com/berachain/beacon-kit/node-api/handlers/utils"
+	"github.com/berachain/beacon-kit/primitives/math"
+)
+
+// GetValidatorBalance returns the balance of a validator along with a Merkle
+// proof that can be verified against the beacon block root.
+func (h *Handler) GetValidatorBalance(c handlers.Context) (any, error) {
+	params, err := utils.BindAndValidate[types.ValidatorBalanceRequest](c, h.Logger())
+	if err != nil {
+		return nil, err
+	}
+
+	validatorIndex, err := math.U64FromString(params.ValidatorIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	slot, beaconState, blockHeader, err := h.resolveTimestampID(params.TimestampID)
+	if err != nil {
+		return nil, err
+	}
+
+	h.Logger().Info(
+		"Generating validator balance proofs", "slot", slot, "validator_index", validatorIndex,
+	)
+
+	bsm, err := beaconState.GetMarshallable()
+	if err != nil {
+		return nil, err
+	}
+
+	balProof, beaconBlockRoot, err := merkle.ProveValidatorBalanceInBlock(
+		validatorIndex, blockHeader, bsm,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	balance, err := beaconState.GetBalance(validatorIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	return types.ValidatorBalanceResponse{
+		BeaconBlockHeader: blockHeader,
+		BeaconBlockRoot:   beaconBlockRoot,
+		Balance:           balance,
+		BalanceProof:      balProof,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- add gindices for validator balances
- implement merkle proofs for validator balances
- expose `GetValidatorBalance` endpoint
- support new request and response types

## Testing
- `go test ./node-api/handlers/proof/merkle -run TestProveBeaconStateInBlock -count=1`

------
https://chatgpt.com/codex/tasks/task_b_686c154b13108329b235d1053a7e8cc2