### PR TITLE
chore(ci): run CI on pushes to preconf-dev working branch

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,6 +29,7 @@ on:
   push:
     branches:
       - main
+      - preconf-dev
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,7 @@ name: release
 on:
   push:
     tags:
-      - "v*"
-    branches:
-      - 'release/*' 
+      - "v*" 
 
 env:
   REPO_NAME: ${{ github.repository }} 


### PR DESCRIPTION
Allows us to catch CI issues on latest preconf-dev branch (like the currently failing vulncheck job). 

Also removes an unneeded trigger for release workflow (as we dont use `release/...` branches in beacon-kit)