### PR TITLE
fix(payload): enforce the fork version of cached verified payload is consistent

### DIFF
--- a/payload/builder/payload.go
+++ b/payload/builder/payload.go
@@ -239,19 +239,24 @@ func (pb *PayloadBuilder) CacheLatestVerifiedPayload(
 	pb.latestEnvelope = latestEnvelope
 }
 
-// getLatestVerifiedPayload is a simple getter to keep pb.muEnv locking scope at minimum
+// getLatestVerifiedPayload returns the latest verified payload if it is for the given slot and fork version.
 func (pb *PayloadBuilder) getLatestVerifiedPayload(
 	slot math.Slot,
 	expectedForkVersion common.Version,
 ) ctypes.BuiltExecutionPayloadEnv {
 	pb.muEnv.RLock()
 	defer pb.muEnv.RUnlock()
-	if pb.latestEnvelope != nil &&
-		slot == pb.latestEnvelopeSlot &&
-		version.Equals(
-			pb.chainSpec.ActiveForkVersionForTimestamp(pb.latestEnvelope.GetExecutionPayload().GetTimestamp()),
-			expectedForkVersion,
-		) {
+	if pb.latestEnvelope == nil || slot != pb.latestEnvelopeSlot {
+		return nil
+	}
+	payload := pb.latestEnvelope.GetExecutionPayload()
+	if payload == nil {
+		return nil
+	}
+	if version.Equals(
+		pb.chainSpec.ActiveForkVersionForTimestamp(payload.GetTimestamp()),
+		expectedForkVersion,
+	) {
 		return pb.latestEnvelope
 	}
 	return nil

--- a/payload/builder/payload.go
+++ b/payload/builder/payload.go
@@ -174,7 +174,7 @@ func (pb *PayloadBuilder) RetrievePayload(
 	payloadRes, found := pb.pc.Get(slot, parentBlockRoot)
 	if !found {
 		// No block built optimistically, try reusing the latest verified payload
-		if verifiedEnvelope := pb.getLatestVerifiedPayload(slot); verifiedEnvelope != nil {
+		if verifiedEnvelope := pb.getLatestVerifiedPayload(slot, expectedForkVersion); verifiedEnvelope != nil {
 			return verifiedEnvelope, nil
 		}
 
@@ -196,7 +196,7 @@ func (pb *PayloadBuilder) RetrievePayload(
 			pb.pc.Delete(slot, parentBlockRoot)
 
 			// Again here we should try reusing the latest verified block.
-			if verifiedEnvelope := pb.getLatestVerifiedPayload(slot); verifiedEnvelope != nil {
+			if verifiedEnvelope := pb.getLatestVerifiedPayload(slot, expectedForkVersion); verifiedEnvelope != nil {
 				return verifiedEnvelope, nil
 			}
 		}
@@ -240,10 +240,18 @@ func (pb *PayloadBuilder) CacheLatestVerifiedPayload(
 }
 
 // getLatestVerifiedPayload is a simple getter to keep pb.muEnv locking scope at minimum
-func (pb *PayloadBuilder) getLatestVerifiedPayload(slot math.Slot) ctypes.BuiltExecutionPayloadEnv {
+func (pb *PayloadBuilder) getLatestVerifiedPayload(
+	slot math.Slot,
+	expectedForkVersion common.Version,
+) ctypes.BuiltExecutionPayloadEnv {
 	pb.muEnv.RLock()
 	defer pb.muEnv.RUnlock()
-	if pb.latestEnvelope != nil && slot == pb.latestEnvelopeSlot {
+	if pb.latestEnvelope != nil &&
+		slot == pb.latestEnvelopeSlot &&
+		version.Equals(
+			pb.chainSpec.ActiveForkVersionForTimestamp(pb.latestEnvelope.GetExecutionPayload().GetTimestamp()),
+			expectedForkVersion,
+		) {
 		return pb.latestEnvelope
 	}
 	return nil

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -164,6 +164,111 @@ func TestRetrievePayloadNilWithdrawalsListRejected(t *testing.T) {
 	require.ErrorIs(t, builder.ErrNilWithdrawals, err)
 }
 
+func TestRetrievePayloadFallbackForkVersionMatch(t *testing.T) {
+	t.Parallel()
+
+	chainSpec, err := spec.MainnetChainSpec()
+	require.NoError(t, err)
+
+	var (
+		logger = noop.NewLogger[any]()
+		cfg    = &builder.Config{Enabled: true}
+		ee     = &stubExecutionEngine{}
+		pc     = cache.NewPayloadIDCache()
+		af     = &stubAttributesFactory{}
+	)
+	pb := builder.New(cfg, chainSpec, logger, ee, pc, af)
+
+	var (
+		ctx             = t.Context()
+		slot            = math.Slot(10)
+		parentBlockRoot = common.Root{0x01}
+	)
+
+	// Timestamp in the Deneb range (before Deneb1ForkTime=1_738_415_507).
+	cachedEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
+		ExecutionPayload: &ctypes.ExecutionPayload{
+			Timestamp:   math.U64(1_737_381_600),
+			Withdrawals: engineprimitives.Withdrawals{},
+		},
+		BlobsBundle: &engineprimitives.BlobsBundleV1{},
+	}
+	pb.CacheLatestVerifiedPayload(slot, cachedEnvelope)
+
+	// PayloadIDCache is empty for (slot, parentBlockRoot), so RetrievePayload
+	// falls through to getLatestVerifiedPayload. Fork versions match → reuse.
+	envelope, err := pb.RetrievePayload(ctx, slot, parentBlockRoot, version.Deneb())
+	require.NoError(t, err)
+	require.Equal(t, cachedEnvelope, envelope)
+}
+
+func TestRetrievePayloadFallbackForkVersionMismatch(t *testing.T) {
+	t.Parallel()
+
+	chainSpec, err := spec.MainnetChainSpec()
+	require.NoError(t, err)
+
+	var (
+		logger = noop.NewLogger[any]()
+		cfg    = &builder.Config{Enabled: true}
+		ee     = &stubExecutionEngine{}
+		pc     = cache.NewPayloadIDCache()
+		af     = &stubAttributesFactory{}
+	)
+	pb := builder.New(cfg, chainSpec, logger, ee, pc, af)
+
+	var (
+		ctx             = t.Context()
+		slot            = math.Slot(10)
+		parentBlockRoot = common.Root{0x01}
+	)
+
+	// Timestamp in the Deneb range, but we'll request Electra.
+	cachedEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
+		ExecutionPayload: &ctypes.ExecutionPayload{
+			Timestamp:   math.U64(1_737_381_600),
+			Withdrawals: engineprimitives.Withdrawals{},
+		},
+		BlobsBundle: &engineprimitives.BlobsBundleV1{},
+	}
+	pb.CacheLatestVerifiedPayload(slot, cachedEnvelope)
+
+	// Fork version mismatch (Deneb payload, Electra expected) → skip reuse → ErrPayloadIDNotFound.
+	_, err = pb.RetrievePayload(ctx, slot, parentBlockRoot, version.Electra())
+	require.ErrorIs(t, err, builder.ErrPayloadIDNotFound)
+}
+
+func TestRetrievePayloadFallbackNilExecutionPayload(t *testing.T) {
+	t.Parallel()
+
+	chainSpec, err := spec.MainnetChainSpec()
+	require.NoError(t, err)
+
+	var (
+		logger = noop.NewLogger[any]()
+		cfg    = &builder.Config{Enabled: true}
+		ee     = &stubExecutionEngine{}
+		pc     = cache.NewPayloadIDCache()
+		af     = &stubAttributesFactory{}
+	)
+	pb := builder.New(cfg, chainSpec, logger, ee, pc, af)
+
+	var (
+		ctx             = t.Context()
+		slot            = math.Slot(10)
+		parentBlockRoot = common.Root{0x01}
+	)
+
+	// Envelope with nil execution payload — must not panic.
+	cachedEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
+		ExecutionPayload: nil,
+	}
+	pb.CacheLatestVerifiedPayload(slot, cachedEnvelope)
+
+	_, err = pb.RetrievePayload(ctx, slot, parentBlockRoot, version.Deneb())
+	require.ErrorIs(t, err, builder.ErrPayloadIDNotFound)
+}
+
 // HELPERS section
 
 var errStubNotImplemented = errors.New("stub not implemented")

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -144,8 +144,8 @@ func TestRetrievePayload(t *testing.T) {
 				pb.CacheLatestVerifiedPayload(slot, tt.verifiedEnvelope)
 			}
 
-			var envelope ctypes.BuiltExecutionPayloadEnv
-			envelope, err = pb.RetrievePayload(t.Context(), slot, parentBlockRoot, tt.expectedForkVersion)
+			//nolint:govet // shadow err so that parallel tests do not overwrite err.
+			envelope, err := pb.RetrievePayload(t.Context(), slot, parentBlockRoot, tt.expectedForkVersion)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 				return

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -38,6 +38,125 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRetrievePayload(t *testing.T) {
+	t.Parallel()
+
+	chainSpec, err := spec.MainnetChainSpec()
+	require.NoError(t, err)
+
+	var (
+		slot            = math.Slot(10)
+		parentBlockRoot = common.Root{0x01}
+		denebTimestamp  = math.U64(1_737_381_600) // before mainnet Deneb1ForkTime
+		dummyPayloadID  = engineprimitives.PayloadID{0xab}
+	)
+
+	validEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
+		ExecutionPayload: &ctypes.ExecutionPayload{
+			Timestamp:   denebTimestamp,
+			Withdrawals: engineprimitives.Withdrawals{},
+		},
+		BlobsBundle: &engineprimitives.BlobsBundleV1{},
+	}
+	nilWithdrawalsEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
+		ExecutionPayload: &ctypes.ExecutionPayload{
+			Timestamp:   denebTimestamp,
+			Withdrawals: nil,
+		},
+		BlobsBundle: &engineprimitives.BlobsBundleV1{},
+	}
+	nilPayloadEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
+		ExecutionPayload: nil,
+	}
+
+	tests := []struct {
+		name string
+
+		// If non-nil, seed the PayloadIDCache before calling RetrievePayload.
+		cachePayloadID   *engineprimitives.PayloadID
+		cacheForkVersion common.Version
+
+		// Stub response from the execution engine's GetPayload.
+		eeEnvelope ctypes.BuiltExecutionPayloadEnv
+
+		// If non-nil, cache as the latest verified payload for the same slot.
+		verifiedEnvelope ctypes.BuiltExecutionPayloadEnv
+
+		expectedForkVersion common.Version
+		wantEnvelope        ctypes.BuiltExecutionPayloadEnv
+		wantErr             error
+	}{
+		{
+			name:                "sunny path via PayloadIDCache",
+			cachePayloadID:      &dummyPayloadID,
+			cacheForkVersion:    version.Deneb(),
+			eeEnvelope:          validEnvelope,
+			expectedForkVersion: version.Deneb(),
+			wantEnvelope:        validEnvelope,
+		},
+		{
+			name:                "nil withdrawals list rejected",
+			cachePayloadID:      &dummyPayloadID,
+			cacheForkVersion:    version.Deneb(),
+			eeEnvelope:          nilWithdrawalsEnvelope,
+			expectedForkVersion: version.Deneb(),
+			wantErr:             builder.ErrNilWithdrawals,
+		},
+		{
+			name:                "fallback reuses verified payload on fork version match",
+			verifiedEnvelope:    validEnvelope,
+			expectedForkVersion: version.Deneb(),
+			wantEnvelope:        validEnvelope,
+		},
+		{
+			name:                "fallback rejects verified payload on fork version mismatch",
+			verifiedEnvelope:    validEnvelope,
+			expectedForkVersion: version.Electra(),
+			wantErr:             builder.ErrPayloadIDNotFound,
+		},
+		{
+			name:                "fallback skips verified payload with nil execution payload",
+			verifiedEnvelope:    nilPayloadEnvelope,
+			expectedForkVersion: version.Deneb(),
+			wantErr:             builder.ErrPayloadIDNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ee := &stubExecutionEngine{payloadEnvToReturn: tt.eeEnvelope}
+			pc := cache.NewPayloadIDCache()
+			pb := builder.New(
+				&builder.Config{Enabled: true},
+				chainSpec,
+				noop.NewLogger[any](),
+				ee,
+				pc,
+				&stubAttributesFactory{},
+			)
+
+			if tt.cachePayloadID != nil {
+				pc.Set(slot, parentBlockRoot, *tt.cachePayloadID, tt.cacheForkVersion)
+			}
+			if tt.verifiedEnvelope != nil {
+				pb.CacheLatestVerifiedPayload(slot, tt.verifiedEnvelope)
+			}
+
+			envelope, err := pb.RetrievePayload(t.Context(), slot, parentBlockRoot, tt.expectedForkVersion)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantEnvelope, envelope)
+		})
+	}
+}
+
+// HELPERS section
+
 type mockExecutionPayloadEnvelope[BlobsBundleT engineprimitives.BlobsBundle] struct {
 	ExecutionPayload  *ctypes.ExecutionPayload         `json:"executionPayload"`
 	BlockValue        *math.U256                       `json:"blockValue"`
@@ -65,211 +184,6 @@ func (m mockExecutionPayloadEnvelope[BlobsBundleT]) GetEncodedExecutionRequests(
 func (m mockExecutionPayloadEnvelope[BlobsBundleT]) ShouldOverrideBuilder() bool {
 	return m.Override
 }
-
-// TODO cluster these tests into a single test table
-func TestRetrievePayloadSunnyPath(t *testing.T) {
-	t.Parallel()
-
-	chainSpec, err := spec.MainnetChainSpec()
-	require.NoError(t, err)
-
-	// Create payload builder
-	var (
-		logger = noop.NewLogger[any]()
-		cfg    = &builder.Config{Enabled: true}
-		ee     = &stubExecutionEngine{}
-		cache  = cache.NewPayloadIDCache()
-		af     = &stubAttributesFactory{}
-	)
-	pb := builder.New(
-		cfg,
-		chainSpec,
-		logger,
-		ee,
-		cache,
-		af,
-	)
-
-	// create inputs and set expectations
-	var (
-		ctx             = t.Context()
-		slot            = math.Slot(2025)
-		parentBlockRoot = common.Root{0xff, 0xaa}
-		dummyPayloadID  = engineprimitives.PayloadID{0xab}
-
-		expectedPayload = &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
-			ExecutionPayload: &ctypes.ExecutionPayload{
-				Withdrawals: engineprimitives.Withdrawals{},
-			},
-			BlobsBundle: &engineprimitives.BlobsBundleV1{},
-		}
-	)
-
-	// set expectations
-	expectedForkVersion := version.Deneb()
-	cache.Set(slot, parentBlockRoot, dummyPayloadID, expectedForkVersion)
-	ee.payloadEnvToReturn = expectedPayload
-
-	// test and checks
-	payload, err := pb.RetrievePayload(ctx, slot, parentBlockRoot, expectedForkVersion)
-	require.NoError(t, err)
-	require.Equal(t, expectedPayload, payload)
-}
-
-func TestRetrievePayloadNilWithdrawalsListRejected(t *testing.T) {
-	t.Parallel()
-
-	chainSpec, err := spec.MainnetChainSpec()
-	require.NoError(t, err)
-
-	// Create payload builder
-	var (
-		logger = noop.NewLogger[any]()
-		cfg    = &builder.Config{Enabled: true}
-		ee     = &stubExecutionEngine{}
-		cache  = cache.NewPayloadIDCache()
-		af     = &stubAttributesFactory{}
-	)
-	pb := builder.New(
-		cfg,
-		chainSpec,
-		logger,
-		ee,
-		cache,
-		af,
-	)
-
-	// create inputs
-	var (
-		ctx             = t.Context()
-		slot            = math.Slot(2025)
-		parentBlockRoot = common.Root{0xff, 0xaa}
-		dummyPayloadID  = engineprimitives.PayloadID{0xab}
-
-		faultyPayload = &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
-			ExecutionPayload: &ctypes.ExecutionPayload{
-				Withdrawals: nil, // empty withdrawals are fine, nil list should be rejected
-			},
-			BlobsBundle: &engineprimitives.BlobsBundleV1{},
-		}
-	)
-
-	// set expectations
-	expectedForkVersion := version.Deneb()
-	cache.Set(slot, parentBlockRoot, dummyPayloadID, expectedForkVersion)
-	ee.payloadEnvToReturn = faultyPayload
-
-	// test and checks
-	_, err = pb.RetrievePayload(ctx, slot, parentBlockRoot, expectedForkVersion)
-	require.ErrorIs(t, builder.ErrNilWithdrawals, err)
-}
-
-func TestRetrievePayloadFallbackForkVersionMatch(t *testing.T) {
-	t.Parallel()
-
-	chainSpec, err := spec.MainnetChainSpec()
-	require.NoError(t, err)
-
-	var (
-		logger = noop.NewLogger[any]()
-		cfg    = &builder.Config{Enabled: true}
-		ee     = &stubExecutionEngine{}
-		pc     = cache.NewPayloadIDCache()
-		af     = &stubAttributesFactory{}
-	)
-	pb := builder.New(cfg, chainSpec, logger, ee, pc, af)
-
-	var (
-		ctx             = t.Context()
-		slot            = math.Slot(10)
-		parentBlockRoot = common.Root{0x01}
-	)
-
-	// Timestamp in the Deneb range (before Deneb1ForkTime=1_738_415_507).
-	cachedEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
-		ExecutionPayload: &ctypes.ExecutionPayload{
-			Timestamp:   math.U64(1_737_381_600),
-			Withdrawals: engineprimitives.Withdrawals{},
-		},
-		BlobsBundle: &engineprimitives.BlobsBundleV1{},
-	}
-	pb.CacheLatestVerifiedPayload(slot, cachedEnvelope)
-
-	// PayloadIDCache is empty for (slot, parentBlockRoot), so RetrievePayload
-	// falls through to getLatestVerifiedPayload. Fork versions match → reuse.
-	envelope, err := pb.RetrievePayload(ctx, slot, parentBlockRoot, version.Deneb())
-	require.NoError(t, err)
-	require.Equal(t, cachedEnvelope, envelope)
-}
-
-func TestRetrievePayloadFallbackForkVersionMismatch(t *testing.T) {
-	t.Parallel()
-
-	chainSpec, err := spec.MainnetChainSpec()
-	require.NoError(t, err)
-
-	var (
-		logger = noop.NewLogger[any]()
-		cfg    = &builder.Config{Enabled: true}
-		ee     = &stubExecutionEngine{}
-		pc     = cache.NewPayloadIDCache()
-		af     = &stubAttributesFactory{}
-	)
-	pb := builder.New(cfg, chainSpec, logger, ee, pc, af)
-
-	var (
-		ctx             = t.Context()
-		slot            = math.Slot(10)
-		parentBlockRoot = common.Root{0x01}
-	)
-
-	// Timestamp in the Deneb range, but we'll request Electra.
-	cachedEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
-		ExecutionPayload: &ctypes.ExecutionPayload{
-			Timestamp:   math.U64(1_737_381_600),
-			Withdrawals: engineprimitives.Withdrawals{},
-		},
-		BlobsBundle: &engineprimitives.BlobsBundleV1{},
-	}
-	pb.CacheLatestVerifiedPayload(slot, cachedEnvelope)
-
-	// Fork version mismatch (Deneb payload, Electra expected) → skip reuse → ErrPayloadIDNotFound.
-	_, err = pb.RetrievePayload(ctx, slot, parentBlockRoot, version.Electra())
-	require.ErrorIs(t, err, builder.ErrPayloadIDNotFound)
-}
-
-func TestRetrievePayloadFallbackNilExecutionPayload(t *testing.T) {
-	t.Parallel()
-
-	chainSpec, err := spec.MainnetChainSpec()
-	require.NoError(t, err)
-
-	var (
-		logger = noop.NewLogger[any]()
-		cfg    = &builder.Config{Enabled: true}
-		ee     = &stubExecutionEngine{}
-		pc     = cache.NewPayloadIDCache()
-		af     = &stubAttributesFactory{}
-	)
-	pb := builder.New(cfg, chainSpec, logger, ee, pc, af)
-
-	var (
-		ctx             = t.Context()
-		slot            = math.Slot(10)
-		parentBlockRoot = common.Root{0x01}
-	)
-
-	// Envelope with nil execution payload — must not panic.
-	cachedEnvelope := &mockExecutionPayloadEnvelope[*engineprimitives.BlobsBundleV1]{
-		ExecutionPayload: nil,
-	}
-	pb.CacheLatestVerifiedPayload(slot, cachedEnvelope)
-
-	_, err = pb.RetrievePayload(ctx, slot, parentBlockRoot, version.Deneb())
-	require.ErrorIs(t, err, builder.ErrPayloadIDNotFound)
-}
-
-// HELPERS section
 
 var errStubNotImplemented = errors.New("stub not implemented")
 

--- a/payload/builder/payload_test.go
+++ b/payload/builder/payload_test.go
@@ -144,7 +144,8 @@ func TestRetrievePayload(t *testing.T) {
 				pb.CacheLatestVerifiedPayload(slot, tt.verifiedEnvelope)
 			}
 
-			envelope, err := pb.RetrievePayload(t.Context(), slot, parentBlockRoot, tt.expectedForkVersion)
+			var envelope ctypes.BuiltExecutionPayloadEnv
+			envelope, err = pb.RetrievePayload(t.Context(), slot, parentBlockRoot, tt.expectedForkVersion)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 				return


### PR DESCRIPTION
Ensures using the cached latest verified payload when building a block is consistent even across fork boundary. If we go to multiple consensus rounds and that happens to cross over the new fork, we should not use this cached payload and instead build just in time/