### PR TITLE
fix: flaky tests by using thread-safe SyncBuffer + refactor test cleanup

### DIFF
--- a/testing/simulated/payload_cache_test.go
+++ b/testing/simulated/payload_cache_test.go
@@ -23,7 +23,6 @@
 package simulated_test
 
 import (
-	"bytes"
 	"context"
 	"path"
 	"strings"
@@ -94,10 +93,10 @@ func (s *PayloadCacheSuite) SetupTest() {
 	s.Reth.ElHandle = rethHandle
 
 	// Prepare a logger backed by a buffer to capture logs for assertions.
-	s.Geth.LogBuffer = new(bytes.Buffer)
+	s.Geth.LogBuffer = &simulated.SyncBuffer{}
 	logger := phuslu.NewLogger(s.Geth.LogBuffer, nil)
 
-	s.Reth.LogBuffer = new(bytes.Buffer)
+	s.Reth.LogBuffer = &simulated.SyncBuffer{}
 	rethLogger := phuslu.NewLogger(s.Reth.LogBuffer, nil)
 
 	// Build the Beacon node with the simulated Comet component and electra genesis chain spec
@@ -154,24 +153,8 @@ func (s *PayloadCacheSuite) SetupTest() {
 
 // TearDownTest cleans up the test environment.
 func (s *PayloadCacheSuite) TearDownTest() {
-	// If the test has failed, log additional information.
-	if s.T().Failed() {
-		s.T().Log("GETH CL LOGS:")
-		s.T().Log(s.Geth.LogBuffer.String())
-		s.T().Log("RETH CL LOGS:")
-		s.T().Log(s.Reth.LogBuffer.String())
-	}
-	if err := s.Geth.ElHandle.Close(); err != nil {
-		s.T().Error("Error closing Geth EL handle:", err)
-	}
-	if err := s.Reth.ElHandle.Close(); err != nil {
-		s.T().Error("Error closing Reth EL handle:", err)
-	}
-	// mimics the behaviour of shutdown func
-	s.Geth.CtxAppCancelFn()
-	s.Geth.TestNode.ServiceRegistry.StopAll()
-	s.Reth.CtxAppCancelFn()
-	s.Reth.TestNode.ServiceRegistry.StopAll()
+	s.Geth.CleanupTestWithLabel(s.T(), "GETH")
+	s.Reth.CleanupTestWithLabel(s.T(), "RETH")
 }
 
 // This tests a reth validator proposing a block. It then accepts the proposal in

--- a/testing/simulated/pectra_genesis_test.go
+++ b/testing/simulated/pectra_genesis_test.go
@@ -23,7 +23,6 @@
 package simulated_test
 
 import (
-	"bytes"
 	"context"
 	"math/big"
 	"path"
@@ -86,7 +85,7 @@ func (s *PectraGenesisSuite) SetupTest() {
 	s.ElHandle = elHandle
 
 	// Prepare a logger backed by a buffer to capture logs for assertions.
-	s.LogBuffer = new(bytes.Buffer)
+	s.LogBuffer = &simulated.SyncBuffer{}
 	logger := phuslu.NewLogger(s.LogBuffer, nil)
 
 	// Build the Beacon node with the simulated Comet component and electra genesis chain spec
@@ -120,16 +119,7 @@ func (s *PectraGenesisSuite) SetupTest() {
 
 // TearDownTest cleans up the test environment.
 func (s *PectraGenesisSuite) TearDownTest() {
-	// If the test has failed, log additional information.
-	if s.T().Failed() {
-		s.T().Log(s.LogBuffer.String())
-	}
-	if err := s.ElHandle.Close(); err != nil {
-		s.T().Error("Error closing EL handle:", err)
-	}
-	// mimics the behaviour of shutdown func
-	s.CtxAppCancelFn()
-	s.TestNode.ServiceRegistry.StopAll()
+	s.CleanupTest(s.T())
 }
 
 func (s *PectraGenesisSuite) TestFullLifecycle_WithoutRequests_IsSuccessful() {

--- a/testing/simulated/pectra_withdrawal_test.go
+++ b/testing/simulated/pectra_withdrawal_test.go
@@ -23,7 +23,6 @@
 package simulated_test
 
 import (
-	"bytes"
 	"context"
 	"math/big"
 	"path"
@@ -93,7 +92,7 @@ func (s *PectraWithdrawalSuite) SetupTest() {
 	s.ElHandle = elHandle
 
 	// Prepare a logger backed by a buffer to capture logs for assertions.
-	s.LogBuffer = new(bytes.Buffer)
+	s.LogBuffer = &simulated.SyncBuffer{}
 	logger := phuslu.NewLogger(s.LogBuffer, nil)
 
 	// Build the Beacon node with the simulated Comet component and electra genesis chain spec
@@ -127,16 +126,7 @@ func (s *PectraWithdrawalSuite) SetupTest() {
 
 // TearDownTest cleans up the test environment.
 func (s *PectraWithdrawalSuite) TearDownTest() {
-	// If the test has failed, log additional information.
-	if s.T().Failed() {
-		s.T().Log(s.LogBuffer.String())
-	}
-	if err := s.ElHandle.Close(); err != nil {
-		s.T().Error("Error closing EL handle:", err)
-	}
-	// mimics the behaviour of shutdown func
-	s.CtxAppCancelFn()
-	s.TestNode.ServiceRegistry.StopAll()
+	s.CleanupTest(s.T())
 }
 
 // TestExcessValidatorBeforeFork_CorrectlyEvicted verifies that when a validator’s deposit

--- a/testing/simulated/simulated_test.go
+++ b/testing/simulated/simulated_test.go
@@ -23,7 +23,6 @@
 package simulated_test
 
 import (
-	"bytes"
 	"context"
 	"path"
 	"testing"
@@ -73,7 +72,7 @@ func (s *SimulatedSuite) SetupTest() {
 	s.ElHandle = elHandle
 
 	// Prepare a logger backed by a buffer to capture logs for assertions.
-	s.LogBuffer = new(bytes.Buffer)
+	s.LogBuffer = &simulated.SyncBuffer{}
 	logger := phuslu.NewLogger(s.LogBuffer, nil)
 
 	// Build the Beacon node with the simulated Comet component.
@@ -106,14 +105,5 @@ func (s *SimulatedSuite) SetupTest() {
 
 // TearDownTest cleans up the test environment.
 func (s *SimulatedSuite) TearDownTest() {
-	// If the test has failed, log additional information.
-	if s.T().Failed() {
-		s.T().Log(s.LogBuffer.String())
-	}
-	if err := s.ElHandle.Close(); err != nil {
-		s.T().Error("Error closing EL handle:", err)
-	}
-	// mimics the behaviour of shutdown func
-	s.CtxAppCancelFn()
-	s.TestNode.ServiceRegistry.StopAll()
+	s.CleanupTest(s.T())
 }


### PR DESCRIPTION
This PR tries to address flaky tests when running simulated tests (like when running `make test-unit-cover`) where on my macbook I often see failed tests with error `timeout waiting for services to start`. 

The logic that decides this (`WaitTillServicesStarted`) has a data race when inspecting the log buffer, which might explain this. 

This PR also refactors the `TearDownTest` callsites by moving that logic into a `SharedAccessors` helper method `CleanupTest` plus also adds better error checks that could cause panics 

Example:

```
make test-unit-cover
...
pectra_fork_test.go:146: 
 Error Trace:    /Users/fridrikasmundsson/workspace/beacon-kit/testing/simulated/pectra_fork_test.go:146
           /Users/fridrikasmundsson/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:188
 Error:          Received unexpected error:
  timeout waiting for services to start
  github.com/berachain/beacon-kit/testing/simulated.WaitTillServicesStarted
          /Users/fridrikasmundsson/workspace/beacon-kit/testing/simulated/utils.go:212
  github.com/berachain/beacon-kit/testing/simulated_test.(*PectraForkSuite).SetupTest
          /Users/fridrikasmundsson/workspace/beacon-kit/testing/simulated/pectra_fork_test.go:145
  github.com/stretchr/testify/suite.Run.func1
          /Users/fridrikasmundsson/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:188
  testing.tRunner
          /usr/local/go/src/testing/testing.go:1934
  runtime.goexit
          /usr/local/go/src/runtime/asm_arm64.s:1268
 Test:           TestPectraForkSuite/TestMaliciousUser_MakesConsolidationRequest_IsIgnored
...
pectra_fork_test.go:146: 
 Error Trace:    /Users/fridrikasmundsson/workspace/beacon-kit/testing/simulated/pectra_fork_test.go:146
           /Users/fridrikasmundsson/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:188
 Error:          Received unexpected error:
  timeout waiting for services to start
  github.com/berachain/beacon-kit/testing/simulated.WaitTillServicesStarted
          /Users/fridrikasmundsson/workspace/beacon-kit/testing/simulated/utils.go:212
  github.com/berachain/beacon-kit/testing/simulated_test.(*PectraForkSuite).SetupTest
          /Users/fridrikasmundsson/workspace/beacon-kit/testing/simulated/pectra_fork_test.go:145
  github.com/stretchr/testify/suite.Run.func1
          /Users/fridrikasmundsson/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:188
  testing.tRunner
          /usr/local/go/src/testing/testing.go:1934
  runtime.goexit
          /usr/local/go/src/runtime/asm_arm64.s:1268
 Test:           TestPectraForkSuite/TestValidProposer_ProposesPreForkBlockWithPostForkConsensusTimestamp_IsRejected
```
