### PR TITLE
Fix high cardinality metrics by removing unbounded labels

### DIFF
--- a/beacon/blockchain/deposit.go
+++ b/beacon/blockchain/deposit.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"maps"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/berachain/beacon-kit/primitives/math"
@@ -55,11 +54,10 @@ func (s *Service) fetchAndStoreDeposits(
 	ctx context.Context,
 	blockNum math.U64,
 ) {
-	blockNumStr := strconv.FormatUint(blockNum.Unwrap(), 10)
 	deposits, err := s.depositContract.ReadDeposits(ctx, blockNum, blockNum)
 	if err != nil {
 		s.logger.Error("Failed to read deposits", "error", err)
-		s.metrics.FailedToGetBlockLogs.With("block_num", blockNumStr).Add(1)
+		s.metrics.FailedToGetBlockLogs.Add(1)
 		s.failedBlocksMu.Lock()
 		s.failedBlocks[blockNum] = struct{}{}
 		s.failedBlocksMu.Unlock()
@@ -75,7 +73,7 @@ func (s *Service) fetchAndStoreDeposits(
 
 	if err = s.storageBackend.DepositStore().EnqueueDeposits(ctx, deposits); err != nil {
 		s.logger.Error("Failed to store deposits", "error", err)
-		s.metrics.FailedToEnqueueDeposits.With("block_num", blockNumStr).Add(1)
+		s.metrics.FailedToEnqueueDeposits.Add(1)
 		s.failedBlocksMu.Lock()
 		s.failedBlocks[blockNum] = struct{}{}
 		s.failedBlocksMu.Unlock()

--- a/beacon/blockchain/metrics.go
+++ b/beacon/blockchain/metrics.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/berachain/beacon-kit/observability/metrics"
-	"github.com/berachain/beacon-kit/primitives/math"
 )
 
 // Metrics is a struct that contains metrics for the blockchain service.
@@ -56,28 +55,28 @@ func NewMetrics(factory metrics.Factory) *Metrics {
 				Name: "beacon_kit_blockchain_rebuild_payload_for_rejected_block_success",
 				Help: "Number of successful payload rebuilds for rejected blocks",
 			},
-			[]string{"slot"},
+			nil,
 		),
 		RebuildPayloadForRejectedBlockFailure: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_blockchain_rebuild_payload_for_rejected_block_failure",
 				Help: "Number of failed payload rebuilds for rejected blocks",
 			},
-			[]string{"slot", "error"},
+			nil,
 		),
 		OptimisticPayloadBuildSuccess: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_blockchain_optimistic_payload_build_success",
 				Help: "Number of successful optimistic payload builds",
 			},
-			[]string{"slot"},
+			nil,
 		),
 		OptimisticPayloadBuildFailure: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_blockchain_optimistic_payload_build_failure",
 				Help: "Number of failed optimistic payload builds",
 			},
-			[]string{"slot", "error"},
+			nil,
 		),
 		StateRootVerificationDuration: factory.NewSummary(
 			metrics.SummaryOpts{
@@ -92,14 +91,14 @@ func NewMetrics(factory metrics.Factory) *Metrics {
 				Name: "beacon_kit_execution_deposit_failed_to_get_block_logs",
 				Help: "Number of times failed to read deposits from execution layer block logs",
 			},
-			[]string{"block_num"},
+			nil,
 		),
 		FailedToEnqueueDeposits: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_execution_deposit_failed_to_enqueue_deposits",
 				Help: "Number of times failed to enqueue deposits to storage",
 			},
-			[]string{"block_num"},
+			nil,
 		),
 	}
 }
