### PR TITLE
fix(ci): use go `run` instead of `install` for vulncheck

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,6 +29,7 @@ on:
   push:
     branches:
       - main
+      - preconf-dev
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,7 @@ name: release
 on:
   push:
     tags:
-      - "v*"
-    branches:
-      - 'release/*' 
+      - "v*" 
 
 env:
   REPO_NAME: ${{ github.repository }} 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/berachain/beacon-kit
 
-go 1.26.1
+go 1.26.2
 
 replace (
 	github.com/cometbft/cometbft => github.com/berachain/cometbft v1.0.1-0.20260407160047-b95619676ffc

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -85,8 +85,8 @@ gosec: gosec-install
 
 vulncheck:
 	@echo "--> Running govulncheck"
-	@GOTOOLCHAIN=go$(shell sed -n 's/^go //p' go.mod) \
-		go run golang.org/x/vuln/cmd/govulncheck@latest $(shell go list ./... | grep -v '/testing/')
+	@export GOTOOLCHAIN=go$$(sed -n 's/^go //p' go.mod) && \
+		go run golang.org/x/vuln/cmd/govulncheck@latest $$(go list ./... | grep -v '/testing/')
 
 #################
 #    slither    #

--- a/scripts/build/linting.mk
+++ b/scripts/build/linting.mk
@@ -83,12 +83,10 @@ gosec: gosec-install
 #   vulncheck   #
 #################
 
-vulncheck-install:
-	@go install golang.org/x/vuln/cmd/govulncheck@latest
-
-vulncheck: vulncheck-install
+vulncheck:
 	@echo "--> Running govulncheck"
-	@govulncheck $(shell go list ./... | grep -v '/testing/')
+	@GOTOOLCHAIN=go$(shell sed -n 's/^go //p' go.mod) \
+		go run golang.org/x/vuln/cmd/govulncheck@latest $(shell go list ./... | grep -v '/testing/')
 
 #################
 #    slither    #

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -69,7 +69,7 @@ This directory is git-ignored. Logs from previous runs are overwritten.
 
 - **Docker** running locally
 - **Kurtosis CLI** installed ([instructions](https://docs.kurtosis.com/install)) with the engine started (`kurtosis engine start`)
-- **Go 1.26.1+**
+- **Go 1.26.2+**
 
 ## Running Tests
 


### PR DESCRIPTION
The vulncheck CI job started failing after new Go stdlib vulnerabilities (GO-2026-4864, GO-2026-4865, etc.) were published on 2026-04-07. These affect go1.26.1 and are fixed in go1.26.2. Bumping the Go version resolves all reported stdlib vulnerabilities.

Also switch the vulncheck Make target from `go install` + bare command to `go run` with GOTOOLCHAIN pinning so it works locally without requiring $GOPATH/bin in PATH.