### PR TITLE
fix(test): fix race on db flaky test

### DIFF
--- a/storage/filedb/db.go
+++ b/storage/filedb/db.go
@@ -50,8 +50,9 @@ func NewDB(opts ...Option) *DB {
 	}
 
 	if db.fs == nil {
-		db.fs = afero.NewBasePathFs(afero.NewOsFs(), db.rootDir)
+		db.fs = afero.NewOsFs()
 	}
+	db.fs = afero.NewBasePathFs(db.fs, db.rootDir)
 	return db
 }
 

--- a/storage/filedb/db.go
+++ b/storage/filedb/db.go
@@ -49,7 +49,9 @@ func NewDB(opts ...Option) *DB {
 		}
 	}
 
-	db.fs = afero.NewBasePathFs(afero.NewOsFs(), db.rootDir)
+	if db.fs == nil {
+		db.fs = afero.NewBasePathFs(afero.NewOsFs(), db.rootDir)
+	}
 	return db
 }
 

--- a/storage/filedb/db_test.go
+++ b/storage/filedb/db_test.go
@@ -181,13 +181,11 @@ func TestDB_SetExistingKey_CreateError(t *testing.T) {
 
 	t.Run(test.name, func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
 		db := file.NewDB(
 			file.WithRootDirectory("/etc"),
 			file.WithFileExtension("txt"),
 			file.WithDirectoryPermissions(0700),
 			file.WithLogger(log.NewNopLogger()),
-			file.WithAferoFS(fs),
 		)
 
 		if test.setupFunc != nil {
@@ -237,13 +235,11 @@ func TestDB_SetHas_NotDirError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			fs := afero.NewMemMapFs()
 			db := file.NewDB(
 				file.WithRootDirectory("/etc/passwd"),
 				file.WithFileExtension("txt"),
 				file.WithDirectoryPermissions(0700),
 				file.WithLogger(log.NewNopLogger()),
-				file.WithAferoFS(fs),
 			)
 
 			if tt.setupFunc != nil {
@@ -280,13 +276,11 @@ func TestDB_Set_MkDirError(t *testing.T) {
 
 	t.Run(test.name, func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
 		db := file.NewDB(
 			file.WithRootDirectory("/etc/test"),
 			file.WithFileExtension("txt"),
 			file.WithDirectoryPermissions(0700),
 			file.WithLogger(log.NewNopLogger()),
-			file.WithAferoFS(fs),
 		)
 
 		if test.setupFunc != nil {

--- a/storage/filedb/range_db_test.go
+++ b/storage/filedb/range_db_test.go
@@ -292,7 +292,7 @@ func TestRangeDB_Invariants(t *testing.T) {
 			},
 			testFunc: func(t *testing.T, rdb *file.RangeDB) {
 				t.Helper()
-				requireNotExist(t, rdb, 0, lastConsequetiveNilIndex(rdb))
+				requireNotExist(t, rdb, 0, lastConsecutiveNilIndex(rdb))
 			},
 		},
 		{
@@ -303,7 +303,7 @@ func TestRangeDB_Invariants(t *testing.T) {
 			testFunc: func(t *testing.T, rdb *file.RangeDB) {
 				t.Helper()
 				_ = rdb.Delete(2, []byte("key"))
-				requireNotExist(t, rdb, 0, lastConsequetiveNilIndex(rdb))
+				requireNotExist(t, rdb, 0, lastConsecutiveNilIndex(rdb))
 			},
 		},
 		{
@@ -314,7 +314,7 @@ func TestRangeDB_Invariants(t *testing.T) {
 			testFunc: func(t *testing.T, rdb *file.RangeDB) {
 				t.Helper()
 				_ = rdb.Prune(0, 3)
-				requireNotExist(t, rdb, 0, lastConsequetiveNilIndex(rdb))
+				requireNotExist(t, rdb, 0, lastConsecutiveNilIndex(rdb))
 			},
 		},
 		{
@@ -328,7 +328,7 @@ func TestRangeDB_Invariants(t *testing.T) {
 					t.Fatalf("Prune() error = %v", err)
 				}
 				_ = populateTestDB(rdb, 5, 10)
-				requireNotExist(t, rdb, 0, lastConsequetiveNilIndex(rdb))
+				requireNotExist(t, rdb, 0, lastConsecutiveNilIndex(rdb))
 			},
 		},
 	}
@@ -343,7 +343,7 @@ func TestRangeDB_Invariants(t *testing.T) {
 						t,
 						rdb,
 						0,
-						lastConsequetiveNilIndex(rdb),
+						lastConsecutiveNilIndex(rdb),
 					)
 				}
 			}
@@ -408,7 +408,7 @@ func getFirstNonNilIndex(rdb *file.RangeDB) uint64 {
 	return reflect.ValueOf(rdb).Elem().FieldByName("lowerBoundIndex").Uint()
 }
 
-func lastConsequetiveNilIndex(rdb *file.RangeDB) uint64 {
+func lastConsecutiveNilIndex(rdb *file.RangeDB) uint64 {
 	return uint64(max(int64(getFirstNonNilIndex(rdb))-1, 0))
 }
 


### PR DESCRIPTION
Fixes this failing pipeline:

https://github.com/berachain/beacon-kit/actions/runs/24676377991/job/72161386938?pr=3086

`TestRangeDB_Invariants/Prune_from_populated` failing with `"Index 1 should have been pruned"` because of test isolation breakage