@@ -111,27 +110,27 @@ func (m *Metrics) measureStateTransitionDuration(start time.Time) {
 
 // markRebuildPayloadForRejectedBlockSuccess increments the counter for the number of times
 // the validator successfully rebuilt the payload for a rejected block.
-func (m *Metrics) markRebuildPayloadForRejectedBlockSuccess(slot math.Slot) {
-	m.RebuildPayloadForRejectedBlockSuccess.With("slot", slot.Base10()).Add(1)
+func (m *Metrics) markRebuildPayloadForRejectedBlockSuccess() {
+	m.RebuildPayloadForRejectedBlockSuccess.Add(1)
 }
 
 // markRebuildPayloadForRejectedBlockFailure increments the counter for the
 // number of times the validator failed to build an optimistic payload
 // due to a failure.
-func (m *Metrics) markRebuildPayloadForRejectedBlockFailure(slot math.Slot, err error) {
-	m.RebuildPayloadForRejectedBlockFailure.With("slot", slot.Base10(), "error", err.Error()).Add(1)
+func (m *Metrics) markRebuildPayloadForRejectedBlockFailure() {
+	m.RebuildPayloadForRejectedBlockFailure.Add(1)
 }
 
 // markOptimisticPayloadBuildSuccess increments the counter for the number of
 // times the validator successfully built an optimistic payload.
-func (m *Metrics) markOptimisticPayloadBuildSuccess(slot math.Slot) {
-	m.OptimisticPayloadBuildSuccess.With("slot", slot.Base10()).Add(1)
+func (m *Metrics) markOptimisticPayloadBuildSuccess() {
+	m.OptimisticPayloadBuildSuccess.Add(1)
 }
 
 // markOptimisticPayloadBuildFailure increments the counter for the number of
 // times the validator failed to build an optimistic payload.
-func (m *Metrics) markOptimisticPayloadBuildFailure(slot math.Slot, err error) {
-	m.OptimisticPayloadBuildFailure.With("slot", slot.Base10(), "error", err.Error()).Add(1)
+func (m *Metrics) markOptimisticPayloadBuildFailure() {
+	m.OptimisticPayloadBuildFailure.Add(1)
 }
 
 // TODO: remove once state caching is activated

--- a/beacon/blockchain/payload.go
+++ b/beacon/blockchain/payload.go
@@ -211,9 +211,8 @@ func (s *Service) handleRebuildPayloadForRejectedBlock(
 	buildData *builder.RequestPayloadData,
 ) {
 	s.logger.Info("Rebuilding payload for rejected block ⏳ ")
-	nextBlkSlot := buildData.Slot
 	if _, _, err := s.localBuilder.RequestPayloadAsync(ctx, buildData); err != nil {
-		s.metrics.markRebuildPayloadForRejectedBlockFailure(nextBlkSlot, err)
+		s.metrics.markRebuildPayloadForRejectedBlockFailure()
 		s.logger.Error(
 			"failed to rebuild payload for nil block",
 			"error", err,
@@ -223,7 +222,7 @@ func (s *Service) handleRebuildPayloadForRejectedBlock(
 
 	s.latestFcuReq.Store(&buildData.FCState)
 
-	s.metrics.markRebuildPayloadForRejectedBlockSuccess(nextBlkSlot)
+	s.metrics.markRebuildPayloadForRejectedBlockSuccess()
 }
 
 // handleOptimisticPayloadBuild handles optimistically
@@ -237,7 +236,7 @@ func (s *Service) handleOptimisticPayloadBuild(
 		"next_slot", buildData.Slot.Base10(),
 	)
 	if _, _, err := s.localBuilder.RequestPayloadAsync(ctx, buildData); err != nil {
-		s.metrics.markOptimisticPayloadBuildFailure(buildData.Slot, err)
+		s.metrics.markOptimisticPayloadBuildFailure()
 		s.logger.Error(
 			"Failed to build optimistic payload",
 			"for_slot", buildData.Slot.Base10(),
@@ -248,5 +247,5 @@ func (s *Service) handleOptimisticPayloadBuild(
 
 	s.latestFcuReq.Store(&buildData.FCState)
 
-	s.metrics.markOptimisticPayloadBuildSuccess(buildData.Slot)
+	s.metrics.markOptimisticPayloadBuildSuccess()
 }

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -115,7 +115,7 @@ func (ee *Engine) NotifyForkchoiceUpdate(
 
 			case errors.IsAny(err, engineerrors.ErrSyncingPayloadStatus):
 				ee.logger.Info("NotifyForkchoiceUpdate: EL syncing. Retrying...")
-				ee.metrics.markForkchoiceUpdateSyncing(req.State, err)
+				ee.metrics.markForkchoiceUpdateSyncing(req.State)
 				return nil, err
 
 			case client.IsNonFatalError(err):
@@ -173,7 +173,7 @@ func (ee *Engine) NotifyNewPayload(
 	_, err := backoff.Retry(
 		ctx,
 		func() (*common.ExecutionHash, error) {
-			ee.metrics.markNewPayloadCalled(payloadHash, payloadParentHash)
+			ee.metrics.markNewPayloadCalled()
 			lastValidHash, err := ee.ec.NewPayload(
 				ctx, req,
 			)

--- a/execution/engine/metrics.go
+++ b/execution/engine/metrics.go
@@ -68,7 +68,7 @@ func NewMetrics(factory metrics.Factory, logger log.Logger) *Metrics {
 				Name: "beacon_kit_execution_engine_new_payload",
 				Help: "Number of new payload calls",
 			},
-			[]string{"payload_block_hash", "payload_parent_block_hash"},
+			nil,
 		),
 		NewPayloadValid: factory.NewCounter(
 			metrics.CounterOpts{
@@ -103,21 +103,21 @@ func NewMetrics(factory metrics.Factory, logger log.Logger) *Metrics {
 				Name: "beacon_kit_execution_engine_new_payload_non_fatal_error",
 				Help: "Number of non-fatal errors during new payload",
 			},
-			[]string{"error"},
+			nil,
 		),
 		NewPayloadFatalError: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_execution_engine_new_payload_fatal_error",
 				Help: "Number of fatal errors during new payload",
 			},
-			[]string{"error"},
+			nil,
 		),
 		NewPayloadUndefinedError: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_execution_engine_new_payload_undefined_error",
 				Help: "Number of undefined errors during new payload",
 			},
-			[]string{"error"},
+			nil,
 		),
 
 		// Forkchoice update metrics
@@ -140,35 +140,35 @@ func NewMetrics(factory metrics.Factory, logger log.Logger) *Metrics {
 				Name: "beacon_kit_execution_engine_forkchoice_update_syncing",
 				Help: "Number of syncing forkchoice update responses",
 			},
-			[]string{"error"},
+			nil,
 		),
 		ForkchoiceUpdateInvalid: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_execution_engine_forkchoice_update_invalid",
 				Help: "Number of invalid forkchoice update responses",
 			},
-			[]string{"error"},
+			nil,
 		),
 		ForkchoiceUpdateFatalError: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_execution_engine_forkchoice_update_fatal_error",
 				Help: "Number of fatal errors during forkchoice update",
 			},
-			[]string{"error"},
+			nil,
 		),
 		ForkchoiceUpdateNonFatalError: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_execution_engine_forkchoice_update_non_fatal_error",
 				Help: "Number of non-fatal errors during forkchoice update",
 			},
-			[]string{"error"},
+			nil,
 		),
 		ForkchoiceUpdateUndefinedError: factory.NewCounter(
 			metrics.CounterOpts{
 				Name: "beacon_kit_execution_engine_forkchoice_update_undefined_error",
 				Help: "Number of undefined errors during forkchoice update",
 			},
-			[]string{"error"},
+			nil,
 		),
 
 		logger: logger,
@@ -176,14 +176,8 @@ func NewMetrics(factory metrics.Factory, logger log.Logger) *Metrics {
 }
 
 // markNewPayloadCalled increments the counter for new payload calls.
-func (m *Metrics) markNewPayloadCalled(
-	payloadHash common.ExecutionHash,
-	parentHash common.ExecutionHash,
-) {
-	m.NewPayload.With(
-		"payload_block_hash", payloadHash.Hex(),
-		"payload_parent_block_hash", parentHash.Hex(),
-	).Add(1)
+func (m *Metrics) markNewPayloadCalled() {
+	m.NewPayload.Add(1)
 }
 
 // markNewPayloadValid increments the counter for valid payloads.
@@ -249,7 +243,7 @@ func (m *Metrics) markNewPayloadNonFatalError(
 		"last_valid_hash", lastValidHash,
 		"error", err,
 	)
-	m.NewPayloadNonFatalError.With("error", err.Error()).Add(1)
+	m.NewPayloadNonFatalError.Add(1)
 }
 
 // markNewPayloadFatalError increments the counter for fatal errors.
@@ -265,7 +259,7 @@ func (m *Metrics) markNewPayloadFatalError(
 		"last_valid_hash", lastValidHash,
 		"error", err,
 	)
-	m.NewPayloadFatalError.With("error", err.Error()).Add(1)
+	m.NewPayloadFatalError.Add(1)
 }
 
 // markNewPayloadUndefinedError increments the counter for undefined errors.
@@ -279,7 +273,7 @@ func (m *Metrics) markNewPayloadUndefinedError(
 		"parent_hash", payloadHash,
 		"error", err,
 	)
-	m.NewPayloadUndefinedError.With("error", err.Error()).Add(1)
+	m.NewPayloadUndefinedError.Add(1)
 }
 
 // markNotifyForkchoiceUpdateCalled increments the counter for
@@ -310,10 +304,7 @@ func (m *Metrics) markForkchoiceUpdateValid(
 }
 
 // markForkchoiceUpdateSyncing increments the counter for syncing forkchoice updates.
-func (m *Metrics) markForkchoiceUpdateSyncing(
-	state *engineprimitives.ForkchoiceStateV1,
-	err error,
-) {
+func (m *Metrics) markForkchoiceUpdateSyncing(state *engineprimitives.ForkchoiceStateV1) {
 	m.logger.Warn(
 		"Received syncing payload status during forkchoice update. Awaiting execution client to finish sync.",
 		"head_block_hash",
@@ -323,7 +314,7 @@ func (m *Metrics) markForkchoiceUpdateSyncing(
 		"finalized_block_hash",
 		state.FinalizedBlockHash,
 	)
-	m.ForkchoiceUpdateSyncing.With("error", err.Error()).Add(1)
+	m.ForkchoiceUpdateSyncing.Add(1)
 }
 
 // markForkchoiceUpdateInvalid increments the counter for invalid forkchoice updates.
@@ -338,7 +329,7 @@ func (m *Metrics) markForkchoiceUpdateInvalid(
 		"finalized_block_hash", state.FinalizedBlockHash,
 		"error", err,
 	)
-	m.ForkchoiceUpdateInvalid.With("error", err.Error()).Add(1)
+	m.ForkchoiceUpdateInvalid.Add(1)
 }
 
 // markForkchoiceUpdateFatalError increments the counter for fatal errors
@@ -348,7 +339,7 @@ func (m *Metrics) markForkchoiceUpdateFatalError(err error) {
 		"Received fatal error during forkchoice update call",
 		"error", err,
 	)
-	m.ForkchoiceUpdateFatalError.With("error", err.Error()).Add(1)
+	m.ForkchoiceUpdateFatalError.Add(1)
 }
 
 // markForkchoiceUpdateNonFatalError increments the counter for non-fatal errors
@@ -358,7 +349,7 @@ func (m *Metrics) markForkchoiceUpdateNonFatalError(err error) {
 		"Received non-fatal error during forkchoice update call",
 		"error", err,
 	)
-	m.ForkchoiceUpdateNonFatalError.With("error", err.Error()).Add(1)
+	m.ForkchoiceUpdateNonFatalError.Add(1)
 }
 
 // markForkchoiceUpdateUndefinedError increments the counter for undefined
