### PR TITLE
fix(blockchain/process proposal): remove duplicate prefetching build data call in  optimistic payload building

### DIFF
--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -303,7 +303,7 @@ func (s *Service) VerifyIncomingBlock(
 	)
 
 	// If we should build the next block and the pre-fetch was successful, trigger the optimistic build
-	if shouldBuildNextBlock && nextBlockData != nil && errFetch == nil {
+	if shouldBuildNextBlock && nextBlockData != nil {
 		go s.handleOptimisticPayloadBuild(ctx, nextBlockData)
 	}
 


### PR DESCRIPTION
## Summary

  This PR fixes a performance issue where `preFetchBuildData` was being called twice during block processing, resulting in duplicate state copies and redundant execution engine API calls.

  ## Problem

  In the `ProcessProposal` flow, the code was executing the same optimistic payload building preparation twice:
  1. **Line 267**: Before block verification
  2. **Line 308**: After successful block verification (duplicate)