### PR TITLE
chore(bepolia): pectra11 hardfork

### DIFF
--- a/config/spec/testnet.go
+++ b/config/spec/testnet.go
@@ -21,8 +21,6 @@
 package spec
 
 import (
-	"math"
-
 	"github.com/berachain/beacon-kit/chain"
 )
 
@@ -44,8 +42,12 @@ func TestnetChainSpecData() *chain.SpecData {
 	// Timestamp of the Electra fork on Bepolia.
 	specData.ElectraForkTime = 1746633600
 
+	// Enable stable block time before the Electra1 fork.
+	specData.Config.ConsensusUpdateHeight = 7_768_334
+	specData.Config.ConsensusEnableHeight = 7_768_335
+
 	// Timestamp of the Electra1 fork on Bepolia.
-	specData.Electra1ForkTime = math.MaxInt64
+	specData.Electra1ForkTime = 1754496000
 
 	return specData
 }

--- a/testing/e2e/e2e_withdrawal_test.go
+++ b/testing/e2e/e2e_withdrawal_test.go
@@ -239,17 +239,10 @@ func (s *BeaconKitE2ESuite) TestSubmitPartialWithdrawalTransaction() {
 	s.Require().NoError(err)
 
 	// Get the transaction receipt
-	var receipt map[string]interface{}
-	err = rpcClient.CallContext(ctx, &receipt, "eth_getTransactionReceipt", txHash.Hex())
+	receipt, err := s.JSONRPCBalancer().TransactionReceipt(ctx, txHash)
 	s.Require().NoError(err)
 	s.Require().NotNil(receipt, "Transaction receipt should not be nil")
-
-	// Get block number where the withdrawal transaction was included
-	blockNumStr, ok := receipt["blockNumber"].(string)
-	s.Require().True(ok, "Block number should be a string")
-	blockNum, err := hexutil.DecodeUint64(blockNumStr)
-	s.Require().NoError(err)
-	s.T().Logf("Withdrawal transaction included in block: %d", blockNum)
+	s.T().Logf("Withdrawal transaction included in block: %d", receipt.BlockNumber)
 
 	// Check for pending partial withdrawals after submitting the transaction
 	pendingWithdrawalsAfter, err := s.getPendingPartialWithdrawals(utils.StateIDHead)

--- a/testing/networks/80069/eth-genesis.json
+++ b/testing/networks/80069/eth-genesis.json
@@ -97,7 +97,7 @@
     },
     "berachain": {
       "prague1": {
-        "time": 17446744073709551614,
+        "time": 1754496000,
         "baseFeeChangeDenominator": 48,
         "minimumBaseFeeWei": 10000000000,
         "polDistributorAddress": "0xD2f19a79b026Fb636A7c300bF5947df113940761"

--- a/testing/networks/80069/spec.toml
+++ b/testing/networks/80069/spec.toml
@@ -35,7 +35,7 @@ target-seconds-per-eth1-block = 2
 genesis-time = 1_739_976_735
 deneb-one-fork-time = 1_740_090_694
 electra-fork-time = 1_746_633_600
-electra-one-fork-time = 9_223_372_036_854_775_807
+electra-one-fork-time = 1_754_496_000
 
 # State list lengths
 epochs-per-historical-vector = 8
@@ -71,5 +71,5 @@ min-validator-withdrawability-delay = 256
 max-block-delay = 300_000_000_000
 target-block-time = 2_000_000_000
 const-block-delay = 500_000_000
-consensus-update-height = 0
-consensus-enable-height = 9_223_372_036_854_775_807
+consensus-update-height = 7_768_334
+consensus-enable-height = 7_768_335

--- a/testing/simulated/components.go
+++ b/testing/simulated/components.go
@@ -106,6 +106,7 @@ func ProvideSimulationChainSpec() (chain.Spec, error) {
 	specData.Deneb1ForkTime = 30
 	// High number as we don't want to activate electra.
 	specData.ElectraForkTime = 9999999999999999
+	specData.Electra1ForkTime = 9999999999999999
 	chainSpec, err := chain.NewSpec(specData)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Pectra11 hard fork on Bepolia at _August 6th, noon EST_ (unix: `1754496000`). Stable block time enabled ~24 hours before at block `7768335` so that as PoL switches over to the new distribution method, there are no hiccups with an already stable block time.