### PR TITLE
Add cli for preconfhealthcheckinterval

### DIFF
--- a/cli/flags/flags.go
+++ b/cli/flags/flags.go
@@ -76,15 +76,16 @@ const (
 	NodeAPILogging = nodeAPIRoot + "logging"
 
 	// Preconf Config.
-	preconfRoot          = beaconKitRoot + "preconf."
-	PreconfEnabled       = preconfRoot + "enabled"
-	PreconfSequencerMode = preconfRoot + "sequencer-mode"
-	PreconfWhitelistPath = preconfRoot + "whitelist-path"
-	PreconfValidatorJWTs = preconfRoot + "validator-jwts-path"
-	PreconfAPIPort       = preconfRoot + "api-port"
-	PreconfSequencerURL  = preconfRoot + "sequencer-url"
-	PreconfSequencerJWT  = preconfRoot + "sequencer-jwt-path"
-	PreconfFetchTimeout  = preconfRoot + "fetch-timeout"
+	preconfRoot                = beaconKitRoot + "preconf."
+	PreconfEnabled             = preconfRoot + "enabled"
+	PreconfSequencerMode       = preconfRoot + "sequencer-mode"
+	PreconfWhitelistPath       = preconfRoot + "whitelist-path"
+	PreconfValidatorJWTs       = preconfRoot + "validator-jwts-path"
+	PreconfAPIPort             = preconfRoot + "api-port"
+	PreconfSequencerURL        = preconfRoot + "sequencer-url"
+	PreconfSequencerJWT        = preconfRoot + "sequencer-jwt-path"
+	PreconfFetchTimeout        = preconfRoot + "fetch-timeout"
+	PreconfHealthCheckInterval = preconfRoot + "health-check-interval"
 
 	// BLS Config.
 	PrivValidatorKeyFile   = "priv_validator_key_file"
@@ -227,5 +228,10 @@ func AddBeaconKitFlags(startCmd *cobra.Command) {
 		PreconfFetchTimeout,
 		defaultCfg.Preconf.FetchTimeout,
 		"timeout for fetching payload from sequencer",
+	)
+	startCmd.Flags().Duration(
+		PreconfHealthCheckInterval,
+		defaultCfg.Preconf.HealthCheckInterval,
+		"how often to probe sequencer health endpoint when it becomes unavailable",
 	)
 }


### PR DESCRIPTION
This Pr adds `--beacon-kit.preconf.health-check-interval` as a CLI flag (default 10s).

On devnet-core, preconf flags are passed via CLI args from the Helm chart. Since `health-check-interval` was only configurable via `app.toml` and had no CLI flag, it defaulted to `0s` when not present in the TOML config, causing a startup panic: `preconf enabled but sequencer health check interval is set to <= 0`

Adding the CLI flag ensures the 10s default applies even when the value isn't set in `app.toml`.