### PR TITLE
refactor(spec): remove import cycle and cleanup (#2831)

### DIFF
--- a/chain/chain_ids.go
+++ b/chain/chain_ids.go
@@ -18,15 +18,18 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-package spec
+package chain
 
+// Chain IDs that must be used for specific Berachain networks.
 const (
-	// DevnetEth1ChainID is the chain ID for a local devnet. Used by `make start` and unit tests.
+	// DevnetEth1ChainID is the chain ID for a local devnet. Used by `make start`, e2e tests, and
+	// many unit tests.
 	DevnetEth1ChainID uint64 = 80087
 
 	// MainnetEth1ChainID is the chain ID for the Berachain mainnet.
 	MainnetEth1ChainID uint64 = 80094
 
-	// TestnetEth1ChainID is the chain ID for the Berachain public testnet.
+	// TestnetEth1ChainID is the chain ID for the Berachain public testnet, Bepolia. Also used by
+	// simulated tests.
 	TestnetEth1ChainID uint64 = 80069
 )

--- a/chain/helpers.go
+++ b/chain/helpers.go
@@ -56,3 +56,18 @@ func (s spec) SlotToEpoch(slot math.Slot) math.Epoch {
 func (s spec) WithinDAPeriod(block, current math.Slot) bool {
 	return s.SlotToEpoch(block)+s.MinEpochsForBlobsSidecarsRequest() >= s.SlotToEpoch(current)
 }
+
+// IsMainnet returns true if the chain is running with the mainnet chain ID.
+func (s spec) IsMainnet() bool {
+	return s.DepositEth1ChainID() == MainnetEth1ChainID
+}
+
+// IsTestnet returns true if the chain is running with the testnet chain ID.
+func (s spec) IsTestnet() bool {
+	return s.DepositEth1ChainID() == TestnetEth1ChainID
+}
+
+// IsDevnet returns true if the chain is running with the devnet chain ID.
+func (s spec) IsDevnet() bool {
+	return s.DepositEth1ChainID() == DevnetEth1ChainID
+}

--- a/chain/spec.go
+++ b/chain/spec.go
@@ -155,6 +155,15 @@ type BerachainSpec interface {
 
 	// ValidatorSetCap retrieves the maximum number of validators allowed in the active set.
 	ValidatorSetCap() uint64
+
+	// IsMainnet returns true if the chain is running with the mainnet chain ID.
+	IsMainnet() bool
+
+	// IsTestnet returns true if the chain is running with the testnet chain ID.
+	IsTestnet() bool
+
+	// IsDevnet returns true if the chain is running with the devnet chain ID.
+	IsDevnet() bool
 }
 
 type WithdrawalsSpec interface {

--- a/config/spec/devnet.go
+++ b/config/spec/devnet.go
@@ -69,7 +69,7 @@ const (
 // TODO: remove modifications from mainnet spec to align with mainnet behavior.
 func DevnetChainSpecData() *chain.SpecData {
 	specData := MainnetChainSpecData()
-	specData.DepositEth1ChainID = DevnetEth1ChainID
+	specData.DepositEth1ChainID = chain.DevnetEth1ChainID
 
 	specData.Config.ConsensusUpdateHeight = 1
 	specData.Config.ConsensusEnableHeight = 2

--- a/config/spec/mainnet.go
+++ b/config/spec/mainnet.go
@@ -133,7 +133,7 @@ func MainnetChainSpecData() *chain.SpecData {
 		// Eth1-related values.
 		DepositContractAddress:    common.NewExecutionAddressFromHex(mainnetDepositContractAddress),
 		MaxDepositsPerBlock:       defaultMaxDepositsPerBlock,
-		DepositEth1ChainID:        MainnetEth1ChainID,
+		DepositEth1ChainID:        chain.MainnetEth1ChainID,
 		Eth1FollowDistance:        defaultEth1FollowDistance,
 		TargetSecondsPerEth1Block: defaultTargetSecondsPerEth1Block,
 

--- a/config/spec/testnet.go
+++ b/config/spec/testnet.go
@@ -31,7 +31,7 @@ func TestnetChainSpecData() *chain.SpecData {
 	specData := MainnetChainSpecData()
 
 	// Testnet uses chain ID of 80069.
-	specData.DepositEth1ChainID = TestnetEth1ChainID
+	specData.DepositEth1ChainID = chain.TestnetEth1ChainID
 
 	// Timestamp of the genesis block of Bepolia testnet.
 	specData.GenesisTime = 1739976735

--- a/state-transition/core/interfaces.go
+++ b/state-transition/core/interfaces.go
@@ -85,4 +85,5 @@ type ChainSpec interface {
 	ActiveForkVersionForTimestamp(timestamp math.U64) common.Version
 	ValidatorSetCap() uint64
 	HistoricalRootsLimit() uint64
+	IsMainnet() bool
 }


### PR DESCRIPTION
Cherry picked this change by @calbera to simplify some diffs down the line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added methods to determine if the chain is running as mainnet, testnet, or devnet.
  * Interfaces now include functions to check for mainnet, testnet, or devnet status.

* **Documentation**
  * Expanded and clarified comments for chain ID constants, including usage details for devnet and testnet environments.

* **Refactor**
  * Updated references to chain ID constants to use fully qualified identifiers for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->