### PR TITLE
chore(node-api): enforce mapping of requested slots 0 to genesis

### DIFF
--- a/node-api/handlers/utils/id.go
+++ b/node-api/handlers/utils/id.go
@@ -21,7 +21,6 @@
 package utils
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/berachain/beacon-kit/errors"
@@ -113,10 +112,11 @@ func IsTimestampIDPrefix(timestampID string) bool {
 }
 
 // slotFromStateID returns a slot number from the given state ID.
-// Currently when requested Genesis, we return block 1 state. This is
-// due to a limitation of CometBFT which does not explicitly commit genesis state
-// (it cumulated block 1 state changes and flush them down altogether).
-// TODO: Properly return genesis state when requested, instead of block 1
+// Currently, when "genesis" is requested, we return the block 1 state.
+// This is due to a CometBFT limitation that does not explicitly commit the
+// genesis state (it accumulates block 1 state changes and flushes them together).
+// Numeric requests are clamped so that slot 0 maps to Genesis (slot 1).
+// TODO: Properly return the true genesis state when requested, instead of block 1.
 func slotFromStateID(id string) (math.Slot, error) {
 	switch id {
 	case StateIDFinalized, StateIDJustified, StateIDHead:
@@ -126,7 +126,7 @@ func slotFromStateID(id string) (math.Slot, error) {
 	default:
 		slot, err := math.U64FromString(id)
 		if err != nil {
-			return math.Slot(0), fmt.Errorf("failed mapping stateID %s to slot: %w", id, err)
+			return math.Slot(0), errors.Wrapf(err, "failed mapping stateID %q to slot", id)
 		}
 
 		// Enforce here too the choice of mapping genesis to slot 1. Without this


### PR DESCRIPTION
We still map genesis to slot 1, due to limitation of how CometBFT handles genesis state.
I defer fixing this to an upcoming PR (we will need to re-process and keep a copy of genesis state in node-api at every restart and change `slotFromStateID` semantics, which is a longer effort) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected mapping of numeric state IDs to slots, preventing incorrect resolution to the chain tip.
  - Ensured genesis references resolve consistently to the genesis state.

- Improvements
  - Clearer error messages when an invalid state ID is provided, aiding troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->