### PR TITLE
feat(preconf): add observability metrics for sequencer and validator flows

### DIFF
--- a/beacon/blockchain/metrics.go
+++ b/beacon/blockchain/metrics.go
@@ -115,3 +115,8 @@ func (cm *chainMetrics) measureStateRootVerificationTime(start time.Time) {
 		"beacon_kit.blockchain.state_root_verification_duration", start,
 	)
 }
+
+// markRoundChange records a CometBFT round-change event on the sequencer.
+func (cm *chainMetrics) markRoundChange() {
+	cm.sink.IncrementCounter("beacon_kit.preconf.round_change_total")
+}

--- a/beacon/blockchain/round_change.go
+++ b/beacon/blockchain/round_change.go
@@ -44,6 +44,8 @@ func (s *Service) HandleRoundChange(
 		return
 	}
 
+	s.metrics.markRoundChange()
+
 	st := s.storageBackend.StateFromContext(ctx)
 
 	slot := math.Slot(height) //#nosec:G115 // CometBFT heights are always positive.

--- a/beacon/preconf/server.go
+++ b/beacon/preconf/server.go
@@ -30,8 +30,10 @@ import (
 	"time"
 
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
+	engineerrors "github.com/berachain/beacon-kit/engine-primitives/errors"
 	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/log"
+	payloadbuilder "github.com/berachain/beacon-kit/payload/builder"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/crypto"
 	"github.com/berachain/beacon-kit/primitives/math"
@@ -67,6 +69,7 @@ type Server struct {
 	preconfProposerTracker ProposerTracker
 	payloadProvider        PayloadProvider
 	port                   int
+	metrics                *serverMetrics
 
 	mu         sync.RWMutex
 	httpServer *http.Server
@@ -80,6 +83,7 @@ func NewServer(
 	preconfProposerTracker ProposerTracker,
 	payloadProvider PayloadProvider,
 	port int,
+	sink TelemetrySink,
 ) *Server {
 	return &Server{
 		logger:                 logger,
@@ -88,6 +92,7 @@ func NewServer(
 		preconfProposerTracker: preconfProposerTracker,
 		payloadProvider:        payloadProvider,
 		port:                   port,
+		metrics:                newServerMetrics(sink),
 	}
 }
 
@@ -168,8 +173,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 // handleGetPayload handles the GetPayload endpoint.
 func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
+	result := ServerResultOK
+	defer func() { s.metrics.markPayloadRequest(result) }()
+
 	// Only accept POST requests
 	if r.Method != http.MethodPost {
+		result = ServerResultMethodNotAllowed
 		s.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
@@ -177,6 +186,7 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 	// Validate JWT and extract validator pubkey
 	pubkey, err := s.validateJWT(r)
 	if err != nil {
+		result = ServerResultUnauthorized
 		s.logger.Warn("JWT validation failed", "error", err)
 		s.writeError(w, http.StatusUnauthorized, "unauthorized: "+err.Error())
 		return
@@ -184,6 +194,7 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 
 	// Check if validator is whitelisted
 	if s.whitelist != nil && !s.whitelist.IsWhitelisted(pubkey) {
+		result = ServerResultNotWhitelisted
 		s.logger.Warn("Validator not whitelisted", "pubkey", pubkey)
 		s.writeError(w, http.StatusForbidden, "validator not whitelisted")
 		return
@@ -192,12 +203,16 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	var req GetPayloadRequest
 	if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		result = ServerResultBadRequest
 		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return
 	}
 
 	// Verify the requesting validator is the expected proposer for this slot.
-	if !s.preconfProposerTracker.IsExpectedProposer(req.Slot, pubkey) {
+	matched := s.preconfProposerTracker.IsExpectedProposer(req.Slot, pubkey)
+	s.metrics.markProposerCheck(matched)
+	if !matched {
+		result = ServerResultWrongProposer
 		s.logger.Warn("Validator is not the expected proposer for slot",
 			"pubkey", pubkey.String(),
 			"slot", req.Slot,
@@ -211,8 +226,11 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 		"validator_pubkey", pubkey.String(),
 	)
 
-	// Get the payload from provider
-	ctx := r.Context()
+	// fetches the payload from sequencer and writes the http response to the caller
+	result = s.fetchAndWritePayload(r.Context(), w, req)
+}
+
+func (s *Server) fetchAndWritePayload(ctx context.Context, w http.ResponseWriter, req GetPayloadRequest) string {
 	startTime := time.Now()
 	envelope, err := s.payloadProvider.GetPayloadBySlot(ctx, req.Slot, req.ParentBlockRoot)
 	elapsed := time.Since(startTime)
@@ -222,22 +240,27 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 			"error", err,
 			"elapsed", elapsed,
 		)
-		s.writeError(w, http.StatusNotFound, "payload not available: "+err.Error())
-		return
+		if errors.Is(err, payloadbuilder.ErrPayloadIDNotFound) || errors.Is(err, engineerrors.ErrUnknownPayload) {
+			s.writeError(w, http.StatusNotFound, "payload not available: "+err.Error())
+			return ServerResultPayloadNotFound
+		}
+		s.writeError(w, http.StatusInternalServerError, "internal server error")
+		return ServerResultInternalError
 	}
 
 	if envelope == nil {
 		s.writeError(w, http.StatusNotFound, "payload not available")
-		return
+		return ServerResultPayloadNotFound
 	}
 
-	// Write response
 	w.Header().Set("Content-Type", "application/json")
 	if err = json.NewEncoder(w).Encode(NewGetPayloadResponseFromEnvelope(envelope)); err != nil {
-		s.logger.Error("Failed to encode response", "error", err)
+		s.logger.Error("Failed to encode response", "slot", req.Slot, "error", err)
+		return ServerResultSerializationError
 	}
 
 	s.logger.Info("GetPayloadBySlot completed", "slot", req.Slot, "elapsed", elapsed)
+	return ServerResultOK
 }
 
 // validateJWT validates the JWT token from the Authorization header and returns

--- a/beacon/preconf/server.go
+++ b/beacon/preconf/server.go
@@ -30,8 +30,10 @@ import (
 	"time"
 
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
+	engineerrors "github.com/berachain/beacon-kit/engine-primitives/errors"
 	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/log"
+	payloadbuilder "github.com/berachain/beacon-kit/payload/builder"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/crypto"
 	"github.com/berachain/beacon-kit/primitives/math"
@@ -67,6 +69,7 @@ type Server struct {
 	preconfProposerTracker ProposerTracker
 	payloadProvider        PayloadProvider
 	port                   int
+	metrics                *serverMetrics
 
 	mu         sync.RWMutex
 	httpServer *http.Server
@@ -80,6 +83,7 @@ func NewServer(
 	preconfProposerTracker ProposerTracker,
 	payloadProvider PayloadProvider,
 	port int,
+	sink TelemetrySink,
 ) *Server {
 	return &Server{
 		logger:                 logger,
@@ -88,6 +92,7 @@ func NewServer(
 		preconfProposerTracker: preconfProposerTracker,
 		payloadProvider:        payloadProvider,
 		port:                   port,
+		metrics:                newServerMetrics(sink),
 	}
 }
 
@@ -168,8 +173,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 // handleGetPayload handles the GetPayload endpoint.
 func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
+	result := ServerResultOK
+	defer func() { s.metrics.markPayloadRequest(result) }()
+
 	// Only accept POST requests
 	if r.Method != http.MethodPost {
+		result = ServerResultMethodNotAllowed
 		s.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
@@ -177,6 +186,7 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 	// Validate JWT and extract validator pubkey
 	pubkey, err := s.validateJWT(r)
 	if err != nil {
+		result = ServerResultUnauthorized
 		s.logger.Warn("JWT validation failed", "error", err)
 		s.writeError(w, http.StatusUnauthorized, "unauthorized: "+err.Error())
 		return
@@ -184,6 +194,7 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 
 	// Check if validator is whitelisted
 	if s.whitelist != nil && !s.whitelist.IsWhitelisted(pubkey) {
+		result = ServerResultNotWhitelisted
 		s.logger.Warn("Validator not whitelisted", "pubkey", pubkey)
 		s.writeError(w, http.StatusForbidden, "validator not whitelisted")
 		return
@@ -192,12 +203,16 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	var req GetPayloadRequest
 	if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		result = ServerResultBadRequest
 		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return
 	}
 
 	// Verify the requesting validator is the expected proposer for this slot.
-	if !s.preconfProposerTracker.IsExpectedProposer(req.Slot, pubkey) {
+	matched := s.preconfProposerTracker.IsExpectedProposer(req.Slot, pubkey)
+	s.metrics.markProposerCheck(matched)
+	if !matched {
+		result = ServerResultWrongProposer
 		s.logger.Warn("Validator is not the expected proposer for slot",
 			"pubkey", pubkey.String(),
 			"slot", req.Slot,
@@ -211,8 +226,11 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 		"validator_pubkey", pubkey.String(),
 	)
 
-	// Get the payload from provider
-	ctx := r.Context()
+	// Fetch the payload via payloadProvider and write the HTTP response to the caller.
+	result = s.fetchAndWritePayload(r.Context(), w, req)
+}
+
+func (s *Server) fetchAndWritePayload(ctx context.Context, w http.ResponseWriter, req GetPayloadRequest) ServerResult {
 	startTime := time.Now()
 	envelope, err := s.payloadProvider.GetPayloadBySlot(ctx, req.Slot, req.ParentBlockRoot)
 	elapsed := time.Since(startTime)
@@ -222,22 +240,27 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 			"error", err,
 			"elapsed", elapsed,
 		)
-		s.writeError(w, http.StatusNotFound, "payload not available: "+err.Error())
-		return
+		if errors.Is(err, payloadbuilder.ErrPayloadIDNotFound) || errors.Is(err, engineerrors.ErrUnknownPayload) {
+			s.writeError(w, http.StatusNotFound, "payload not available: "+err.Error())
+			return ServerResultPayloadNotFound
+		}
+		s.writeError(w, http.StatusInternalServerError, "internal server error")
+		return ServerResultInternalError
 	}
 
 	if envelope == nil {
 		s.writeError(w, http.StatusNotFound, "payload not available")
-		return
+		return ServerResultPayloadNotFound
 	}
 
-	// Write response
 	w.Header().Set("Content-Type", "application/json")
 	if err = json.NewEncoder(w).Encode(NewGetPayloadResponseFromEnvelope(envelope)); err != nil {
-		s.logger.Error("Failed to encode response", "error", err)
+		s.logger.Warn("Failed to write payload response", "slot", req.Slot, "error", err)
+		return ServerResultResponseWriteError
 	}
 
 	s.logger.Info("GetPayloadBySlot completed", "slot", req.Slot, "elapsed", elapsed)
+	return ServerResultOK
 }
 
 // validateJWT validates the JWT token from the Authorization header and returns

--- a/beacon/preconf/server_metrics.go
+++ b/beacon/preconf/server_metrics.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package preconf
+
+import "strconv"
+
+// Preconf server payload request outcomes used as the `result` label on
+// beacon_kit.preconf.server.payload_request_total.
+const (
+	ServerResultOK                 = "ok"
+	ServerResultUnauthorized       = "unauthorized"
+	ServerResultNotWhitelisted     = "not_whitelisted"
+	ServerResultWrongProposer      = "wrong_proposer"
+	ServerResultPayloadNotFound    = "payload_not_found"
+	ServerResultInternalError      = "internal_error"
+	ServerResultSerializationError = "serialization_error"
+	ServerResultMethodNotAllowed   = "method_not_allowed"
+	ServerResultBadRequest         = "bad_request"
+)
+
+// TelemetrySink is a minimal sink interface used by the preconf server for
+// emitting counters.
+type TelemetrySink interface {
+	IncrementCounter(key string, args ...string)
+}
+
+// serverMetrics wraps a TelemetrySink and emits sequencer-server metrics.
+type serverMetrics struct {
+	sink TelemetrySink
+}
+
+func newServerMetrics(sink TelemetrySink) *serverMetrics {
+	return &serverMetrics{sink: sink}
+}
+
+// markPayloadRequest records the outcome of a GetPayload request.
+func (m *serverMetrics) markPayloadRequest(result string) {
+	m.sink.IncrementCounter("beacon_kit.preconf.server.payload_request_total", "result", result)
+}
+
+// markProposerCheck records the outcome of an expected-proposer check.
+func (m *serverMetrics) markProposerCheck(matched bool) {
+	m.sink.IncrementCounter("beacon_kit.preconf.proposer_tracker.check_total", "matched", strconv.FormatBool(matched))
+}

--- a/beacon/preconf/server_metrics.go
+++ b/beacon/preconf/server_metrics.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package preconf
+
+import "strconv"
+
+// ServerResult is the outcome of a preconf GetPayload request, used as the
+// `result` label on beacon_kit.preconf.server.payload_request_total.
+type ServerResult string
+
+const (
+	ServerResultOK                 ServerResult = "ok"
+	ServerResultUnauthorized       ServerResult = "unauthorized"
+	ServerResultNotWhitelisted     ServerResult = "not_whitelisted"
+	ServerResultWrongProposer      ServerResult = "wrong_proposer"
+	ServerResultPayloadNotFound    ServerResult = "payload_not_found"
+	ServerResultInternalError      ServerResult = "internal_error"
+	ServerResultResponseWriteError ServerResult = "response_write_error"
+	ServerResultMethodNotAllowed   ServerResult = "method_not_allowed"
+	ServerResultBadRequest         ServerResult = "bad_request"
+)
+
+// TelemetrySink is a minimal sink interface used by the preconf server for
+// emitting counters.
+type TelemetrySink interface {
+	IncrementCounter(key string, args ...string)
+}
+
+// serverMetrics wraps a TelemetrySink and emits sequencer-server metrics.
+type serverMetrics struct {
+	sink TelemetrySink
+}
+
+func newServerMetrics(sink TelemetrySink) *serverMetrics {
+	return &serverMetrics{sink: sink}
+}
+
+// markPayloadRequest records the outcome of a GetPayload request.
+func (m *serverMetrics) markPayloadRequest(result ServerResult) {
+	m.sink.IncrementCounter("beacon_kit.preconf.server.payload_request_total", "result", string(result))
+}
+
+// markProposerCheck records the outcome of an expected-proposer check.
+func (m *serverMetrics) markProposerCheck(matched bool) {
+	m.sink.IncrementCounter("beacon_kit.preconf.proposer_tracker.check_total", "matched", strconv.FormatBool(matched))
+}

--- a/beacon/preconf/server_test.go
+++ b/beacon/preconf/server_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -35,6 +36,8 @@ import (
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
 	engineprimitives "github.com/berachain/beacon-kit/engine-primitives/engine-primitives"
 	"github.com/berachain/beacon-kit/log/noop"
+	"github.com/berachain/beacon-kit/node-core/components/metrics"
+	payloadbuilder "github.com/berachain/beacon-kit/payload/builder"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/crypto"
 	"github.com/berachain/beacon-kit/primitives/math"
@@ -121,6 +124,7 @@ func TestServer_HandleGetPayload(t *testing.T) {
 				tracker,
 				provider,
 				0,
+				metrics.NewNoOpTelemetrySink(),
 			)
 
 			body, _ := json.Marshal(preconf.GetPayloadRequest{Slot: tt.requestSlot})
@@ -199,6 +203,7 @@ func TestServer_ProposerCheck(t *testing.T) {
 				tt.setupTracker(),
 				&mockPayloadProvider{hasPayload: true},
 				0,
+				metrics.NewNoOpTelemetrySink(),
 			)
 
 			body, _ := json.Marshal(preconf.GetPayloadRequest{Slot: targetSlot})
@@ -220,7 +225,7 @@ func TestServer_ProposerCheck(t *testing.T) {
 func TestServer_RejectsNonPostMethods(t *testing.T) {
 	t.Parallel()
 
-	server := preconf.NewServer(noop.NewLogger[any](), nil, nil, nil, nil, 0)
+	server := preconf.NewServer(noop.NewLogger[any](), nil, nil, nil, nil, 0, metrics.NewNoOpTelemetrySink())
 
 	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
 		req := httptest.NewRequest(method, preconf.PayloadEndpoint, nil)
@@ -263,7 +268,7 @@ func TestServer_OnSIGHUP(t *testing.T) {
 	wl, err := preconf.NewWhitelist(tmpFile)
 	require.NoError(t, err)
 
-	server := preconf.NewServer(noop.NewLogger[any](), nil, wl, nil, nil, 0)
+	server := preconf.NewServer(noop.NewLogger[any](), nil, wl, nil, nil, 0, metrics.NewNoOpTelemetrySink())
 
 	require.True(t, wl.IsWhitelisted(pkA))
 	require.False(t, wl.IsWhitelisted(pkB))
@@ -283,6 +288,7 @@ func TestServer_OnSIGHUP(t *testing.T) {
 // mockPayloadProvider implements PayloadProvider for tests.
 type mockPayloadProvider struct {
 	hasPayload bool
+	returnErr  error
 }
 
 func (m *mockPayloadProvider) GetPayloadBySlot(
@@ -290,8 +296,11 @@ func (m *mockPayloadProvider) GetPayloadBySlot(
 	_ math.Slot,
 	_ common.Root,
 ) (ctypes.BuiltExecutionPayloadEnv, error) {
+	if m.returnErr != nil {
+		return nil, m.returnErr
+	}
 	if !m.hasPayload {
-		return nil, preconf.ErrPayloadNotFound
+		return nil, payloadbuilder.ErrPayloadIDNotFound
 	}
 	return &mockPayloadEnvelope{forkVersion: version.Deneb1()}, nil
 }
@@ -314,3 +323,113 @@ func (m *mockPayloadEnvelope) GetEncodedExecutionRequests() []ctypes.EncodedExec
 }
 
 func (m *mockPayloadEnvelope) ShouldOverrideBuilder() bool { return false }
+
+// recordingSink captures counter increments for label assertions.
+type recordingSink struct {
+	counters map[string][]string
+}
+
+func newRecordingSink() *recordingSink {
+	return &recordingSink{counters: make(map[string][]string)}
+}
+
+func (r *recordingSink) IncrementCounter(key string, args ...string) {
+	// Expect labels as k,v pairs; record the first value label.
+	if len(args) >= 2 {
+		r.counters[key] = append(r.counters[key], args[1])
+	}
+}
+
+func TestServer_MetricsLabels(t *testing.T) {
+	t.Parallel()
+
+	validatorA, _ := parser.ConvertPubkey(pubkeyAHex)
+	validatorB, _ := parser.ConvertPubkey(pubkeyBHex)
+	secretA, _ := jwt.NewFromHex(secretAHex)
+	secretB, _ := jwt.NewFromHex(secretBHex)
+
+	const (
+		payloadKey  = "beacon_kit.preconf.server.payload_request_total"
+		proposerKey = "beacon_kit.preconf.proposer_tracker.check_total"
+		targetSlot  = math.Slot(100)
+	)
+
+	tests := []struct {
+		name         string
+		requestJWT   *jwt.Secret
+		hasPayload   bool
+		providerErr  error
+		wantResult   string
+		wantProposer string // empty when the proposer check isn't reached
+		wantStatus   int
+	}{
+		{
+			name:         "happy path emits ok",
+			requestJWT:   secretA,
+			hasPayload:   true,
+			wantResult:   preconf.ServerResultOK,
+			wantProposer: "true",
+			wantStatus:   http.StatusOK,
+		},
+		{
+			name:         "wrong proposer emits wrong_proposer",
+			requestJWT:   secretB,
+			hasPayload:   true,
+			wantResult:   preconf.ServerResultWrongProposer,
+			wantProposer: "false",
+			wantStatus:   http.StatusForbidden,
+		},
+		{
+			name:         "missing payload emits payload_not_found",
+			requestJWT:   secretA,
+			hasPayload:   false,
+			wantResult:   preconf.ServerResultPayloadNotFound,
+			wantProposer: "true",
+			wantStatus:   http.StatusNotFound,
+		},
+		{
+			name:         "provider internal error emits internal_error with 500",
+			requestJWT:   secretA,
+			providerErr:  errors.New("EL exploded"),
+			wantResult:   preconf.ServerResultInternalError,
+			wantProposer: "true",
+			wantStatus:   http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := newRecordingSink()
+			tracker := preconf.NewProposerTracker()
+			tracker.SetExpectedProposer(targetSlot, validatorA)
+
+			server := preconf.NewServer(
+				noop.NewLogger[any](),
+				preconf.ValidatorJWTs{validatorA: secretA, validatorB: secretB},
+				newTestWhitelist(t, pubkeyAHex, pubkeyBHex),
+				tracker,
+				&mockPayloadProvider{hasPayload: tt.hasPayload, returnErr: tt.providerErr},
+				0,
+				sink,
+			)
+
+			body, _ := json.Marshal(preconf.GetPayloadRequest{Slot: targetSlot})
+			req := httptest.NewRequest(http.MethodPost, preconf.PayloadEndpoint, bytes.NewReader(body))
+			token, _ := tt.requestJWT.BuildSignedToken()
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rec := httptest.NewRecorder()
+			server.Handler().ServeHTTP(rec, req)
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+			require.Equal(t, []string{tt.wantResult}, sink.counters[payloadKey])
+			if tt.wantProposer == "" {
+				require.Empty(t, sink.counters[proposerKey])
+			} else {
+				require.Equal(t, []string{tt.wantProposer}, sink.counters[proposerKey])
+			}
+		})
+	}
+}

--- a/beacon/preconf/server_test.go
+++ b/beacon/preconf/server_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -35,6 +36,8 @@ import (
 	ctypes "github.com/berachain/beacon-kit/consensus-types/types"
 	engineprimitives "github.com/berachain/beacon-kit/engine-primitives/engine-primitives"
 	"github.com/berachain/beacon-kit/log/noop"
+	"github.com/berachain/beacon-kit/node-core/components/metrics"
+	payloadbuilder "github.com/berachain/beacon-kit/payload/builder"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/crypto"
 	"github.com/berachain/beacon-kit/primitives/math"
@@ -121,6 +124,7 @@ func TestServer_HandleGetPayload(t *testing.T) {
 				tracker,
 				provider,
 				0,
+				metrics.NewNoOpTelemetrySink(),
 			)
 
 			body, _ := json.Marshal(preconf.GetPayloadRequest{Slot: tt.requestSlot})
@@ -199,6 +203,7 @@ func TestServer_ProposerCheck(t *testing.T) {
 				tt.setupTracker(),
 				&mockPayloadProvider{hasPayload: true},
 				0,
+				metrics.NewNoOpTelemetrySink(),
 			)
 
 			body, _ := json.Marshal(preconf.GetPayloadRequest{Slot: targetSlot})
@@ -220,7 +225,7 @@ func TestServer_ProposerCheck(t *testing.T) {
 func TestServer_RejectsNonPostMethods(t *testing.T) {
 	t.Parallel()
 
-	server := preconf.NewServer(noop.NewLogger[any](), nil, nil, nil, nil, 0)
+	server := preconf.NewServer(noop.NewLogger[any](), nil, nil, nil, nil, 0, metrics.NewNoOpTelemetrySink())
 
 	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
 		req := httptest.NewRequest(method, preconf.PayloadEndpoint, nil)
@@ -263,7 +268,7 @@ func TestServer_OnSIGHUP(t *testing.T) {
 	wl, err := preconf.NewWhitelist(tmpFile)
 	require.NoError(t, err)
 
-	server := preconf.NewServer(noop.NewLogger[any](), nil, wl, nil, nil, 0)
+	server := preconf.NewServer(noop.NewLogger[any](), nil, wl, nil, nil, 0, metrics.NewNoOpTelemetrySink())
 
 	require.True(t, wl.IsWhitelisted(pkA))
 	require.False(t, wl.IsWhitelisted(pkB))
@@ -283,6 +288,7 @@ func TestServer_OnSIGHUP(t *testing.T) {
 // mockPayloadProvider implements PayloadProvider for tests.
 type mockPayloadProvider struct {
 	hasPayload bool
+	returnErr  error
 }
 
 func (m *mockPayloadProvider) GetPayloadBySlot(
@@ -290,8 +296,11 @@ func (m *mockPayloadProvider) GetPayloadBySlot(
 	_ math.Slot,
 	_ common.Root,
 ) (ctypes.BuiltExecutionPayloadEnv, error) {
+	if m.returnErr != nil {
+		return nil, m.returnErr
+	}
 	if !m.hasPayload {
-		return nil, preconf.ErrPayloadNotFound
+		return nil, payloadbuilder.ErrPayloadIDNotFound
 	}
 	return &mockPayloadEnvelope{forkVersion: version.Deneb1()}, nil
 }
@@ -314,3 +323,113 @@ func (m *mockPayloadEnvelope) GetEncodedExecutionRequests() []ctypes.EncodedExec
 }
 
 func (m *mockPayloadEnvelope) ShouldOverrideBuilder() bool { return false }
+
+// recordingSink captures counter increments for label assertions.
+type recordingSink struct {
+	counters map[string][]string
+}
+
+func newRecordingSink() *recordingSink {
+	return &recordingSink{counters: make(map[string][]string)}
+}
+
+func (r *recordingSink) IncrementCounter(key string, args ...string) {
+	// Expect labels as k,v pairs; record the first value label.
+	if len(args) >= 2 {
+		r.counters[key] = append(r.counters[key], args[1])
+	}
+}
+
+func TestServer_MetricsLabels(t *testing.T) {
+	t.Parallel()
+
+	validatorA, _ := parser.ConvertPubkey(pubkeyAHex)
+	validatorB, _ := parser.ConvertPubkey(pubkeyBHex)
+	secretA, _ := jwt.NewFromHex(secretAHex)
+	secretB, _ := jwt.NewFromHex(secretBHex)
+
+	const (
+		payloadKey  = "beacon_kit.preconf.server.payload_request_total"
+		proposerKey = "beacon_kit.preconf.proposer_tracker.check_total"
+		targetSlot  = math.Slot(100)
+	)
+
+	tests := []struct {
+		name         string
+		requestJWT   *jwt.Secret
+		hasPayload   bool
+		providerErr  error
+		wantResult   preconf.ServerResult
+		wantProposer string // empty when the proposer check isn't reached
+		wantStatus   int
+	}{
+		{
+			name:         "happy path emits ok",
+			requestJWT:   secretA,
+			hasPayload:   true,
+			wantResult:   preconf.ServerResultOK,
+			wantProposer: "true",
+			wantStatus:   http.StatusOK,
+		},
+		{
+			name:         "wrong proposer emits wrong_proposer",
+			requestJWT:   secretB,
+			hasPayload:   true,
+			wantResult:   preconf.ServerResultWrongProposer,
+			wantProposer: "false",
+			wantStatus:   http.StatusForbidden,
+		},
+		{
+			name:         "missing payload emits payload_not_found",
+			requestJWT:   secretA,
+			hasPayload:   false,
+			wantResult:   preconf.ServerResultPayloadNotFound,
+			wantProposer: "true",
+			wantStatus:   http.StatusNotFound,
+		},
+		{
+			name:         "provider internal error emits internal_error with 500",
+			requestJWT:   secretA,
+			providerErr:  errors.New("EL exploded"),
+			wantResult:   preconf.ServerResultInternalError,
+			wantProposer: "true",
+			wantStatus:   http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := newRecordingSink()
+			tracker := preconf.NewProposerTracker()
+			tracker.SetExpectedProposer(targetSlot, validatorA)
+
+			server := preconf.NewServer(
+				noop.NewLogger[any](),
+				preconf.ValidatorJWTs{validatorA: secretA, validatorB: secretB},
+				newTestWhitelist(t, pubkeyAHex, pubkeyBHex),
+				tracker,
+				&mockPayloadProvider{hasPayload: tt.hasPayload, returnErr: tt.providerErr},
+				0,
+				sink,
+			)
+
+			body, _ := json.Marshal(preconf.GetPayloadRequest{Slot: targetSlot})
+			req := httptest.NewRequest(http.MethodPost, preconf.PayloadEndpoint, bytes.NewReader(body))
+			token, _ := tt.requestJWT.BuildSignedToken()
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rec := httptest.NewRecorder()
+			server.Handler().ServeHTTP(rec, req)
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+			require.Equal(t, []string{string(tt.wantResult)}, sink.counters[payloadKey])
+			if tt.wantProposer == "" {
+				require.Empty(t, sink.counters[proposerKey])
+			} else {
+				require.Equal(t, []string{tt.wantProposer}, sink.counters[proposerKey])
+			}
+		})
+	}
+}

--- a/beacon/validator/block_builder.go
+++ b/beacon/validator/block_builder.go
@@ -228,13 +228,20 @@ func (s *Service) retrieveExecutionPayload(
 				"slot", slot.Base10(),
 				"error", fetchErr,
 			)
+			s.preconfMetrics.markFallback(fallbackReasonFromFetchErr(fetchErr))
 		} else if validateErr := s.validateSequencerPayload(ctx, st, envelope, parentBlockRoot); validateErr != nil {
 			s.logger.Warn("Sequencer payload failed local EL validation, falling back to local build",
 				"slot", slot.Base10(),
 				"error", validateErr,
 			)
+			s.preconfMetrics.markFetch(FetchOutcomeValidationFailed)
+			s.preconfMetrics.markFallback(FallbackReasonValidationFailed)
 		} else {
 			s.logger.Info("Using payload from sequencer", "slot", slot.Base10())
+			s.preconfMetrics.markFetch(FetchOutcomeOK)
+			// Re-emit on every success so the gauge isn't dropped by
+			// prometheus-retention-time when the state never transitions.
+			s.preconfMetrics.setSequencerAvailable(true)
 			return envelope, nil
 		}
 		// Fall through to local building
@@ -477,10 +484,14 @@ func (s *Service) fetchFromSequencer(
 	parentBlockRoot common.Root,
 ) (ctypes.BuiltExecutionPayloadEnv, error) {
 	envelope, err := s.preconfClient.GetPayloadBySlot(ctx, slot, parentBlockRoot)
+	if err != nil {
+		s.preconfMetrics.markFetch(fetchOutcomeFromErr(err))
+	}
 	if errors.Is(err, preconf.ErrSequencerUnavailable) {
 		if s.sequencerMonitorRunning.CompareAndSwap(false, true) {
 			s.logger.Info("Detected sequencer offline, starting health monitor")
 			s.sequencerAvailable.Store(false)
+			s.preconfMetrics.setSequencerAvailable(false)
 			go s.monitorSequencerHealth(ctx)
 		}
 	}
@@ -503,9 +514,34 @@ func (s *Service) monitorSequencerHealth(ctx context.Context) {
 			if s.preconfClient.CheckHealth(ctx) == nil {
 				s.logger.Info("Sequencer is healthy again, stopping health monitor")
 				s.sequencerAvailable.Store(true)
+				s.preconfMetrics.setSequencerAvailable(true)
 				return
 			}
 		}
+	}
+}
+
+// fetchOutcomeFromErr classifies a sequencer fetch error into a metric outcome label.
+func fetchOutcomeFromErr(err error) string {
+	switch {
+	case errors.Is(err, preconf.ErrSequencerUnavailable):
+		return FetchOutcomeUnavailable
+	case errors.Is(err, preconf.ErrPayloadNotFound):
+		return FetchOutcomeNotFound
+	default:
+		return FetchOutcomeOther
+	}
+}
+
+// fallbackReasonFromFetchErr maps a sequencer fetch error to a fallback reason label.
+func fallbackReasonFromFetchErr(err error) string {
+	switch {
+	case errors.Is(err, preconf.ErrSequencerUnavailable):
+		return FallbackReasonUnavailable
+	case errors.Is(err, preconf.ErrPayloadNotFound):
+		return FallbackReasonNotFound
+	default:
+		return FallbackReasonOther
 	}
 }
 

--- a/beacon/validator/interfaces.go
+++ b/beacon/validator/interfaces.go
@@ -99,6 +99,8 @@ type TelemetrySink interface {
 	// IncrementCounter increments a counter metric identified by the provided
 	// keys.
 	IncrementCounter(key string, args ...string)
+	// SetGauge sets a gauge metric to the given value.
+	SetGauge(key string, value int64, args ...string)
 	// MeasureSince measures the time since the provided start time,
 	// identified by the provided keys.
 	MeasureSince(key string, start time.Time, args ...string)

--- a/beacon/validator/preconf_metrics.go
+++ b/beacon/validator/preconf_metrics.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package validator
+
+// Validator-side preconf fetch outcomes used as the `outcome` label on
+// beacon_kit.preconf.client.fetch_total.
+const (
+	FetchOutcomeOK               = "ok"
+	FetchOutcomeUnavailable      = "unavailable"
+	FetchOutcomeNotFound         = "not_found"
+	FetchOutcomeValidationFailed = "validation_failed"
+	FetchOutcomeOther            = "other"
+)
+
+// Fallback-to-local reasons used as the `reason` label on
+// beacon_kit.preconf.client.fallback_to_local_total.
+const (
+	FallbackReasonUnavailable      = "sequencer_unavailable"
+	FallbackReasonNotFound         = "payload_not_found"
+	FallbackReasonValidationFailed = "local_validation_failed"
+	FallbackReasonOther            = "other"
+)
+
+// preconfMetrics wraps a TelemetrySink and emits validator-side preconf metrics.
+type preconfMetrics struct {
+	sink TelemetrySink
+}
+
+func newPreconfMetrics(sink TelemetrySink) *preconfMetrics {
+	return &preconfMetrics{sink: sink}
+}
+
+// markFetch records the outcome of a sequencer payload fetch attempt.
+func (m *preconfMetrics) markFetch(outcome string) {
+	m.sink.IncrementCounter("beacon_kit.preconf.client.fetch_total", "outcome", outcome)
+}
+
+// markFallback records a fallback to local building with the reason that triggered it.
+func (m *preconfMetrics) markFallback(reason string) {
+	m.sink.IncrementCounter("beacon_kit.preconf.client.fallback_to_local_total", "reason", reason)
+}
+
+// setSequencerAvailable sets the sequencer availability gauge (1=available, 0=offline).
+func (m *preconfMetrics) setSequencerAvailable(available bool) {
+	v := int64(0)
+	if available {
+		v = 1
+	}
+	m.sink.SetGauge("beacon_kit.preconf.client.sequencer_available", v)
+}

--- a/beacon/validator/service.go
+++ b/beacon/validator/service.go
@@ -52,6 +52,8 @@ type Service struct {
 	localPayloadBuilder PayloadBuilder
 	// metrics is a metrics collector.
 	metrics *validatorMetrics
+	// preconfMetrics emits validator-side preconf metrics.
+	preconfMetrics *preconfMetrics
 
 	// engineClient is used to validate sequencer payloads against the local EL.
 	engineClient EngineClient
@@ -93,11 +95,17 @@ func NewService(
 		blobFactory:         blobFactory,
 		localPayloadBuilder: localPayloadBuilder,
 		metrics:             newValidatorMetrics(ts),
+		preconfMetrics:      newPreconfMetrics(ts),
 		engineClient:        engineClient,
 		preconfCfg:          preconfCfg,
 		preconfClient:       preconfClient,
 	}
 	s.sequencerAvailable.Store(true) // assume sequencer is up until proven otherwise
+	// Emit initial gauge so scrapes see a value before any state change. Only
+	// meaningful when this node actually fetches from the sequencer.
+	if preconfCfg != nil && preconfCfg.ShouldFetchFromSequencer() {
+		s.preconfMetrics.setSequencerAvailable(true)
+	}
 	return s
 }
 

--- a/node-core/components/preconf_server.go
+++ b/node-core/components/preconf_server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/berachain/beacon-kit/config"
 	"github.com/berachain/beacon-kit/errors"
 	"github.com/berachain/beacon-kit/log/phuslu"
+	"github.com/berachain/beacon-kit/node-core/components/metrics"
 	payloadbuilder "github.com/berachain/beacon-kit/payload/builder"
 )
 
@@ -38,6 +39,7 @@ type PreconfServerInput struct {
 	Whitelist              preconf.Whitelist
 	PreconfProposerTracker preconf.ProposerTracker
 	LocalBuilder           *payloadbuilder.PayloadBuilder
+	TelemetrySink          *metrics.TelemetrySink
 }
 
 // ProvidePreconfServer provides the preconf API server for sequencer mode.
@@ -85,5 +87,6 @@ func ProvidePreconfServer(in PreconfServerInput) (*preconf.Server, error) {
 		in.PreconfProposerTracker,
 		in.LocalBuilder,
 		cfg.APIPort,
+		in.TelemetrySink,
 	), nil
 }


### PR DESCRIPTION
This PR adds observability metrics for preconf sequencer/validator flows:
- Sequencer-side: request outcomes, proposer-check results
- Validator-side: fetch outcomes, fallback reasons, sequencer-available gauge
- Blockchain: round-change counter
- Internal errors now return `500` (was `404`) so HTTP status matches the metric label 