### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -116,7 +116,7 @@ func (s *EngineClient) Start(ctx context.Context) error {
 		"dial_url", s.cfg.RPCDialURL.String(),
 	)
 
-	// If the connection connection succeeds, we can skip the
+	// If the connection succeeds, we can skip the
 	// connection initialization loop.
 	if err := s.verifyChainIDAndConnection(ctx); err == nil {
 		return nil


### PR DESCRIPTION
remove redundant word in comment