### PR TITLE
upgrade go to v1.25.3 to address vulnerability from go stdlib

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.3"
           check-latest: true
           cache-dependency-path: "**/*.sum"
         if: ${{ !(matrix.args == 'test-forge-cover' || matrix.args == 'test-forge-fuzz') }}
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.3"
           check-latest: true
           cache-dependency-path: "**/*.sum"
       - name: Set up QEMU

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25.0"
+          go-version: "1.25.3"
         env:
           GOOS: ${{ matrix.configs.target-os }}
           GOARCH: ${{ matrix.configs.arch }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -722,7 +722,7 @@ func ProvideBlockchainService(
 ## Build Requirements
 
 ### Dependencies
-- Go 1.25.0+
+- Go 1.25.3+
 - Docker (for running EL clients)
 - Foundry (for Solidity contracts)
 - Make (GNU Make)

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ###           Stage 0 - Build Arguments             ###
 #######################################################
 
-ARG GO_VERSION=1.25.0
+ARG GO_VERSION=1.25.3
 ARG RUNNER_IMAGE=alpine:3.20
 ARG BUILD_TAGS="netgo,muslc,blst,bls12381,pebbledb"
 ARG NAME=beacond

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ BeaconKit supports the following execution clients:
 **Prerequisites:**
 
 - [Docker](https://docs.docker.com/engine/install/)
-- [Golang 1.25.0+](https://go.dev/doc/install)
+- [Golang 1.25.3+](https://go.dev/doc/install)
 - [Foundry](https://book.getfoundry.sh/)
 
 Start by opening two terminals side-by-side:
@@ -85,7 +85,7 @@ The chainspec is set with the `--beacon-kit.chain-spec` command line option, and
 
 You can override the default operating directories for beacond with the `--home <path>` option.
 
-The [Berachain Node Quickstart](https://docs.berachain.com/nodes/quickstart) provides a quick deployment of mainnet or testnet on your desk. 
+The [Berachain Node Quickstart](https://docs.berachain.com/nodes/quickstart) provides a quick deployment of mainnet or testnet on your desk.
 
 For developing with beacon-kit, you have options:
 1. see the Makefile for targets to start stand-alone processes

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/berachain/beacon-kit
 
-go 1.25
+go 1.25.3
 
 replace (
 	github.com/cometbft/cometbft => github.com/berachain/cometbft v1.0.1-0.20251015081901-8394c619874a


### PR DESCRIPTION
Update to Go 1.25.3 as the `make vulncheck` linter was failing due to reported vulnerabilities in our Go's stdlib which has now been fixed in  Go 1.25.3

Before:

```
make vulncheck
--> Running govulncheck
=== Symbol Results ===

Vulnerability #1: GO-2025-4013
    Panic when validating certificates with DSA public keys in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4013
  Standard library
    Found in: crypto/x509@go1.25.1
    Fixed in: crypto/x509@go1.25.2
    Example traces found:
      #1: node-api/middleware/middleware.go:54:21: middleware.Middleware.Run calls echo.Echo.Start, which eventually calls x509.Certificate.Verify

Vulnerability #2: GO-2025-4012
    Lack of limit when parsing cookies can cause memory exhaustion in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-4012
  Standard library
    Found in: net/http@go1.25.1
    Fixed in: net/http@go1.25.2
    Example traces found:
      #1: execution/client/ethclient/rpc/client.go:173:32: rpc.client.callRaw calls http.Client.Do
      #2: common/types.go:531:13: common.Pubkey.Format calls fmt.Fprint, which eventually calls http.Request.Cookie
      #3: consensus/cometbft/service/service.go:234:21: service.Start calls service.BaseService.Start, which eventually calls http.Response.Cookies
...
Your code is affected by 8 vulnerabilities from the Go standard library.
This scan also found 1 vulnerability in packages you import and 5
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more
```

After:

```
 make vulncheck
--> Running govulncheck
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 0 vulnerabilities in packages you import and 4
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```