### PR TITLE
fix(engine): retry on EL connection errors to survive EL restarts

### DIFF
--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -123,10 +123,7 @@ func (s *EngineClient) handleRPCError(
 // IsFatalError defines errors that indicate a bad request or an otherwise
 // unusable client.
 func IsFatalError(err error) bool {
-	return jsonrpc.IsPreDefinedError(err) || errors.IsAny(
-		err,
-		ErrBadConnection,
-	)
+	return jsonrpc.IsPreDefinedError(err)
 }
 
 // IsNonFatalError defines errors that should be ephemeral and can be
@@ -136,5 +133,6 @@ func IsNonFatalError(err error) bool {
 		err,
 		engineerrors.ErrEngineAPITimeout,
 		http.ErrTimeout,
+		ErrBadConnection,
 	)
 }

--- a/testing/simulated/chaos_test.go
+++ b/testing/simulated/chaos_test.go
@@ -26,56 +26,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/berachain/beacon-kit/execution/client"
 	"github.com/cometbft/cometbft/abci/types"
 )
-
-// TestProcessProposal_CrashedExecutionClient_Errors effectively serves as a test for how a valid node would react to
-// a valid block being proposed but the execution client has crashed.
-func (s *SimulatedSuite) TestProcessProposal_CrashedExecutionClient_Errors() {
-	const blockHeight = 1
-	const coreLoopIterations = 1
-
-	// Initialize the chain state.
-	s.InitializeChain(s.T(), 1)
-	nodeAddress, err := s.SimComet.GetNodeAddress()
-	s.Require().NoError(err)
-	s.SimComet.Comet.SetNodeAddress(nodeAddress)
-
-	// Test happens post Deneb1 fork.
-	startTime := time.Now()
-
-	// Go through 1 iteration of the core loop to bypass any startup specific edge cases such as sync head on startup.
-	proposals, _, proposalTime := s.MoveChainToHeight(s.T(), blockHeight, coreLoopIterations, nodeAddress, startTime)
-	s.Require().Len(proposals, coreLoopIterations)
-
-	currentHeight := int64(blockHeight + coreLoopIterations)
-
-	// Prepare a valid block proposal.
-	proposal, err := s.SimComet.Comet.PrepareProposal(s.CtxComet, &types.PrepareProposalRequest{
-		Height:          currentHeight,
-		Time:            proposalTime,
-		ProposerAddress: nodeAddress,
-	})
-	s.Require().NoError(err)
-	s.Require().NotEmpty(proposal)
-
-	// Reset the log buffer to discard old logs we don't care about.
-	s.LogBuffer.Reset()
-	// Kill the execution client.
-	err = s.ElHandle.Close()
-	s.Require().NoError(err)
-	// Process the proposal containing the valid block.
-	processResp, err := s.SimComet.Comet.ProcessProposal(s.CtxComet, &types.ProcessProposalRequest{
-		Txs:             proposal.Txs,
-		Height:          currentHeight,
-		ProposerAddress: nodeAddress,
-		Time:            proposalTime,
-	})
-	s.Require().NoError(err)
-	s.Require().Equal(types.PROCESS_PROPOSAL_STATUS_REJECT, processResp.Status)
-	s.Require().Contains(s.LogBuffer.String(), client.ErrBadConnection.Error())
-}
 
 // TestContextHandling_SIGINT_SafeShutdown mimicks the expected outcome of a SIGINT by calling context cancel and stop services.
 func (s *SimulatedSuite) TestContextHandling_SIGINT_SafeShutdown() {

--- a/testing/simulated/rpc_errors_test.go
+++ b/testing/simulated/rpc_errors_test.go
@@ -47,10 +47,12 @@ import (
 )
 
 // HTTP proxy in between beacon node and execution client. When active,
-// replaces responses with specified JSON-RPC error.
+// replaces responses with specified JSON-RPC error. When dropConn is set,
+// hijacks and closes the TCP connection to simulate an unreachable EL.
 type rpcErrorProxy struct {
 	targetURL  string
 	active     atomic.Bool
+	dropConn   atomic.Bool
 	errorCode  int
 	errorMsg   string
 	httpClient *http.Client
@@ -69,8 +71,15 @@ func (p *rpcErrorProxy) activate(code int, msg string) {
 	p.active.Store(true)
 }
 
+// activateDropConn simulates an unreachable EL by dropping the TCP
+// connection on any engine-API request.
+func (p *rpcErrorProxy) activateDropConn() {
+	p.dropConn.Store(true)
+}
+
 func (p *rpcErrorProxy) deactivate() {
 	p.active.Store(false)
+	p.dropConn.Store(false)
 }
 
 func (p *rpcErrorProxy) getErr(reqId json.RawMessage) string {
@@ -88,21 +97,8 @@ func (p *rpcErrorProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	// Check if need interceptor.
-	if p.active.Load() {
-		var req struct {
-			ID     json.RawMessage `json:"id"`
-			Method string          `json:"method"`
-		}
-		if json.Unmarshal(bodyBytes, &req) == nil {
-			// Intercept targeted methods.
-			if isTargetedEngineMethod(req.Method) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(p.getErr(req.ID)))
-				return
-			}
-		}
+	if p.intercept(w, bodyBytes) {
+		return
 	}
 
 	// Forward original request.
@@ -130,6 +126,45 @@ func (p *rpcErrorProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+// intercept reports whether the request should be intercepted and writes
+// the intercepted response to w. Returns true when the request was handled.
+func (p *rpcErrorProxy) intercept(w http.ResponseWriter, bodyBytes []byte) bool {
+	if !p.active.Load() && !p.dropConn.Load() {
+		return false
+	}
+	var req struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	if json.Unmarshal(bodyBytes, &req) != nil || !isTargetedEngineMethod(req.Method) {
+		return false
+	}
+	if p.dropConn.Load() {
+		dropTCPConn(w)
+		return true
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(p.getErr(req.ID)))
+	return true
+}
+
+// dropTCPConn hijacks and closes the TCP connection to simulate an
+// unreachable EL.
+func dropTCPConn(w http.ResponseWriter) {
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijack not supported", http.StatusInternalServerError)
+		return
+	}
+	conn, _, err := hj.Hijack()
+	if err != nil {
+		http.Error(w, "hijack failed", http.StatusInternalServerError)
+		return
+	}
+	_ = conn.Close()
 }
 
 func isTargetedEngineMethod(method string) bool {
@@ -284,4 +319,34 @@ func (s *RPCErrorProxySuite) TestFinalizeBlock_HandleRPCError() {
 	s.Require().Error(err, "FinalizeBlock should fail on fatal RPC error")
 	s.Require().Nil(finalizeResp)
 	s.Require().ErrorIs(err, jsonrpc.ErrParse, "Error should be correctly classified")
+}
+
+// TestFinalizeBlock_ConnectionDrop_Recovery shows that when the EL is
+// unreachable (e.g. bera-reth restart) the engine keeps retrying and
+// FinalizeBlock succeeds once the EL comes back.
+func (s *RPCErrorProxySuite) TestFinalizeBlock_ConnectionDrop_Recovery() {
+	pp := s.prepareForFinalize()
+
+	// Simulate the EL going away: next engine-API requests have their TCP
+	// connection dropped.
+	s.errProxy.activateDropConn()
+
+	// Bring the EL back after a short delay so the retry can succeed.
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		s.errProxy.deactivate()
+	}()
+
+	finalizeResp, err := s.SimComet.Comet.FinalizeBlock(s.CtxComet, &types.FinalizeBlockRequest{
+		Txs:             pp.txs,
+		Height:          pp.height,
+		ProposerAddress: pp.proposerAddress,
+		Time:            pp.proposalTime,
+	})
+
+	s.Require().NoError(err, "FinalizeBlock should recover after EL comes back")
+	s.Require().NotNil(finalizeResp)
+
+	logs := s.LogBuffer.String()
+	s.Require().Contains(logs, "non fatal error", "Should log non fatal retry attempts")
 }


### PR DESCRIPTION
Fixes #3083. Restarting the EL (e.g. `bera-reth`) left `beacond` unable to recover on its own and the beacon node had to be restarted too.

The root cause was that `ErrBadConnection` was classified as fatal and wrapped in `backoff.Permanent`, so the retry loop (configured for infinite retries) bailed on the first attempt. `FinalizeBlock` returned the error to CometBFT and consensus could not progress.

This PR addresses this by reclassifying `ErrBadConnection` as non-fatal. A dropped TCP connection is exactly the retryable case the existing backoff was built for. The retry loop now waits out the outage and resumes once the EL is back. Truly fatal errors (JSON-RPC predefined errors, invalid payload status) stay fatal.

**Test Plan**
- Unit test pinning the classification of `ErrBadConnection`.
- Simulated test that drops the TCP connection mid-flight and asserts `FinalizeBlock` recovers once the EL returns.
- Also removed `TestProcessProposal_CrashedExecutionClient_Errors`. It pinned the old fast-fail behavior and is now redundant with the unit test and the new connection-drop recovery test.
- Tested this on local kurtosis devnet and obvserved that beacond successfully resumed when bera-reth was restarted
