### PR TITLE
feat(preconf): verify requesting validator is the expected proposer before serving payloads

### DIFF
--- a/beacon/blockchain/payload_test.go
+++ b/beacon/blockchain/payload_test.go
@@ -286,6 +286,7 @@ func setupOptimisticPayloadTests(t *testing.T, cs chain.Spec) (
 		ts,
 		nil, // preconf.Config unused in this test
 		nil, // preconf.Whitelist unused in this test
+		nil, // preconf.ProposerTracker unused in this test
 	)
 	return chain, st, cms, ctx, sp, b, sb, eng, depStore
 }

--- a/beacon/blockchain/process_proposal.go
+++ b/beacon/blockchain/process_proposal.go
@@ -329,6 +329,9 @@ func (s *Service) VerifyIncomingBlock(
 				s.logger.Error("Failed to get next proposer pubkey", "error", pubkeyErr)
 			} else {
 				shouldBuildNextPayload = s.preconfWhitelist.IsWhitelisted(expectedProposerPubkey)
+				// Record expected proposer so the preconf server can verify
+				// that payload requests come from the correct validator.
+				s.preconfProposerTracker.SetExpectedProposer(blkSlot+1, expectedProposerPubkey)
 			}
 			s.logger.Info("Sequencer mode: determined next proposer",
 				"current_block_slot", blkSlot.Base10(),

--- a/beacon/blockchain/round_change.go
+++ b/beacon/blockchain/round_change.go
@@ -22,6 +22,8 @@ package blockchain
 
 import (
 	"context"
+
+	"github.com/berachain/beacon-kit/primitives/math"
 )
 
 // HandleRoundChange is called when CometBFT enters a new consensus round
@@ -44,8 +46,13 @@ func (s *Service) HandleRoundChange(
 
 	st := s.storageBackend.StateFromContext(ctx)
 
+	slot := math.Slot(height) //#nosec:G115 // CometBFT heights are always positive.
+
 	proposerPubkey, err := s.getNextProposerPubkey(st, proposerAddress)
 	if err != nil {
+		// Clear the tracker so the stale proposer can no longer fetch payloads.
+		s.preconfProposerTracker.ClearExpectedProposer(slot)
+
 		s.logger.Warn("Round change: failed to resolve proposer pubkey",
 			"height", height,
 			"round", round,
@@ -53,6 +60,11 @@ func (s *Service) HandleRoundChange(
 		)
 		return
 	}
+
+	// Update expected proposer immediately so the preconf server rejects
+	// requests from the previous round's proposer, even if the new proposer
+	// is not whitelisted or prefetch fails below.
+	s.preconfProposerTracker.SetExpectedProposer(slot, proposerPubkey)
 
 	if !s.preconfWhitelist.IsWhitelisted(proposerPubkey) {
 		s.logger.Debug("Round change: new proposer not whitelisted, skipping rebuild",

--- a/beacon/blockchain/service.go
+++ b/beacon/blockchain/service.go
@@ -84,8 +84,7 @@ type Service struct {
 	// preconfProposerTracker tracks the expected proposer pubkey for upcoming slots.
 	// The sequencer writes entries here so the preconf server can verify that
 	// payload requests come from the correct proposer.
-	// Can be nil if preconf is disabled.
-	preconfProposerTracker *preconf.ProposerTracker
+	preconfProposerTracker preconf.ProposerTracker
 }
 
 // NewService creates a new validator service.
@@ -101,7 +100,7 @@ func NewService(
 	telemetrySink TelemetrySink,
 	preconfCfg *preconf.Config,
 	preconfWhitelist preconf.Whitelist,
-	preconfProposerTracker *preconf.ProposerTracker,
+	preconfProposerTracker preconf.ProposerTracker,
 ) *Service {
 	return &Service{
 		storageBackend:         storageBackend,

--- a/beacon/blockchain/service.go
+++ b/beacon/blockchain/service.go
@@ -80,6 +80,12 @@ type Service struct {
 	// - Validator: checks if self is whitelisted to fetch payload from sequencer
 	// Can be nil if preconf is disabled.
 	preconfWhitelist preconf.Whitelist
+
+	// preconfProposerTracker tracks the expected proposer pubkey for upcoming slots.
+	// The sequencer writes entries here so the preconf server can verify that
+	// payload requests come from the correct proposer.
+	// Can be nil if preconf is disabled.
+	preconfProposerTracker *preconf.ProposerTracker
 }
 
 // NewService creates a new validator service.
@@ -95,22 +101,24 @@ func NewService(
 	telemetrySink TelemetrySink,
 	preconfCfg *preconf.Config,
 	preconfWhitelist preconf.Whitelist,
+	preconfProposerTracker *preconf.ProposerTracker,
 ) *Service {
 	return &Service{
-		storageBackend:       storageBackend,
-		blobProcessor:        blobProcessor,
-		depositContract:      depositContract,
-		eth1FollowDistance:   math.U64(chainSpec.Eth1FollowDistance()),
-		failedBlocks:         make(map[math.Slot]struct{}),
-		logger:               logger,
-		chainSpec:            chainSpec,
-		executionEngine:      executionEngine,
-		localBuilder:         localBuilder,
-		stateProcessor:       stateProcessor,
-		metrics:              newChainMetrics(telemetrySink),
-		forceStartupSyncOnce: new(sync.Once),
-		preconfCfg:           preconfCfg,
-		preconfWhitelist:     preconfWhitelist,
+		storageBackend:         storageBackend,
+		blobProcessor:          blobProcessor,
+		depositContract:        depositContract,
+		eth1FollowDistance:     math.U64(chainSpec.Eth1FollowDistance()),
+		failedBlocks:           make(map[math.Slot]struct{}),
+		logger:                 logger,
+		chainSpec:              chainSpec,
+		executionEngine:        executionEngine,
+		localBuilder:           localBuilder,
+		stateProcessor:         stateProcessor,
+		metrics:                newChainMetrics(telemetrySink),
+		forceStartupSyncOnce:   new(sync.Once),
+		preconfCfg:             preconfCfg,
+		preconfWhitelist:       preconfWhitelist,
+		preconfProposerTracker: preconfProposerTracker,
 	}
 }
 

--- a/beacon/preconf/proposer_tracker.go
+++ b/beacon/preconf/proposer_tracker.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package preconf
+
+import (
+	"sync"
+
+	"github.com/berachain/beacon-kit/primitives/crypto"
+	"github.com/berachain/beacon-kit/primitives/math"
+)
+
+// ProposerTracker tracks the expected proposer for the next slot.
+// Written by the blockchain service, read by the preconf server.
+type ProposerTracker struct {
+	mu       sync.RWMutex
+	slot     math.Slot
+	expected crypto.BLSPubkey
+}
+
+// NewProposerTracker creates a new ProposerTracker.
+func NewProposerTracker() *ProposerTracker {
+	return &ProposerTracker{}
+}
+
+// SetExpectedProposer records the expected proposer for a slot.
+func (pt *ProposerTracker) SetExpectedProposer(slot math.Slot, pubkey crypto.BLSPubkey) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	pt.slot = slot
+	pt.expected = pubkey
+}
+
+// ClearExpectedProposer removes the expected proposer for a slot so that no
+// validator is considered the expected proposer.
+func (pt *ProposerTracker) ClearExpectedProposer(slot math.Slot) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	if pt.slot == slot {
+		pt.expected = crypto.BLSPubkey{}
+	}
+}
+
+// IsExpectedProposer returns true if pubkey matches the expected proposer for slot.
+func (pt *ProposerTracker) IsExpectedProposer(slot math.Slot, pubkey crypto.BLSPubkey) bool {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+	return pt.slot == slot && pt.expected == pubkey
+}

--- a/beacon/preconf/proposer_tracker.go
+++ b/beacon/preconf/proposer_tracker.go
@@ -28,29 +28,37 @@ import (
 )
 
 // ProposerTracker tracks the expected proposer for the next slot.
-// Written by the blockchain service, read by the preconf server.
-type ProposerTracker struct {
+type ProposerTracker interface {
+	// SetExpectedProposer records the expected proposer for a slot.
+	SetExpectedProposer(slot math.Slot, pubkey crypto.BLSPubkey)
+	// ClearExpectedProposer clears the expected proposer if the slot matches.
+	ClearExpectedProposer(slot math.Slot)
+	// IsExpectedProposer returns true if pubkey matches the expected proposer for slot.
+	IsExpectedProposer(slot math.Slot, pubkey crypto.BLSPubkey) bool
+}
+
+// proposerTracker is the concrete implementation of ProposerTracker.
+type proposerTracker struct {
 	mu       sync.RWMutex
 	slot     math.Slot
 	expected crypto.BLSPubkey
 }
 
-// NewProposerTracker creates a new ProposerTracker.
-func NewProposerTracker() *ProposerTracker {
-	return &ProposerTracker{}
+// NewProposerTracker creates a new ProposerTracker. A freshly constructed
+// tracker has no expected proposer, so IsExpectedProposer returns false until
+// SetExpectedProposer is called.
+func NewProposerTracker() ProposerTracker {
+	return &proposerTracker{}
 }
 
-// SetExpectedProposer records the expected proposer for a slot.
-func (pt *ProposerTracker) SetExpectedProposer(slot math.Slot, pubkey crypto.BLSPubkey) {
+func (pt *proposerTracker) SetExpectedProposer(slot math.Slot, pubkey crypto.BLSPubkey) {
 	pt.mu.Lock()
 	defer pt.mu.Unlock()
 	pt.slot = slot
 	pt.expected = pubkey
 }
 
-// ClearExpectedProposer removes the expected proposer for a slot so that no
-// validator is considered the expected proposer.
-func (pt *ProposerTracker) ClearExpectedProposer(slot math.Slot) {
+func (pt *proposerTracker) ClearExpectedProposer(slot math.Slot) {
 	pt.mu.Lock()
 	defer pt.mu.Unlock()
 	if pt.slot == slot {
@@ -58,8 +66,7 @@ func (pt *ProposerTracker) ClearExpectedProposer(slot math.Slot) {
 	}
 }
 
-// IsExpectedProposer returns true if pubkey matches the expected proposer for slot.
-func (pt *ProposerTracker) IsExpectedProposer(slot math.Slot, pubkey crypto.BLSPubkey) bool {
+func (pt *proposerTracker) IsExpectedProposer(slot math.Slot, pubkey crypto.BLSPubkey) bool {
 	pt.mu.RLock()
 	defer pt.mu.RUnlock()
 	return pt.slot == slot && pt.expected == pubkey

--- a/beacon/preconf/server.go
+++ b/beacon/preconf/server.go
@@ -64,7 +64,7 @@ type Server struct {
 	logger                 log.Logger
 	validatorJWTs          ValidatorJWTs
 	whitelist              Whitelist
-	preconfProposerTracker *ProposerTracker
+	preconfProposerTracker ProposerTracker
 	payloadProvider        PayloadProvider
 	port                   int
 
@@ -77,7 +77,7 @@ func NewServer(
 	logger log.Logger,
 	validatorJWTs ValidatorJWTs,
 	whitelist Whitelist,
-	preconfProposerTracker *ProposerTracker,
+	preconfProposerTracker ProposerTracker,
 	payloadProvider PayloadProvider,
 	port int,
 ) *Server {

--- a/beacon/preconf/server.go
+++ b/beacon/preconf/server.go
@@ -61,11 +61,12 @@ type PayloadProvider interface {
 
 // Server is the preconf API server that serves GetPayload requests from validators.
 type Server struct {
-	logger          log.Logger
-	validatorJWTs   ValidatorJWTs
-	whitelist       Whitelist
-	payloadProvider PayloadProvider
-	port            int
+	logger                 log.Logger
+	validatorJWTs          ValidatorJWTs
+	whitelist              Whitelist
+	preconfProposerTracker *ProposerTracker
+	payloadProvider        PayloadProvider
+	port                   int
 
 	mu         sync.RWMutex
 	httpServer *http.Server
@@ -76,15 +77,17 @@ func NewServer(
 	logger log.Logger,
 	validatorJWTs ValidatorJWTs,
 	whitelist Whitelist,
+	preconfProposerTracker *ProposerTracker,
 	payloadProvider PayloadProvider,
 	port int,
 ) *Server {
 	return &Server{
-		logger:          logger,
-		validatorJWTs:   validatorJWTs,
-		whitelist:       whitelist,
-		payloadProvider: payloadProvider,
-		port:            port,
+		logger:                 logger,
+		validatorJWTs:          validatorJWTs,
+		whitelist:              whitelist,
+		preconfProposerTracker: preconfProposerTracker,
+		payloadProvider:        payloadProvider,
+		port:                   port,
 	}
 }
 
@@ -190,6 +193,16 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 	var req GetPayloadRequest
 	if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
 		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	// Verify the requesting validator is the expected proposer for this slot.
+	if !s.preconfProposerTracker.IsExpectedProposer(req.Slot, pubkey) {
+		s.logger.Warn("Validator is not the expected proposer for slot",
+			"pubkey", pubkey.String(),
+			"slot", req.Slot,
+		)
+		s.writeError(w, http.StatusForbidden, "not the expected proposer for this slot")
 		return
 	}
 

--- a/beacon/preconf/server_test.go
+++ b/beacon/preconf/server_test.go
@@ -153,14 +153,14 @@ func TestServer_ProposerCheck(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		setupTracker func() *preconf.ProposerTracker
+		setupTracker func() preconf.ProposerTracker
 		requestJWT   *jwt.Secret
 		wantStatus   int
 		wantContains string
 	}{
 		{
 			name: "expected proposer gets payload",
-			setupTracker: func() *preconf.ProposerTracker {
+			setupTracker: func() preconf.ProposerTracker {
 				tr := preconf.NewProposerTracker()
 				tr.SetExpectedProposer(targetSlot, validatorA)
 				return tr
@@ -170,7 +170,7 @@ func TestServer_ProposerCheck(t *testing.T) {
 		},
 		{
 			name: "non-expected proposer is rejected",
-			setupTracker: func() *preconf.ProposerTracker {
+			setupTracker: func() preconf.ProposerTracker {
 				tr := preconf.NewProposerTracker()
 				tr.SetExpectedProposer(targetSlot, validatorA)
 				return tr

--- a/beacon/preconf/server_test.go
+++ b/beacon/preconf/server_test.go
@@ -36,6 +36,7 @@ import (
 	engineprimitives "github.com/berachain/beacon-kit/engine-primitives/engine-primitives"
 	"github.com/berachain/beacon-kit/log/noop"
 	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/crypto"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/net/jwt"
 	"github.com/berachain/beacon-kit/primitives/version"
@@ -97,6 +98,11 @@ func TestServer_HandleGetPayload(t *testing.T) {
 		},
 	}
 
+	jwtToValidator := map[*jwt.Secret]crypto.BLSPubkey{
+		secretA: validatorA,
+		secretB: validatorB,
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -104,10 +110,15 @@ func TestServer_HandleGetPayload(t *testing.T) {
 			provider := &mockPayloadProvider{
 				hasPayload: tt.payloadExists,
 			}
+			tracker := preconf.NewProposerTracker()
+			if pubkey, ok := jwtToValidator[tt.requestJWT]; ok {
+				tracker.SetExpectedProposer(tt.requestSlot, pubkey)
+			}
 			server := preconf.NewServer(
 				noop.NewLogger[any](),
 				preconf.ValidatorJWTs{validatorA: secretA, validatorB: secretB},
 				newTestWhitelist(t, pubkeyAHex, pubkeyBHex),
+				tracker,
 				provider,
 				0,
 			)
@@ -130,10 +141,86 @@ func TestServer_HandleGetPayload(t *testing.T) {
 	}
 }
 
+func TestServer_ProposerCheck(t *testing.T) {
+	t.Parallel()
+
+	validatorA, _ := parser.ConvertPubkey(pubkeyAHex)
+	validatorB, _ := parser.ConvertPubkey(pubkeyBHex)
+	secretA, _ := jwt.NewFromHex(secretAHex)
+	secretB, _ := jwt.NewFromHex(secretBHex)
+
+	const targetSlot math.Slot = 100
+
+	tests := []struct {
+		name         string
+		setupTracker func() *preconf.ProposerTracker
+		requestJWT   *jwt.Secret
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name: "expected proposer gets payload",
+			setupTracker: func() *preconf.ProposerTracker {
+				tr := preconf.NewProposerTracker()
+				tr.SetExpectedProposer(targetSlot, validatorA)
+				return tr
+			},
+			requestJWT: secretA,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "non-expected proposer is rejected",
+			setupTracker: func() *preconf.ProposerTracker {
+				tr := preconf.NewProposerTracker()
+				tr.SetExpectedProposer(targetSlot, validatorA)
+				return tr
+			},
+			requestJWT:   secretB,
+			wantStatus:   http.StatusForbidden,
+			wantContains: "not the expected proposer",
+		},
+		{
+			name:         "no tracked proposer for slot is rejected",
+			setupTracker: preconf.NewProposerTracker,
+			requestJWT:   secretA,
+			wantStatus:   http.StatusForbidden,
+			wantContains: "not the expected proposer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := preconf.NewServer(
+				noop.NewLogger[any](),
+				preconf.ValidatorJWTs{validatorA: secretA, validatorB: secretB},
+				newTestWhitelist(t, pubkeyAHex, pubkeyBHex),
+				tt.setupTracker(),
+				&mockPayloadProvider{hasPayload: true},
+				0,
+			)
+
+			body, _ := json.Marshal(preconf.GetPayloadRequest{Slot: targetSlot})
+			req := httptest.NewRequest(http.MethodPost, preconf.PayloadEndpoint, bytes.NewReader(body))
+			token, _ := tt.requestJWT.BuildSignedToken()
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rec := httptest.NewRecorder()
+			server.Handler().ServeHTTP(rec, req)
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+			if tt.wantContains != "" {
+				require.Contains(t, rec.Body.String(), tt.wantContains)
+			}
+		})
+	}
+}
+
 func TestServer_RejectsNonPostMethods(t *testing.T) {
 	t.Parallel()
 
-	server := preconf.NewServer(noop.NewLogger[any](), nil, nil, nil, 0)
+	server := preconf.NewServer(noop.NewLogger[any](), nil, nil, nil, nil, 0)
 
 	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
 		req := httptest.NewRequest(method, preconf.PayloadEndpoint, nil)
@@ -176,7 +263,7 @@ func TestServer_OnSIGHUP(t *testing.T) {
 	wl, err := preconf.NewWhitelist(tmpFile)
 	require.NoError(t, err)
 
-	server := preconf.NewServer(noop.NewLogger[any](), nil, wl, nil, 0)
+	server := preconf.NewServer(noop.NewLogger[any](), nil, wl, nil, nil, 0)
 
 	require.True(t, wl.IsWhitelisted(pkA))
 	require.False(t, wl.IsWhitelisted(pkB))

--- a/cmd/beacond/defaults.go
+++ b/cmd/beacond/defaults.go
@@ -43,6 +43,7 @@ func DefaultComponents() []any {
 		components.ProvideJWTSecret,
 		components.ProvideLocalBuilder,
 		components.ProvidePreconfWhitelist,
+		components.ProvidePreconfProposerTracker,
 		components.ProvidePreconfServer,
 		components.ProvidePreconfClient,
 		components.ProvideReportingService,

--- a/node-core/components/chain_service.go
+++ b/node-core/components/chain_service.go
@@ -37,17 +37,18 @@ import (
 type ChainServiceInput struct {
 	depinject.In
 
-	Cfg                   *config.Config
-	ChainSpec             chain.Spec
-	ExecutionEngine       *engine.Engine
-	LocalBuilder          LocalBuilder
-	Logger                *phuslu.Logger
-	StateProcessor        StateProcessor
-	StorageBackend        *storage.Backend
-	BlobProcessor         BlobProcessor
-	TelemetrySink         *metrics.TelemetrySink
-	BeaconDepositContract deposit.Contract
-	PreconfWhitelist      preconf.Whitelist
+	Cfg                    *config.Config
+	ChainSpec              chain.Spec
+	ExecutionEngine        *engine.Engine
+	LocalBuilder           LocalBuilder
+	Logger                 *phuslu.Logger
+	StateProcessor         StateProcessor
+	StorageBackend         *storage.Backend
+	BlobProcessor          BlobProcessor
+	TelemetrySink          *metrics.TelemetrySink
+	BeaconDepositContract  deposit.Contract
+	PreconfWhitelist       preconf.Whitelist
+	PreconfProposerTracker *preconf.ProposerTracker
 }
 
 // ProvideChainService is a depinject provider for the blockchain service.
@@ -64,5 +65,6 @@ func ProvideChainService(in ChainServiceInput) *blockchain.Service {
 		in.TelemetrySink,
 		&in.Cfg.Preconf,
 		in.PreconfWhitelist,
+		in.PreconfProposerTracker,
 	)
 }

--- a/node-core/components/chain_service.go
+++ b/node-core/components/chain_service.go
@@ -48,7 +48,7 @@ type ChainServiceInput struct {
 	TelemetrySink          *metrics.TelemetrySink
 	BeaconDepositContract  deposit.Contract
 	PreconfWhitelist       preconf.Whitelist
-	PreconfProposerTracker *preconf.ProposerTracker
+	PreconfProposerTracker preconf.ProposerTracker
 }
 
 // ProvideChainService is a depinject provider for the blockchain service.

--- a/node-core/components/preconf.go
+++ b/node-core/components/preconf.go
@@ -28,6 +28,12 @@ import (
 	"github.com/berachain/beacon-kit/log/phuslu"
 )
 
+// ProvidePreconfProposerTracker provides a ProposerTracker shared between the
+// blockchain service (writer) and the preconf server (reader).
+func ProvidePreconfProposerTracker() *preconf.ProposerTracker {
+	return preconf.NewProposerTracker()
+}
+
 // PreconfWhitelistInput is the input for the preconf whitelist provider.
 type PreconfWhitelistInput struct {
 	depinject.In

--- a/node-core/components/preconf.go
+++ b/node-core/components/preconf.go
@@ -30,7 +30,7 @@ import (
 
 // ProvidePreconfProposerTracker provides a ProposerTracker shared between the
 // blockchain service (writer) and the preconf server (reader).
-func ProvidePreconfProposerTracker() *preconf.ProposerTracker {
+func ProvidePreconfProposerTracker() preconf.ProposerTracker {
 	return preconf.NewProposerTracker()
 }
 

--- a/node-core/components/preconf_server.go
+++ b/node-core/components/preconf_server.go
@@ -36,7 +36,7 @@ type PreconfServerInput struct {
 	Cfg                    *config.Config
 	Logger                 *phuslu.Logger
 	Whitelist              preconf.Whitelist
-	PreconfProposerTracker *preconf.ProposerTracker
+	PreconfProposerTracker preconf.ProposerTracker
 	LocalBuilder           *payloadbuilder.PayloadBuilder
 }
 

--- a/node-core/components/preconf_server.go
+++ b/node-core/components/preconf_server.go
@@ -33,10 +33,11 @@ import (
 type PreconfServerInput struct {
 	depinject.In
 
-	Cfg          *config.Config
-	Logger       *phuslu.Logger
-	Whitelist    preconf.Whitelist
-	LocalBuilder *payloadbuilder.PayloadBuilder
+	Cfg                    *config.Config
+	Logger                 *phuslu.Logger
+	Whitelist              preconf.Whitelist
+	PreconfProposerTracker *preconf.ProposerTracker
+	LocalBuilder           *payloadbuilder.PayloadBuilder
 }
 
 // ProvidePreconfServer provides the preconf API server for sequencer mode.
@@ -81,6 +82,7 @@ func ProvidePreconfServer(in PreconfServerInput) (*preconf.Server, error) {
 		logger,
 		validatorJWTs,
 		in.Whitelist,
+		in.PreconfProposerTracker,
 		in.LocalBuilder,
 		cfg.APIPort,
 	), nil

--- a/testing/simulated/components.go
+++ b/testing/simulated/components.go
@@ -50,6 +50,7 @@ func FixedComponents(t *testing.T) []any {
 		components.ProvideJWTSecret,
 		components.ProvideLocalBuilder,
 		components.ProvidePreconfWhitelist,
+		components.ProvidePreconfProposerTracker,
 		components.ProvidePreconfServer,
 		components.ProvidePreconfClient,
 		components.ProvideReportingService,


### PR DESCRIPTION
This PR adds proposer verification to the preconf server on the sequencer so that only the current expected proposer can retrieve payloads. It extends the `EventBus` round-change mechanism from #3068 by introducing a simple `ProposerTracker` that records which validator should be proposing for a given slot, updated on every `ProcessProposal` and `HandleRoundChange`. 

The sequencer then checks the `ProposerTracker` on each `GetPayload` request and rejects stale proposers making sure that only the proposing validator for that round is allowed to be served that payload.

Implicitly covered by the e2e `TestRoundChangeRebuild` test from #3068, which forces consensus round timeouts 