### PR TITLE
feat(chain): implement BRIP-0008 hysteresis update for Fulu fork

### DIFF
--- a/chain/data.go
+++ b/chain/data.go
@@ -165,12 +165,18 @@ type SpecData struct {
 	// minted to the EVMInflationAddressDeneb1 via a withdrawal every block in the Deneb1 fork.
 	EVMInflationPerBlockDeneb1 uint64 `mapstructure:"evm-inflation-per-block-deneb-one"`
 
+	// Electra Values
+	//
+	// MinActivationBalance [New in Electra:EIP7251] Minimum balance for a validator to become active
+	MinActivationBalance uint64 `mapstructure:"min-activation-balance"`
+	// MinValidatorWithdrawabilityDelay is defined in the Electra spec and introduces
+	// withdrawability delays to allow for slashing.
+	MinValidatorWithdrawabilityDelay uint64 `mapstructure:"min-validator-withdrawability-delay"`
+
 	// Fulu Value Changes
 	//
 	// HysteresisQuotientFulu is the hysteresis quotient for the Fulu fork (BRIP-0008).
 	HysteresisQuotientFulu uint64 `mapstructure:"hysteresis-quotient-fulu"`
-	// HysteresisDownwardMultiplierFulu is the hysteresis downward multiplier for the Fulu fork.
-	HysteresisDownwardMultiplierFulu uint64 `mapstructure:"hysteresis-downward-multiplier-fulu"`
 	// HysteresisUpwardMultiplierFulu is the hysteresis upward multiplier for the Fulu fork.
 	HysteresisUpwardMultiplierFulu uint64 `mapstructure:"hysteresis-upward-multiplier-fulu"`
 	// EVMInflationAddressFulu is the address on the EVM which will receive the
@@ -179,12 +185,4 @@ type SpecData struct {
 	// EVMInflationPerBlockFulu is the amount of native EVM balance (in Gwei) to be
 	// minted to the EVMInflationAddressFulu via a withdrawal every block in the Fulu fork.
 	EVMInflationPerBlockFulu uint64 `mapstructure:"evm-inflation-per-block-fulu"`
-
-	// Electra Values
-	//
-	// MinActivationBalance [New in Electra:EIP7251] Minimum balance for a validator to become active
-	MinActivationBalance uint64 `mapstructure:"min-activation-balance"`
-	// MinValidatorWithdrawabilityDelay is defined in the Electra spec and introduces
-	// withdrawability delays to allow for slashing.
-	MinValidatorWithdrawabilityDelay uint64 `mapstructure:"min-validator-withdrawability-delay"`
 }

--- a/chain/data.go
+++ b/chain/data.go
@@ -102,6 +102,8 @@ type SpecData struct {
 	ElectraForkTime uint64 `mapstructure:"electra-fork-time"`
 	// Electra1ForkTime is the time at which the Electra1 fork is activated.
 	Electra1ForkTime uint64 `mapstructure:"electra-one-fork-time"`
+	// FuluForkTime is the time at which the Fulu fork is activated (Fusaka CL fork).
+	FuluForkTime uint64 `mapstructure:"fulu-fork-time"`
 
 	// State list lengths
 	//
@@ -162,6 +164,21 @@ type SpecData struct {
 	// EVMInflationPerBlockDeneb1 is the amount of native EVM balance (in Gwei) to be
 	// minted to the EVMInflationAddressDeneb1 via a withdrawal every block in the Deneb1 fork.
 	EVMInflationPerBlockDeneb1 uint64 `mapstructure:"evm-inflation-per-block-deneb-one"`
+
+	// Fulu Value Changes
+	//
+	// HysteresisQuotientFulu is the hysteresis quotient for the Fulu fork (BRIP-0008).
+	HysteresisQuotientFulu uint64 `mapstructure:"hysteresis-quotient-fulu"`
+	// HysteresisDownwardMultiplierFulu is the hysteresis downward multiplier for the Fulu fork.
+	HysteresisDownwardMultiplierFulu uint64 `mapstructure:"hysteresis-downward-multiplier-fulu"`
+	// HysteresisUpwardMultiplierFulu is the hysteresis upward multiplier for the Fulu fork.
+	HysteresisUpwardMultiplierFulu uint64 `mapstructure:"hysteresis-upward-multiplier-fulu"`
+	// EVMInflationAddressFulu is the address on the EVM which will receive the
+	// inflation amount of native EVM balance through a withdrawal every block in the Fulu fork.
+	EVMInflationAddressFulu common.ExecutionAddress `mapstructure:"evm-inflation-address-fulu"`
+	// EVMInflationPerBlockFulu is the amount of native EVM balance (in Gwei) to be
+	// minted to the EVMInflationAddressFulu via a withdrawal every block in the Fulu fork.
+	EVMInflationPerBlockFulu uint64 `mapstructure:"evm-inflation-per-block-fulu"`
 
 	// Electra Values
 	//

--- a/chain/helpers.go
+++ b/chain/helpers.go
@@ -29,6 +29,9 @@ import (
 // ActiveForkVersionForTimestamp returns the active fork version for a given timestamp.
 func (s spec) ActiveForkVersionForTimestamp(timestamp math.U64) common.Version {
 	time := timestamp.Unwrap()
+	if time >= s.FuluForkTime() {
+		return version.Fulu()
+	}
 	if time >= s.Electra1ForkTime() {
 		return version.Electra1()
 	}

--- a/chain/helpers_test.go
+++ b/chain/helpers_test.go
@@ -38,6 +38,7 @@ var spec, _ = chain.NewSpec(
 		Deneb1ForkTime:                   9 * 32 * 2,
 		ElectraForkTime:                  10 * 32 * 2,
 		Electra1ForkTime:                 11 * 32 * 2,
+		FuluForkTime:                     12 * 32 * 2,
 		SlotsPerEpoch:                    32,
 		MinEpochsForBlobsSidecarsRequest: 5,
 		MaxWithdrawalsPerPayload:         2,

--- a/chain/spec.go
+++ b/chain/spec.go
@@ -48,15 +48,18 @@ type HysteresisSpec interface {
 	// HysteresisQuotient returns the quotient used in effective balance
 	// calculations to create hysteresis. This provides resistance to small
 	// balance changes triggering effective balance updates.
-	HysteresisQuotient() math.U64
+	// The value is fork-gated by timestamp (updated in Fulu per BRIP-0008).
+	HysteresisQuotient(timestamp math.U64) math.U64
 
 	// HysteresisDownwardMultiplier returns the multiplier used when checking
 	// if the effective balance should be decreased.
-	HysteresisDownwardMultiplier() math.U64
+	// The value is fork-gated by timestamp (updated in Fulu per BRIP-0008).
+	HysteresisDownwardMultiplier(timestamp math.U64) math.U64
 
 	// HysteresisUpwardMultiplier returns the multiplier used when checking
 	// if the effective balance should be increased.
-	HysteresisUpwardMultiplier() math.U64
+	// The value is fork-gated by timestamp (updated in Fulu per BRIP-0008).
+	HysteresisUpwardMultiplier(timestamp math.U64) math.U64
 }
 
 type DepositSpec interface {
@@ -109,6 +112,9 @@ type ForkSpec interface {
 
 	// Electra1ForkTime returns the time at which the Electra1 fork takes effect.
 	Electra1ForkTime() uint64
+
+	// FuluForkTime returns the time at which the Fulu fork takes effect.
+	FuluForkTime() uint64
 }
 
 type BlobSpec interface {
@@ -269,6 +275,7 @@ func (s spec) validate() error {
 		s.Data.Deneb1ForkTime,
 		s.Data.ElectraForkTime,
 		s.Data.Electra1ForkTime,
+		s.Data.FuluForkTime,
 	}
 	for i := 1; i < len(orderedForkTimes); i++ {
 		prev, cur := orderedForkTimes[i-1], orderedForkTimes[i]
@@ -332,15 +339,27 @@ func (s spec) EffectiveBalanceIncrement() math.Gwei {
 	return math.Gwei(s.Data.EffectiveBalanceIncrement)
 }
 
-func (s spec) HysteresisQuotient() math.U64 {
+func (s spec) HysteresisQuotient(timestamp math.U64) math.U64 {
+	fv := s.ActiveForkVersionForTimestamp(timestamp)
+	if version.EqualsOrIsAfter(fv, version.Fulu()) {
+		return math.U64(s.Data.HysteresisQuotientFulu)
+	}
 	return math.U64(s.Data.HysteresisQuotient)
 }
 
-func (s spec) HysteresisDownwardMultiplier() math.U64 {
+func (s spec) HysteresisDownwardMultiplier(timestamp math.U64) math.U64 {
+	fv := s.ActiveForkVersionForTimestamp(timestamp)
+	if version.EqualsOrIsAfter(fv, version.Fulu()) {
+		return math.U64(s.Data.HysteresisDownwardMultiplierFulu)
+	}
 	return math.U64(s.Data.HysteresisDownwardMultiplier)
 }
 
-func (s spec) HysteresisUpwardMultiplier() math.U64 {
+func (s spec) HysteresisUpwardMultiplier(timestamp math.U64) math.U64 {
+	fv := s.ActiveForkVersionForTimestamp(timestamp)
+	if version.EqualsOrIsAfter(fv, version.Fulu()) {
+		return math.U64(s.Data.HysteresisUpwardMultiplierFulu)
+	}
 	return math.U64(s.Data.HysteresisUpwardMultiplier)
 }
 
@@ -447,6 +466,11 @@ func (s spec) Electra1ForkTime() uint64 {
 	return s.Data.Electra1ForkTime
 }
 
+// FuluForkTime returns the timestamp of the Fulu fork.
+func (s spec) FuluForkTime() uint64 {
+	return s.Data.FuluForkTime
+}
+
 // EpochsPerHistoricalVector returns the number of epochs per historical vector.
 func (s spec) EpochsPerHistoricalVector() uint64 {
 	return s.Data.EpochsPerHistoricalVector
@@ -518,10 +542,12 @@ func (s spec) ValidatorSetCap() uint64 {
 // inflation amount of native EVM balance through a withdrawal every block.
 func (s spec) EVMInflationAddress(timestamp math.U64) common.ExecutionAddress {
 	fv := s.ActiveForkVersionForTimestamp(timestamp)
-	switch fv {
-	case version.Deneb1(), version.Electra(), version.Electra1():
+	switch {
+	case version.EqualsOrIsAfter(fv, version.Fulu()):
+		return s.Data.EVMInflationAddressFulu
+	case version.EqualsOrIsAfter(fv, version.Deneb1()):
 		return s.Data.EVMInflationAddressDeneb1
-	case version.Deneb():
+	case version.Equals(fv, version.Deneb()):
 		return s.Data.EVMInflationAddressGenesis
 	default:
 		panic(fmt.Sprintf("EVMInflationAddress not supported for this fork version: %d", fv))
@@ -532,10 +558,12 @@ func (s spec) EVMInflationAddress(timestamp math.U64) common.ExecutionAddress {
 // be minted to the EVMInflationAddress via a withdrawal every block.
 func (s spec) EVMInflationPerBlock(timestamp math.U64) math.Gwei {
 	fv := s.ActiveForkVersionForTimestamp(timestamp)
-	switch fv {
-	case version.Deneb1(), version.Electra(), version.Electra1():
+	switch {
+	case version.EqualsOrIsAfter(fv, version.Fulu()):
+		return math.Gwei(s.Data.EVMInflationPerBlockFulu)
+	case version.EqualsOrIsAfter(fv, version.Deneb1()):
 		return math.Gwei(s.Data.EVMInflationPerBlockDeneb1)
-	case version.Deneb():
+	case version.Equals(fv, version.Deneb()):
 		return math.Gwei(s.Data.EVMInflationPerBlockGenesis)
 	default:
 		panic(fmt.Sprintf("EVMInflationPerBlock not supported for this fork version: %d", fv))

--- a/chain/spec.go
+++ b/chain/spec.go
@@ -348,10 +348,6 @@ func (s spec) HysteresisQuotient(timestamp math.U64) math.U64 {
 }
 
 func (s spec) HysteresisDownwardMultiplier(timestamp math.U64) math.U64 {
-	fv := s.ActiveForkVersionForTimestamp(timestamp)
-	if version.EqualsOrIsAfter(fv, version.Fulu()) {
-		return math.U64(s.Data.HysteresisDownwardMultiplierFulu)
-	}
 	return math.U64(s.Data.HysteresisDownwardMultiplier)
 }
 

--- a/chain/spec.go
+++ b/chain/spec.go
@@ -48,16 +48,17 @@ type HysteresisSpec interface {
 	// HysteresisQuotient returns the quotient used in effective balance
 	// calculations to create hysteresis. This provides resistance to small
 	// balance changes triggering effective balance updates.
-	// The value is fork-gated by timestamp (updated in Fulu per BRIP-0008).
+	// This value is fork-gated by timestamp (updated in Fulu per BRIP-0008).
 	HysteresisQuotient(timestamp math.U64) math.U64
 
 	// HysteresisDownwardMultiplier returns the multiplier used when checking
 	// if the effective balance should be decreased.
+	// The value is NOT fork-gated by timestamped as no changes are expected to this value.
 	HysteresisDownwardMultiplier() math.U64
 
 	// HysteresisUpwardMultiplier returns the multiplier used when checking
 	// if the effective balance should be increased.
-	// The value is fork-gated by timestamp (updated in Fulu per BRIP-0008).
+	// This value is fork-gated by timestamp (updated in Fulu per BRIP-0008).
 	HysteresisUpwardMultiplier(timestamp math.U64) math.U64
 }
 

--- a/chain/spec.go
+++ b/chain/spec.go
@@ -53,7 +53,7 @@ type HysteresisSpec interface {
 
 	// HysteresisDownwardMultiplier returns the multiplier used when checking
 	// if the effective balance should be decreased.
-	// The value is NOT fork-gated by timestamped as no changes are expected to this value.
+	// This value is NOT fork-gated by timestamped as no changes are expected to this value.
 	HysteresisDownwardMultiplier() math.U64
 
 	// HysteresisUpwardMultiplier returns the multiplier used when checking

--- a/chain/spec.go
+++ b/chain/spec.go
@@ -53,8 +53,7 @@ type HysteresisSpec interface {
 
 	// HysteresisDownwardMultiplier returns the multiplier used when checking
 	// if the effective balance should be decreased.
-	// The value is fork-gated by timestamp (updated in Fulu per BRIP-0008).
-	HysteresisDownwardMultiplier(timestamp math.U64) math.U64
+	HysteresisDownwardMultiplier() math.U64
 
 	// HysteresisUpwardMultiplier returns the multiplier used when checking
 	// if the effective balance should be increased.
@@ -347,7 +346,7 @@ func (s spec) HysteresisQuotient(timestamp math.U64) math.U64 {
 	return math.U64(s.Data.HysteresisQuotient)
 }
 
-func (s spec) HysteresisDownwardMultiplier(timestamp math.U64) math.U64 {
+func (s spec) HysteresisDownwardMultiplier() math.U64 {
 	return math.U64(s.Data.HysteresisDownwardMultiplier)
 }
 

--- a/chain/spec.go
+++ b/chain/spec.go
@@ -341,10 +341,14 @@ func (s spec) EffectiveBalanceIncrement() math.Gwei {
 
 func (s spec) HysteresisQuotient(timestamp math.U64) math.U64 {
 	fv := s.ActiveForkVersionForTimestamp(timestamp)
-	if version.EqualsOrIsAfter(fv, version.Fulu()) {
+	switch {
+	case version.EqualsOrIsAfter(fv, version.Fulu()):
 		return math.U64(s.Data.HysteresisQuotientFulu)
+	case version.EqualsOrIsAfter(fv, s.GenesisForkVersion()):
+		return math.U64(s.Data.HysteresisQuotient)
+	default:
+		panic(fmt.Sprintf("HysteresisQuotient not supported for this fork version: %d", fv))
 	}
-	return math.U64(s.Data.HysteresisQuotient)
 }
 
 func (s spec) HysteresisDownwardMultiplier() math.U64 {
@@ -353,10 +357,14 @@ func (s spec) HysteresisDownwardMultiplier() math.U64 {
 
 func (s spec) HysteresisUpwardMultiplier(timestamp math.U64) math.U64 {
 	fv := s.ActiveForkVersionForTimestamp(timestamp)
-	if version.EqualsOrIsAfter(fv, version.Fulu()) {
+	switch {
+	case version.EqualsOrIsAfter(fv, version.Fulu()):
 		return math.U64(s.Data.HysteresisUpwardMultiplierFulu)
+	case version.EqualsOrIsAfter(fv, s.GenesisForkVersion()):
+		return math.U64(s.Data.HysteresisUpwardMultiplierFulu)
+	default:
+		panic(fmt.Sprintf("HysteresisUpwardMultiplier not supported for this fork version: %d", fv))
 	}
-	return math.U64(s.Data.HysteresisUpwardMultiplier)
 }
 
 // SlotsPerEpoch returns the number of slots per epoch.
@@ -543,7 +551,7 @@ func (s spec) EVMInflationAddress(timestamp math.U64) common.ExecutionAddress {
 		return s.Data.EVMInflationAddressFulu
 	case version.EqualsOrIsAfter(fv, version.Deneb1()):
 		return s.Data.EVMInflationAddressDeneb1
-	case version.Equals(fv, version.Deneb()):
+	case version.Equals(fv, s.GenesisForkVersion()):
 		return s.Data.EVMInflationAddressGenesis
 	default:
 		panic(fmt.Sprintf("EVMInflationAddress not supported for this fork version: %d", fv))
@@ -559,7 +567,7 @@ func (s spec) EVMInflationPerBlock(timestamp math.U64) math.Gwei {
 		return math.Gwei(s.Data.EVMInflationPerBlockFulu)
 	case version.EqualsOrIsAfter(fv, version.Deneb1()):
 		return math.Gwei(s.Data.EVMInflationPerBlockDeneb1)
-	case version.Equals(fv, version.Deneb()):
+	case version.Equals(fv, s.GenesisForkVersion()):
 		return math.Gwei(s.Data.EVMInflationPerBlockGenesis)
 	default:
 		panic(fmt.Sprintf("EVMInflationPerBlock not supported for this fork version: %d", fv))

--- a/chain/spec.go
+++ b/chain/spec.go
@@ -342,13 +342,15 @@ func (s spec) EffectiveBalanceIncrement() math.Gwei {
 func (s spec) HysteresisQuotient(timestamp math.U64) math.U64 {
 	fv := s.ActiveForkVersionForTimestamp(timestamp)
 	switch {
-	case version.EqualsOrIsAfter(fv, version.Fulu()):
+	case version.Equals(fv, version.Fulu()):
 		return math.U64(s.Data.HysteresisQuotientFulu)
-	case version.EqualsOrIsAfter(fv, s.GenesisForkVersion()):
+	case version.Equals(fv, s.GenesisForkVersion()),
+		version.Equals(fv, version.Deneb1()),
+		version.Equals(fv, version.Electra()),
+		version.Equals(fv, version.Electra1()):
 		return math.U64(s.Data.HysteresisQuotient)
-	default:
-		panic(fmt.Sprintf("HysteresisQuotient not supported for this fork version: %d", fv))
 	}
+	panic(fmt.Sprintf("HysteresisQuotient not supported for this fork version: %d", fv))
 }
 
 func (s spec) HysteresisDownwardMultiplier() math.U64 {
@@ -358,13 +360,15 @@ func (s spec) HysteresisDownwardMultiplier() math.U64 {
 func (s spec) HysteresisUpwardMultiplier(timestamp math.U64) math.U64 {
 	fv := s.ActiveForkVersionForTimestamp(timestamp)
 	switch {
-	case version.EqualsOrIsAfter(fv, version.Fulu()):
+	case version.Equals(fv, version.Fulu()):
 		return math.U64(s.Data.HysteresisUpwardMultiplierFulu)
-	case version.EqualsOrIsAfter(fv, s.GenesisForkVersion()):
+	case version.Equals(fv, s.GenesisForkVersion()),
+		version.Equals(fv, version.Deneb1()),
+		version.Equals(fv, version.Electra()),
+		version.Equals(fv, version.Electra1()):
 		return math.U64(s.Data.HysteresisUpwardMultiplierFulu)
-	default:
-		panic(fmt.Sprintf("HysteresisUpwardMultiplier not supported for this fork version: %d", fv))
 	}
+	panic(fmt.Sprintf("HysteresisUpwardMultiplier not supported for this fork version: %d", fv))
 }
 
 // SlotsPerEpoch returns the number of slots per epoch.
@@ -547,15 +551,16 @@ func (s spec) ValidatorSetCap() uint64 {
 func (s spec) EVMInflationAddress(timestamp math.U64) common.ExecutionAddress {
 	fv := s.ActiveForkVersionForTimestamp(timestamp)
 	switch {
-	case version.EqualsOrIsAfter(fv, version.Fulu()):
+	case version.Equals(fv, version.Fulu()):
 		return s.Data.EVMInflationAddressFulu
-	case version.EqualsOrIsAfter(fv, version.Deneb1()):
+	case version.Equals(fv, version.Deneb1()),
+		version.Equals(fv, version.Electra()),
+		version.Equals(fv, version.Electra1()):
 		return s.Data.EVMInflationAddressDeneb1
 	case version.Equals(fv, s.GenesisForkVersion()):
 		return s.Data.EVMInflationAddressGenesis
-	default:
-		panic(fmt.Sprintf("EVMInflationAddress not supported for this fork version: %d", fv))
 	}
+	panic(fmt.Sprintf("EVMInflationAddress not supported for this fork version: %d", fv))
 }
 
 // EVMInflationPerBlock returns the amount of native EVM balance (in Gwei) to
@@ -563,13 +568,14 @@ func (s spec) EVMInflationAddress(timestamp math.U64) common.ExecutionAddress {
 func (s spec) EVMInflationPerBlock(timestamp math.U64) math.Gwei {
 	fv := s.ActiveForkVersionForTimestamp(timestamp)
 	switch {
-	case version.EqualsOrIsAfter(fv, version.Fulu()):
+	case version.Equals(fv, version.Fulu()):
 		return math.Gwei(s.Data.EVMInflationPerBlockFulu)
-	case version.EqualsOrIsAfter(fv, version.Deneb1()):
+	case version.Equals(fv, version.Deneb1()),
+		version.Equals(fv, version.Electra()),
+		version.Equals(fv, version.Electra1()):
 		return math.Gwei(s.Data.EVMInflationPerBlockDeneb1)
 	case version.Equals(fv, s.GenesisForkVersion()):
 		return math.Gwei(s.Data.EVMInflationPerBlockGenesis)
-	default:
-		panic(fmt.Sprintf("EVMInflationPerBlock not supported for this fork version: %d", fv))
 	}
+	panic(fmt.Sprintf("EVMInflationPerBlock not supported for this fork version: %d", fv))
 }

--- a/chain/spec_test.go
+++ b/chain/spec_test.go
@@ -43,6 +43,7 @@ func TestValidate_ForkOrder_Success(t *testing.T) {
 	data.Deneb1ForkTime = 20
 	data.ElectraForkTime = 30
 	data.Electra1ForkTime = 40
+	data.FuluForkTime = 50
 
 	_, err := chain.NewSpec(data)
 	require.NoError(t, err)
@@ -55,6 +56,7 @@ func TestValidate_ForkOrder_GenesisAfterDeneb(t *testing.T) {
 	data.Deneb1ForkTime = 20
 	data.ElectraForkTime = 60
 	data.Electra1ForkTime = 70
+	data.FuluForkTime = 80
 
 	_, err := chain.NewSpec(data)
 	require.Error(t, err)
@@ -68,6 +70,7 @@ func TestValidate_ForkOrder_DenebAfterElectra(t *testing.T) {
 	data.Deneb1ForkTime = 80
 	data.ElectraForkTime = 40
 	data.Electra1ForkTime = 50
+	data.FuluForkTime = 90
 
 	_, err := chain.NewSpec(data)
 	require.Error(t, err)

--- a/cli/commands/genesis/payload.go
+++ b/cli/commands/genesis/payload.go
@@ -148,8 +148,8 @@ func executableDataToExecutionPayloadHeader(
 ) (*types.ExecutionPayloadHeader, error) {
 	eph := &types.ExecutionPayloadHeader{}
 
-	// We do not support fork versions before Deneb and after Electra1.
-	if version.IsAfter(forkVersion, version.Electra1()) ||
+	// We do not support fork versions before Deneb and after Fulu.
+	if version.IsAfter(forkVersion, version.Fulu()) ||
 		version.IsBefore(forkVersion, version.Deneb()) {
 		return nil, types.ErrForkVersionNotSupported
 	}

--- a/config/spec/defaults.go
+++ b/config/spec/defaults.go
@@ -33,11 +33,6 @@ const (
 	defaultHysteresisDownwardMultiplier = 1
 	defaultHysteresisUpwardMultiplier   = 5
 
-	// Fulu hysteresis values (BRIP-0008).
-	defaultHysteresisQuotientFulu           = 100
-	defaultHysteresisDownwardMultiplierFulu = 1
-	defaultHysteresisUpwardMultiplierFulu   = 10
-
 	// Time parameters constants.
 	defaultSlotsPerEpoch                = 32
 	defaultSlotsPerHistoricalRoot       = 8

--- a/config/spec/defaults.go
+++ b/config/spec/defaults.go
@@ -33,6 +33,11 @@ const (
 	defaultHysteresisDownwardMultiplier = 1
 	defaultHysteresisUpwardMultiplier   = 5
 
+	// Fulu hysteresis values (BRIP-0008).
+	defaultHysteresisQuotientFulu           = 100
+	defaultHysteresisDownwardMultiplierFulu = 1
+	defaultHysteresisUpwardMultiplierFulu   = 10
+
 	// Time parameters constants.
 	defaultSlotsPerEpoch                = 32
 	defaultSlotsPerHistoricalRoot       = 8

--- a/config/spec/devnet.go
+++ b/config/spec/devnet.go
@@ -66,10 +66,6 @@ const (
 	// Set to 0 so devnet starts with Fulu active.
 	devnetFuluForkTime = 0
 
-	// devnetEVMInflationAddressFulu is the address of the EVM inflation contract
-	// after the Fulu fork on devnet.
-	devnetEVMInflationAddressFulu = "0x4206942069420694206942069420694206942069"
-
 	// devnetEVMInflationPerBlockFulu is the amount of native EVM balance (in units
 	// of Gwei) to be minted per EL block after the Fulu fork on devnet.
 	devnetEVMInflationPerBlockFulu = 12 * params.GWei
@@ -108,8 +104,8 @@ func DevnetChainSpecData() *chain.SpecData {
 	specData.SlotsPerEpoch = defaultSlotsPerEpoch
 	specData.MinValidatorWithdrawabilityDelay = devnetMinValidatorWithdrawabilityDelay
 
-	// EVM inflation for the Fulu fork on devnet.
-	specData.EVMInflationAddressFulu = common.MustNewExecutionAddressFromHex(devnetEVMInflationAddressFulu)
+	// EVM inflation for the Fulu fork on devnet. The address remains the same as the Deneb1 fork.
+	specData.EVMInflationAddressFulu = common.MustNewExecutionAddressFromHex(devnetEVMInflationAddressDeneb1)
 	specData.EVMInflationPerBlockFulu = devnetEVMInflationPerBlockFulu
 
 	return specData

--- a/config/spec/devnet.go
+++ b/config/spec/devnet.go
@@ -61,6 +61,18 @@ const (
 
 	// devnetMinValidatorWithdrawabilityDelay is the delay (in epochs) before a validator can withdraw their stake.
 	devnetMinValidatorWithdrawabilityDelay = 32
+
+	// devnetFuluForkTime is the timestamp at which the Fulu fork occurs on devnet.
+	// Set to 0 so devnet starts with Fulu active.
+	devnetFuluForkTime = 0
+
+	// devnetEVMInflationAddressFulu is the address of the EVM inflation contract
+	// after the Fulu fork on devnet.
+	devnetEVMInflationAddressFulu = "0x4206942069420694206942069420694206942069"
+
+	// devnetEVMInflationPerBlockFulu is the amount of native EVM balance (in units
+	// of Gwei) to be minted per EL block after the Fulu fork on devnet.
+	devnetEVMInflationPerBlockFulu = 12 * params.GWei
 )
 
 // DevnetChainSpecData is the chain.SpecData for a devnet. It is similar to mainnet but
@@ -79,6 +91,7 @@ func DevnetChainSpecData() *chain.SpecData {
 	specData.Deneb1ForkTime = devnetDeneb1ForkTime
 	specData.ElectraForkTime = devnetElectraForkTime
 	specData.Electra1ForkTime = devnetElectra1ForkTime
+	specData.FuluForkTime = devnetFuluForkTime
 
 	// EVM inflation is different from mainnet to test.
 	specData.EVMInflationAddressGenesis = common.MustNewExecutionAddressFromHex(devnetEVMInflationAddress)
@@ -94,6 +107,10 @@ func DevnetChainSpecData() *chain.SpecData {
 	specData.EffectiveBalanceIncrement = defaultEffectiveBalanceIncrement
 	specData.SlotsPerEpoch = defaultSlotsPerEpoch
 	specData.MinValidatorWithdrawabilityDelay = devnetMinValidatorWithdrawabilityDelay
+
+	// EVM inflation for the Fulu fork on devnet.
+	specData.EVMInflationAddressFulu = common.MustNewExecutionAddressFromHex(devnetEVMInflationAddressFulu)
+	specData.EVMInflationPerBlockFulu = devnetEVMInflationPerBlockFulu
 
 	return specData
 }

--- a/config/spec/mainnet.go
+++ b/config/spec/mainnet.go
@@ -107,6 +107,12 @@ const (
 	// TODO: Set to actual fork time before Fulu activation.
 	mainnetFuluForkTime = 9_999_999_999_999_999
 
+	// mainnetHysteresisQuotientFulu is the hysteresis quotient for the Fulu fork (BRIP-0008).
+	mainnetHysteresisQuotientFulu = 100
+
+	// mainnetHysteresisUpwardMultiplierFulu is the hysteresis upward multiplier for the Fulu fork.
+	mainnetHysteresisUpwardMultiplierFulu = 10
+
 	// mainnetEVMInflationAddressFulu is the address on the EVM which will receive the
 	// inflation amount of native EVM balance through a withdrawal every block in the Fulu fork.
 	// TODO: Set to actual address before Fulu activation.
@@ -186,16 +192,15 @@ func MainnetChainSpecData() *chain.SpecData {
 		EVMInflationAddressDeneb1:  common.MustNewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1),
 		EVMInflationPerBlockDeneb1: mainnetEVMInflationPerBlockDeneb1,
 
-		// Fulu values (BRIP-0008 hysteresis + PoL vNext).
-		HysteresisQuotientFulu:           defaultHysteresisQuotientFulu,
-		HysteresisDownwardMultiplierFulu: defaultHysteresisDownwardMultiplierFulu,
-		HysteresisUpwardMultiplierFulu:   defaultHysteresisUpwardMultiplierFulu,
-		EVMInflationAddressFulu:          common.MustNewExecutionAddressFromHex(mainnetEVMInflationAddressFulu),
-		EVMInflationPerBlockFulu:         mainnetEVMInflationPerBlockFulu,
-
 		// Electra values.
 		MinActivationBalance:             mainnetMinActivationBalance,
 		MinValidatorWithdrawabilityDelay: mainnetMinValidatorWithdrawabilityDelay,
+
+		// Fulu values (BRIP-0008 hysteresis + PoL vNext).
+		HysteresisQuotientFulu:         mainnetHysteresisQuotientFulu,
+		HysteresisUpwardMultiplierFulu: mainnetHysteresisUpwardMultiplierFulu,
+		EVMInflationAddressFulu:        common.MustNewExecutionAddressFromHex(mainnetEVMInflationAddressFulu),
+		EVMInflationPerBlockFulu:       mainnetEVMInflationPerBlockFulu,
 	}
 
 	specData.Config.ConsensusUpdateHeight = mainnetSBTConsensusUpdateHeight

--- a/config/spec/mainnet.go
+++ b/config/spec/mainnet.go
@@ -102,6 +102,20 @@ const (
 	// These are the heights at which SBT is activated on mainnet.
 	mainnetSBTConsensusUpdateHeight = 9_983_085
 	mainnetSBTConsensusEnableHeight = 9_983_086
+
+	// mainnetFuluForkTime is the timestamp at which the Fulu fork occurs.
+	// TODO: Set to actual fork time before Fulu activation.
+	mainnetFuluForkTime = 9_999_999_999_999_999
+
+	// mainnetEVMInflationAddressFulu is the address on the EVM which will receive the
+	// inflation amount of native EVM balance through a withdrawal every block in the Fulu fork.
+	// TODO: Set to actual address before Fulu activation.
+	mainnetEVMInflationAddressFulu = "0x0000000000000000000000000000000000000000"
+
+	// mainnetEVMInflationPerBlockFulu is the amount of native EVM balance (in Gwei) to be
+	// minted to the EVMInflationAddressFulu via a withdrawal every block in the Fulu fork.
+	// TODO: Set to actual value before Fulu activation.
+	mainnetEVMInflationPerBlockFulu = 0
 )
 
 // MainnetChainSpecData is the chain.SpecData for the Berachain mainnet.
@@ -144,6 +158,7 @@ func MainnetChainSpecData() *chain.SpecData {
 		Deneb1ForkTime:   mainnetDeneb1ForkTime,
 		ElectraForkTime:  mainnetElectraForkTime,
 		Electra1ForkTime: mainnetElectra1ForkTime,
+		FuluForkTime:     mainnetFuluForkTime,
 
 		// State list length constants.
 		EpochsPerHistoricalVector: defaultEpochsPerHistoricalVector,
@@ -170,6 +185,13 @@ func MainnetChainSpecData() *chain.SpecData {
 		// Deneb1 values.
 		EVMInflationAddressDeneb1:  common.MustNewExecutionAddressFromHex(mainnetEVMInflationAddressDeneb1),
 		EVMInflationPerBlockDeneb1: mainnetEVMInflationPerBlockDeneb1,
+
+		// Fulu values (BRIP-0008 hysteresis + PoL vNext).
+		HysteresisQuotientFulu:           defaultHysteresisQuotientFulu,
+		HysteresisDownwardMultiplierFulu: defaultHysteresisDownwardMultiplierFulu,
+		HysteresisUpwardMultiplierFulu:   defaultHysteresisUpwardMultiplierFulu,
+		EVMInflationAddressFulu:          common.MustNewExecutionAddressFromHex(mainnetEVMInflationAddressFulu),
+		EVMInflationPerBlockFulu:         mainnetEVMInflationPerBlockFulu,
 
 		// Electra values.
 		MinActivationBalance:             mainnetMinActivationBalance,

--- a/config/spec/testnet.go
+++ b/config/spec/testnet.go
@@ -49,6 +49,10 @@ func TestnetChainSpecData() *chain.SpecData {
 	// Timestamp of the Electra1 fork on Bepolia.
 	specData.Electra1ForkTime = 1_754_496_000
 
+	// Timestamp of the Fulu fork on Bepolia.
+	// TODO: Set to actual fork time before Fulu activation.
+	specData.FuluForkTime = 9_999_999_999_999_999
+
 	return specData
 }
 

--- a/consensus-types/types/block.go
+++ b/consensus-types/types/block.go
@@ -61,7 +61,7 @@ func NewBeaconBlockWithVersion(
 	forkVersion common.Version,
 ) (*BeaconBlock, error) {
 	switch forkVersion {
-	case version.Deneb(), version.Deneb1(), version.Electra(), version.Electra1():
+	case version.Deneb(), version.Deneb1(), version.Electra(), version.Electra1(), version.Fulu():
 		block := NewEmptyBeaconBlockWithVersion(forkVersion)
 		block.Slot = slot
 		block.ProposerIndex = proposerIndex

--- a/consensus-types/types/payload.go
+++ b/consensus-types/types/payload.go
@@ -575,7 +575,7 @@ func (p *ExecutionPayload) GetExcessBlobGas() math.U64 {
 // ToHeader converts the ExecutionPayload to an ExecutionPayloadHeader.
 func (p *ExecutionPayload) ToHeader() (*ExecutionPayloadHeader, error) {
 	switch p.GetForkVersion() {
-	case version.Deneb(), version.Deneb1(), version.Electra(), version.Electra1():
+	case version.Deneb(), version.Deneb1(), version.Electra(), version.Electra1(), version.Fulu():
 		return &ExecutionPayloadHeader{
 			Versionable:      p.Versionable,
 			ParentHash:       p.GetParentHash(),

--- a/consensus-types/types/signed_beacon_block.go
+++ b/consensus-types/types/signed_beacon_block.go
@@ -70,7 +70,7 @@ func NewSignedBeaconBlock(
 
 func NewEmptySignedBeaconBlockWithVersion(forkVersion common.Version) (*SignedBeaconBlock, error) {
 	switch forkVersion {
-	case version.Deneb(), version.Deneb1(), version.Electra(), version.Electra1():
+	case version.Deneb(), version.Deneb1(), version.Electra(), version.Electra1(), version.Fulu():
 		return &SignedBeaconBlock{
 			BeaconBlock: NewEmptyBeaconBlockWithVersion(forkVersion),
 		}, nil

--- a/execution/client/ethclient/engine.go
+++ b/execution/client/ethclient/engine.go
@@ -70,8 +70,9 @@ func (s *Client) NewPayload(
 			executionRequests,
 		)
 
-	case version.Equals(forkVersion, version.Electra1()):
-		// Use V4P11 for Electra1 versions.
+	case version.Equals(forkVersion, version.Electra1()),
+		version.Equals(forkVersion, version.Fulu()):
+		// Use V4P11 for Electra1 and Fulu versions.
 		executionRequests, err := req.GetEncodedExecutionRequests()
 		if err != nil {
 			return nil, err
@@ -164,8 +165,9 @@ func (s *Client) ForkchoiceUpdated(
 		// Deneb versions and Electra use ForkchoiceUpdatedV3.
 		return s.ForkchoiceUpdatedV3(ctx, state, attrs)
 
-	case version.Equals(forkVersion, version.Electra1()):
-		// Electra1 uses ForkchoiceUpdatedV3P11.
+	case version.Equals(forkVersion, version.Electra1()),
+		version.Equals(forkVersion, version.Fulu()):
+		// Electra1 and Fulu use ForkchoiceUpdatedV3P11.
 		return s.ForkchoiceUpdatedV3P11(ctx, state, attrs)
 
 	default:
@@ -234,7 +236,8 @@ func (s *Client) GetPayload(
 	case version.Equals(forkVersion, version.Electra()):
 		return s.GetPayloadV4(ctx, payloadID, forkVersion)
 
-	case version.Equals(forkVersion, version.Electra1()):
+	case version.Equals(forkVersion, version.Electra1()),
+		version.Equals(forkVersion, version.Fulu()):
 		return s.GetPayloadV4P11(ctx, payloadID, forkVersion)
 
 	default:

--- a/execution/client/ethclient/engine_test.go
+++ b/execution/client/ethclient/engine_test.go
@@ -76,7 +76,7 @@ func TestNewPayloadWithInvalidVersion(t *testing.T) {
 	ctx := t.Context()
 
 	n := mocks.NewPayloadRequest{}
-	n.On("GetForkVersion").Return(version.Electra2())
+	n.On("GetForkVersion").Return(version.Capella())
 	_, err := c.NewPayload(ctx, &n)
 	require.ErrorIs(t, err, ethclient.ErrInvalidVersion)
 }

--- a/primitives/version/name.go
+++ b/primitives/version/name.go
@@ -41,6 +41,8 @@ func Name(v common.Version) string {
 		return "electra"
 	case electra1:
 		return "electra1"
+	case fulu:
+		return "fulu"
 	default:
 		return "unknown"
 	}

--- a/primitives/version/supported.go
+++ b/primitives/version/supported.go
@@ -28,6 +28,7 @@ var supportedVersions = []common.Version{
 	deneb1,
 	electra,
 	electra1,
+	fulu,
 }
 
 // GetSupportedVersions returns the supported versions of beacon-kit.

--- a/primitives/version/versions.go
+++ b/primitives/version/versions.go
@@ -44,9 +44,7 @@ var (
 	electra = common.Version{0x05, 0x00, 0x00, 0x00}
 	// electra1 is the first hardfork of Electra on Berachain mainnet.
 	electra1 = common.Version{0x05, 0x01, 0x00, 0x00}
-	// TBD if used but kept as an example.
-	electra2 = common.Version{0x05, 0x02, 0x00, 0x00}
-	// fulu is the Fulu hardfork of Berachain mainnet (Fusaka CL fork).
+	// fulu is the first version of the Fulu hardfork on Berachain mainnet.
 	fulu = common.Version{0x06, 0x00, 0x00, 0x00}
 )
 
@@ -89,11 +87,6 @@ func Electra() common.Version {
 // Electra1 returns electra1 as a common.Version.
 func Electra1() common.Version {
 	return electra1
-}
-
-// Electra2 returns electra2 as a common.Version.
-func Electra2() common.Version {
-	return electra2
 }
 
 // Fulu returns fulu as a common.Version. Fulu is the CL component of the

--- a/primitives/version/versions.go
+++ b/primitives/version/versions.go
@@ -46,6 +46,8 @@ var (
 	electra1 = common.Version{0x05, 0x01, 0x00, 0x00}
 	// TBD if used but kept as an example.
 	electra2 = common.Version{0x05, 0x02, 0x00, 0x00}
+	// fulu is the Fulu hardfork of Berachain mainnet (Fusaka CL fork).
+	fulu = common.Version{0x06, 0x00, 0x00, 0x00}
 )
 
 // Phase0 returns phase0 as a common.Version.
@@ -92,4 +94,10 @@ func Electra1() common.Version {
 // Electra2 returns electra2 as a common.Version.
 func Electra2() common.Version {
 	return electra2
+}
+
+// Fulu returns fulu as a common.Version. Fulu is the CL component of the
+// Fusaka hardfork on Berachain mainnet.
+func Fulu() common.Version {
+	return fulu
 }

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -401,7 +401,7 @@ func (sp *StateProcessor) processEffectiveBalanceUpdates(st *state.StateDB) erro
 	var (
 		effectiveBalanceIncrement = sp.cs.EffectiveBalanceIncrement()
 		hysteresisIncrement       = effectiveBalanceIncrement / sp.cs.HysteresisQuotient(timestamp)
-		downwardThreshold         = hysteresisIncrement * sp.cs.HysteresisDownwardMultiplier(timestamp)
+		downwardThreshold         = hysteresisIncrement * sp.cs.HysteresisDownwardMultiplier()
 		upwardThreshold           = hysteresisIncrement * sp.cs.HysteresisUpwardMultiplier(timestamp)
 
 		idx     math.U64

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -392,6 +392,12 @@ func (sp *StateProcessor) processEffectiveBalanceUpdates(st *state.StateDB) erro
 
 	// Get the timestamp from the latest execution payload header to determine the active fork
 	// version for fork-gated hysteresis parameters (BRIP-0008).
+	//
+	// Note: this uses the previous block's payload timestamp because processEpoch runs
+	// inside ProcessSlots, before ProcessFork updates the state. If Fulu activates exactly
+	// at an epoch boundary, the new hysteresis values take effect one epoch later. This is
+	// acceptable because hysteresis only affects capital efficiency (not consensus safety),
+	// and is consistent with how all fork-gated logic in processEpoch operates.
 	lph, err := st.GetLatestExecutionPayloadHeader()
 	if err != nil {
 		return err

--- a/state-transition/core/state_processor.go
+++ b/state-transition/core/state_processor.go
@@ -390,11 +390,19 @@ func (sp *StateProcessor) processEffectiveBalanceUpdates(st *state.StateDB) erro
 		return err
 	}
 
+	// Get the timestamp from the latest execution payload header to determine the active fork
+	// version for fork-gated hysteresis parameters (BRIP-0008).
+	lph, err := st.GetLatestExecutionPayloadHeader()
+	if err != nil {
+		return err
+	}
+	timestamp := lph.GetTimestamp()
+
 	var (
 		effectiveBalanceIncrement = sp.cs.EffectiveBalanceIncrement()
-		hysteresisIncrement       = effectiveBalanceIncrement / sp.cs.HysteresisQuotient()
-		downwardThreshold         = hysteresisIncrement * sp.cs.HysteresisDownwardMultiplier()
-		upwardThreshold           = hysteresisIncrement * sp.cs.HysteresisUpwardMultiplier()
+		hysteresisIncrement       = effectiveBalanceIncrement / sp.cs.HysteresisQuotient(timestamp)
+		downwardThreshold         = hysteresisIncrement * sp.cs.HysteresisDownwardMultiplier(timestamp)
+		upwardThreshold           = hysteresisIncrement * sp.cs.HysteresisUpwardMultiplier(timestamp)
 
 		idx     math.U64
 		balance math.Gwei

--- a/state-transition/core/state_processor_forks.go
+++ b/state-transition/core/state_processor_forks.go
@@ -45,6 +45,8 @@ import (
 // NOTE for caller: `ProcessSlots` must be called before this function. If we are
 // crossing into a new fork, the first slot of the new fork will be retrieved from
 // the state. The state must be prepared for this new slot.
+//
+//nolint:gocognit // switch-case is unavoidable here.
 func (sp *StateProcessor) ProcessFork(
 	st *statedb.StateDB, timestamp math.U64, logUpgrade bool,
 ) error {

--- a/state-transition/core/state_processor_forks.go
+++ b/state-transition/core/state_processor_forks.go
@@ -109,6 +109,15 @@ func (sp *StateProcessor) ProcessFork(
 		if logUpgrade {
 			sp.logElectra1Fork(stateFork.PreviousVersion, timestamp, slot)
 		}
+	case version.Fulu():
+		if err = sp.upgradeToFulu(st, stateFork, slot); err != nil {
+			return err
+		}
+
+		// Log the upgrade to Fulu if requested.
+		if logUpgrade {
+			sp.logFuluFork(stateFork.PreviousVersion, timestamp, slot)
+		}
 	default:
 		panic(fmt.Sprintf("unsupported fork version: %s", forkVersion))
 	}
@@ -264,6 +273,53 @@ func (sp *StateProcessor) logElectra1Fork(
 `,
 		version.Name(previousVersion), previousVersion.String(),
 		sp.cs.Electra1ForkTime(),
+		slot.Unwrap(), timestamp.Unwrap(),
+		sp.cs.SlotToEpoch(slot).Unwrap(),
+	))
+}
+
+// upgradeToFulu upgrades the state to the Fulu fork version.
+func (sp *StateProcessor) upgradeToFulu(
+	st *statedb.StateDB, fork *types.Fork, slot math.Slot,
+) error {
+	// Set the fork on BeaconState.
+	fork.PreviousVersion = fork.CurrentVersion
+	fork.CurrentVersion = version.Fulu()
+	fork.Epoch = sp.cs.SlotToEpoch(slot)
+	if err := st.SetFork(fork); err != nil {
+		return err
+	}
+
+	// Initialize the pending partial withdrawals to an empty array if not already initialized.
+	// This handles the case where the chain starts directly on Fulu (e.g., devnet).
+	if _, err := st.GetPendingPartialWithdrawals(); errors.Is(err, collections.ErrNotFound) {
+		sp.metrics.gaugePartialWithdrawalsEnqueued(0)
+		return st.SetPendingPartialWithdrawals([]*types.PendingPartialWithdrawal{})
+	}
+
+	return nil
+}
+
+// logFuluFork logs information about the Fulu fork.
+func (sp *StateProcessor) logFuluFork(
+	previousVersion common.Version, timestamp math.U64, slot math.Slot,
+) {
+	sp.logger.Info(fmt.Sprintf(`
+
+
+	⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️
+
+	+ ✅  welcome to the fulu (0x06000000) fork! 🎉
+	+ 🚝  previous fork: %s (%s)
+	+ ⏱️   fulu fork time: %d
+	+ 🍴  first slot / timestamp of fulu: %d / %d
+	+ ⛓️   current beacon epoch: %d
+
+	⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️⏭️
+
+`,
+		version.Name(previousVersion), previousVersion.String(),
+		sp.cs.FuluForkTime(),
 		slot.Unwrap(), timestamp.Unwrap(),
 		sp.cs.SlotToEpoch(slot).Unwrap(),
 	))

--- a/testing/e2e/standard/beacon_api_test.go
+++ b/testing/e2e/standard/beacon_api_test.go
@@ -889,7 +889,7 @@ func (s *BeaconKitE2ESuite) TestGenesis() {
 	s.Require().NotEmpty(genesis.GenesisValidatorsRoot, "Genesis validators root should not be empty")
 	s.Require().NotEmpty(genesis.GenesisForkVersion, "Genesis fork version should not be empty")
 
-	expectedVersion := version.Electra1() // TODO: change this back to Deneb once devnet spec is updated.
+	expectedVersion := version.Fulu() // TODO: change this back to Deneb once devnet spec is updated.
 	s.Require().Equal(
 		expectedVersion[:],
 		genesis.GenesisForkVersion[:],

--- a/testing/e2e/standard/withdrawal_test.go
+++ b/testing/e2e/standard/withdrawal_test.go
@@ -95,7 +95,7 @@ func (s *BeaconKitE2ESuite) getPendingPartialWithdrawals(stateID string) ([]type
 	}
 
 	// Validate response fields
-	s.Require().Equal(response.Version, version.Name(version.Electra1())) // TODO: assert this is after Electra
+	s.Require().Equal(response.Version, version.Name(version.Fulu())) // TODO: assert this is after Electra
 	s.Require().False(response.ExecutionOptimistic)
 	s.Require().True(response.Finalized)
 

--- a/testing/files/eth-genesis.json
+++ b/testing/files/eth-genesis.json
@@ -20,6 +20,7 @@
     "shanghaiTime": 0,
     "cancunTime": 0,
     "pragueTime": 0,
+    "osakaTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "ethash": {},

--- a/testing/files/spec.toml
+++ b/testing/files/spec.toml
@@ -36,6 +36,7 @@ genesis-time = 0
 deneb-one-fork-time = 0
 electra-fork-time = 0
 electra-one-fork-time = 0
+fulu-fork-time = 0
 
 # State list lengths
 epochs-per-historical-vector = 8
@@ -62,6 +63,13 @@ evm-inflation-per-block = 10_000_000_000
 # Deneb1 value changes
 evm-inflation-address-deneb-one = "0x4206942069420694206942069420694206942069"
 evm-inflation-per-block-deneb-one = 11_000_000_000
+
+# Fulu values (BRIP-0008 hysteresis + PoL vNext)
+hysteresis-quotient-fulu = 100
+hysteresis-downward-multiplier-fulu = 1
+hysteresis-upward-multiplier-fulu = 10
+evm-inflation-address-fulu = "0x4206942069420694206942069420694206942069"
+evm-inflation-per-block-fulu = 12_000_000_000
 
 # Electra values
 min-activation-balance = 32_000_000_000

--- a/testing/files/spec.toml
+++ b/testing/files/spec.toml
@@ -64,16 +64,15 @@ evm-inflation-per-block = 10_000_000_000
 evm-inflation-address-deneb-one = "0x4206942069420694206942069420694206942069"
 evm-inflation-per-block-deneb-one = 11_000_000_000
 
-# Fulu values (BRIP-0008 hysteresis + PoL vNext)
-hysteresis-quotient-fulu = 100
-hysteresis-downward-multiplier-fulu = 1
-hysteresis-upward-multiplier-fulu = 10
-evm-inflation-address-fulu = "0x4206942069420694206942069420694206942069"
-evm-inflation-per-block-fulu = 12_000_000_000
-
 # Electra values
 min-activation-balance = 32_000_000_000
 min-validator-withdrawability-delay = 32
+
+# Fulu values (BRIP-0008 hysteresis + PoL vNext)
+hysteresis-quotient-fulu = 100
+hysteresis-upward-multiplier-fulu = 10
+evm-inflation-address-fulu = "0x4206942069420694206942069420694206942069"
+evm-inflation-per-block-fulu = 12_000_000_000
 
 [block-delay-configuration]
 max-block-delay = 300_000_000_000

--- a/testing/networks/80069/eth-genesis.json
+++ b/testing/networks/80069/eth-genesis.json
@@ -81,6 +81,7 @@
     "petersburgBlock": 0,
     "shanghaiTime": 0,
     "pragueTime": 1746633600,
+    "osakaTime": 9999999999999999,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "blobSchedule": {

--- a/testing/networks/80069/spec.toml
+++ b/testing/networks/80069/spec.toml
@@ -64,16 +64,15 @@ evm-inflation-per-block = 0
 evm-inflation-address-deneb-one = "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba"
 evm-inflation-per-block-deneb-one = 5_750_000_000
 
-# Fulu values (BRIP-0008 hysteresis + PoL vNext)
-hysteresis-quotient-fulu = 100
-hysteresis-downward-multiplier-fulu = 1
-hysteresis-upward-multiplier-fulu = 10
-evm-inflation-address-fulu = "0x0000000000000000000000000000000000000000"
-evm-inflation-per-block-fulu = 0
-
 # Electra values
 min-activation-balance = 250_000_000_000_000
 min-validator-withdrawability-delay = 256
+
+# Fulu values (BRIP-0008 hysteresis + PoL vNext -- TODO: update values)
+hysteresis-quotient-fulu = 100
+hysteresis-upward-multiplier-fulu = 10
+evm-inflation-address-fulu = "0x0000000000000000000000000000000000000000"
+evm-inflation-per-block-fulu = 0
 
 [block-delay-configuration]
 max-block-delay = 300_000_000_000

--- a/testing/networks/80069/spec.toml
+++ b/testing/networks/80069/spec.toml
@@ -36,6 +36,7 @@ genesis-time = 1_739_976_735
 deneb-one-fork-time = 1_740_090_694
 electra-fork-time = 1_746_633_600
 electra-one-fork-time = 1_754_496_000
+fulu-fork-time = 9_999_999_999_999_999
 
 # State list lengths
 epochs-per-historical-vector = 8
@@ -62,6 +63,13 @@ evm-inflation-per-block = 0
 # Deneb1 value changes
 evm-inflation-address-deneb-one = "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba"
 evm-inflation-per-block-deneb-one = 5_750_000_000
+
+# Fulu values (BRIP-0008 hysteresis + PoL vNext)
+hysteresis-quotient-fulu = 100
+hysteresis-downward-multiplier-fulu = 1
+hysteresis-upward-multiplier-fulu = 10
+evm-inflation-address-fulu = "0x0000000000000000000000000000000000000000"
+evm-inflation-per-block-fulu = 0
 
 # Electra values
 min-activation-balance = 250_000_000_000_000

--- a/testing/networks/80094/spec.toml
+++ b/testing/networks/80094/spec.toml
@@ -64,16 +64,15 @@ evm-inflation-per-block = 0
 evm-inflation-address-deneb-one = "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba"
 evm-inflation-per-block-deneb-one = 5_750_000_000
 
-# Fulu values (BRIP-0008 hysteresis + PoL vNext)
-hysteresis-quotient-fulu = 100
-hysteresis-downward-multiplier-fulu = 1
-hysteresis-upward-multiplier-fulu = 10
-evm-inflation-address-fulu = "0x0000000000000000000000000000000000000000"
-evm-inflation-per-block-fulu = 0
-
 # Electra values
 min-activation-balance = 250_000_000_000_000
 min-validator-withdrawability-delay = 256
+
+# Fulu values (BRIP-0008 hysteresis + PoL vNext -- TODO: update values)
+hysteresis-quotient-fulu = 100
+hysteresis-upward-multiplier-fulu = 10
+evm-inflation-address-fulu = "0x0000000000000000000000000000000000000000"
+evm-inflation-per-block-fulu = 0
 
 [block-delay-configuration]
 max-block-delay = 300_000_000_000

--- a/testing/networks/80094/spec.toml
+++ b/testing/networks/80094/spec.toml
@@ -36,6 +36,7 @@ genesis-time = 1_737_381_600
 deneb-one-fork-time = 1_738_415_507
 electra-fork-time = 1_749_056_400
 electra-one-fork-time = 1_756_915_200
+fulu-fork-time = 9_999_999_999_999_999
 
 # State list lengths
 epochs-per-historical-vector = 8
@@ -62,6 +63,13 @@ evm-inflation-per-block = 0
 # Deneb1 value changes
 evm-inflation-address-deneb-one = "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba"
 evm-inflation-per-block-deneb-one = 5_750_000_000
+
+# Fulu values (BRIP-0008 hysteresis + PoL vNext)
+hysteresis-quotient-fulu = 100
+hysteresis-downward-multiplier-fulu = 1
+hysteresis-upward-multiplier-fulu = 10
+evm-inflation-address-fulu = "0x0000000000000000000000000000000000000000"
+evm-inflation-per-block-fulu = 0
 
 # Electra values
 min-activation-balance = 250_000_000_000_000

--- a/testing/simulated/components.go
+++ b/testing/simulated/components.go
@@ -73,6 +73,7 @@ func ProvideElectraGenesisChainSpec() (chain.Spec, error) {
 	specData.Deneb1ForkTime = 0
 	specData.ElectraForkTime = 0
 	specData.Electra1ForkTime = 9223372036854775807
+	specData.FuluForkTime = 9223372036854775807
 	// We set slots per epoch to 2 for faster observation of withdrawal behaviour
 	specData.SlotsPerEpoch = 2
 	// We set this to 4 so tests are faster
@@ -95,6 +96,7 @@ func ProvideSimulationChainSpec() (chain.Spec, error) {
 	// High number as we don't want to activate electra.
 	specData.ElectraForkTime = 9999999999999999
 	specData.Electra1ForkTime = 9999999999999999
+	specData.FuluForkTime = 9999999999999999
 	chainSpec, err := chain.NewSpec(specData)
 	if err != nil {
 		return nil, err
@@ -109,6 +111,7 @@ func ProvidePectraForkTestChainSpec() (chain.Spec, error) {
 	specData.Deneb1ForkTime = 0
 	specData.ElectraForkTime = 10
 	specData.Electra1ForkTime = 9223372036854775807
+	specData.FuluForkTime = 9223372036854775807
 	chainSpec, err := chain.NewSpec(specData)
 	if err != nil {
 		return nil, err
@@ -123,6 +126,7 @@ func ProvidePectraWithdrawalTestChainSpec() (chain.Spec, error) {
 	specData.Deneb1ForkTime = 0
 	specData.ElectraForkTime = 10
 	specData.Electra1ForkTime = 9223372036854775807
+	specData.FuluForkTime = 9223372036854775807
 	// We set slots per epoch to 1 for faster observation of withdrawal behaviour
 	specData.SlotsPerEpoch = 1
 	// We set this to 4 so tests are faster

--- a/testing/simulated/el-genesis-files/eth-genesis.json
+++ b/testing/simulated/el-genesis-files/eth-genesis.json
@@ -19,6 +19,7 @@
     "mergeNetsplitBlock": 0,
     "shanghaiTime": 0,
     "cancunTime": 0,
+    "osakaTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "ethash": {},

--- a/testing/simulated/el-genesis-files/eth-genesis.json
+++ b/testing/simulated/el-genesis-files/eth-genesis.json
@@ -19,7 +19,6 @@
     "mergeNetsplitBlock": 0,
     "shanghaiTime": 0,
     "cancunTime": 0,
-    "osakaTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "ethash": {},


### PR DESCRIPTION
https://github.com/berachain/BRIPs/blob/main/meta/BRIP-0010.md

Add the Fulu fork (CL component of the Fusaka hardfork) with:

- BRIP-0008: Fork-gated hysteresis parameter updates that improve validator capital efficiency by reducing the upward buffer from 125% to ~110% of the effective balance increment (HysteresisQuotient: 4->100, UpwardMultiplier: 5->10, DownwardMultiplier: 1->1 unchanged).

- PoL vNext: New EVMInflationAddressFulu and EVMInflationPerBlockFulu fields following the same pattern as the Genesis-to-Deneb1 inflation migration. Values are placeholders pending PoL vNext design finalization.

- Fulu fork plumbing: version constant (0x06000000), fork time in chain spec, fork ordering validation, state upgrade handler, Engine API routing, consensus type support, and osakaTime in EL genesis configs.

All devnet/testnet/mainnet chain specs and TOML configs updated with placeholder values (devnet: active from genesis, testnet/mainnet: far future).