@@ -369,5 +360,5 @@ func (m *Metrics) markForkchoiceUpdateUndefinedError(err error) {
 		"error",
 		err,
 	)
-	m.ForkchoiceUpdateUndefinedError.With("error", err.Error()).Add(1)
+	m.ForkchoiceUpdateUndefinedError.Add(1)
 }

--- a/state-transition/core/metrics.go
+++ b/state-transition/core/metrics.go
@@ -46,14 +46,14 @@ func NewMetrics(factory metrics.Factory) *Metrics {
 				Name: "beacon_kit_state_block_tx_gas_used",
 				Help: "Transaction gas used in the block",
 			},
-			[]string{"block_number"},
+			nil,
 		),
 		BlockBlobGasUsed: factory.NewGauge(
 			metrics.GaugeOpts{
 				Name: "beacon_kit_state_block_blob_gas_used",
 				Help: "Blob gas used in the block",
 			},
-			[]string{"block_number"},
+			nil,
 		),
 		PartialWithdrawalsEnqueued: factory.NewGauge(
 			metrics.GaugeOpts{
@@ -100,10 +100,9 @@ func NewMetrics(factory metrics.Factory) *Metrics {
 	}
 }
 
-func (m *Metrics) gaugeBlockGasUsed(blockNumber, txGasUsed, blobGasUsed math.U64) {
-	blockNumberStr := blockNumber.Base10()
-	m.BlockTxGasUsed.With("block_number", blockNumberStr).Set(float64(txGasUsed.Unwrap()))
-	m.BlockBlobGasUsed.With("block_number", blockNumberStr).Set(float64(blobGasUsed.Unwrap()))
+func (m *Metrics) gaugeBlockGasUsed(txGasUsed, blobGasUsed math.U64) {
+	m.BlockTxGasUsed.Set(float64(txGasUsed.Unwrap()))
+	m.BlockBlobGasUsed.Set(float64(blobGasUsed.Unwrap()))
 }
 
 func (m *Metrics) gaugePartialWithdrawalsEnqueued(count int) {

--- a/state-transition/core/state_processor_payload.go
+++ b/state-transition/core/state_processor_payload.go
@@ -94,7 +94,7 @@ func (sp *StateProcessor) processExecutionPayload(
 
 	if txCtx.MeterGas() {
 		sp.metrics.gaugeBlockGasUsed(
-			payload.GetNumber(), payload.GetGasUsed(), payload.GetBlobGasUsed(),
+			payload.GetGasUsed(), payload.GetBlobGasUsed(),
 		)
 	}
 


### PR DESCRIPTION
This PR addresses a metrics issue by removing unbounded labels from Prometheus metrics that can cause cardinality explosion and degrade system performance in our monitoring systems.

I believe it should be fine to remove these labels as we should have information about them in our logs/loki.

Note: if any Grafana dashboards relied on these labels, they may need to be updated to reflect the new metric structure.