### PR TITLE
fix: resolve JWT authentication race condition on validator restart

### DIFF
--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -22,6 +22,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"sync"
 	"time"
@@ -68,6 +69,7 @@ func New(
 		cfg.RPCDialURL.String(),
 		jwtSecret,
 		cfg.RPCJWTRefreshInterval,
+		logger,
 	)
 
 	// Enforcing minimum rpc timeout
@@ -108,7 +110,12 @@ func (s *EngineClient) Name() string {
 
 // Start the engine client.
 func (s *EngineClient) Start(ctx context.Context) error {
-	// Start the Client.
+	// Initialize the JWT token before making any RPC calls
+	if err := s.Client.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize RPC client: %w", err)
+	}
+
+	// Start the Client background refresh loop.
 	go s.Client.Start(ctx)
 
 	s.logger.Info(

--- a/execution/client/ethclient/engine_test.go
+++ b/execution/client/ethclient/engine_test.go
@@ -154,6 +154,7 @@ type stubRPCClient struct {
 	t *testing.T
 }
 
+func (tc *stubRPCClient) Initialize() error     { return nil }
 func (tc *stubRPCClient) Start(context.Context) {}
 func (tc *stubRPCClient) Call(_ context.Context, target any, _ string, _ ...any) error {
 	tc.t.Helper()


### PR DESCRIPTION
This commit addresses a race condition that caused JWT authentication failures when validators restarted after extended downtime. 

I noticed this when I was testing blob distribution where I stopped a single validator for an extended period of time (over 1hour) and then restarted it expecting it to fetch blobs from other peers, instead it caused a JWT token invalid error.

The issue occurred because the RPC client's JWT refresh was happening asynchronously in a go routine while the main thread immediately attempted to make RPC calls with a expired token.

I added also logging to the JWT refresh mechanics.