### PR TITLE
fix: guard capabilities map with RWMutex

### DIFF
--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -48,7 +48,8 @@ type EngineClient struct {
 	// clientMetrics is the metrics for the engine client.
 	metrics *clientMetrics
 	// capabilities is a map of capabilities that the execution client has.
-	capabilities map[string]struct{}
+	capabilitiesMu sync.RWMutex
+	capabilities   map[string]struct{}
 	// connected will be set to true when we have successfully connected
 	// to the execution client.
 	connectedMu sync.RWMutex
@@ -166,6 +167,8 @@ func (s *EngineClient) IsConnected() bool {
 }
 
 func (s *EngineClient) HasCapability(capability string) bool {
+	s.capabilitiesMu.RLock()
+	defer s.capabilitiesMu.RUnlock()
 	_, ok := s.capabilities[capability]
 	return ok
 }

--- a/execution/client/client_test.go
+++ b/execution/client/client_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package client
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestCapabilitiesRace verifies that concurrent writes (ExchangeCapabilities)
+// and reads (HasCapability) on the capabilities map do not race.
+func TestCapabilitiesRace(t *testing.T) {
+	t.Parallel()
+
+	c := &EngineClient{
+		capabilities: make(map[string]struct{}),
+	}
+
+	const cap = "engine_newPayloadV3"
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: repeatedly write a capability (simulates ExchangeCapabilities).
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			c.capabilitiesMu.Lock()
+			c.capabilities[cap] = struct{}{}
+			c.capabilitiesMu.Unlock()
+		}
+	}()
+
+	// Goroutine 2: repeatedly read a capability (simulates HasCapability).
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			c.HasCapability(cap)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/execution/client/engine.go
+++ b/execution/client/engine.go
@@ -167,13 +167,17 @@ func (s *EngineClient) ExchangeCapabilities(
 		return nil, err
 	}
 
-	// Capture and log the capabilities that the execution client has.
+	// Write all capabilities under a single lock acquisition.
 	s.capabilitiesMu.Lock()
 	for _, capability := range result {
-		s.logger.Info("Exchanged capability", "capability", capability)
 		s.capabilities[capability] = struct{}{}
 	}
 	s.capabilitiesMu.Unlock()
+
+	// Log after the lock is released to avoid blocking readers during I/O.
+	for _, capability := range result {
+		s.logger.Info("Exchanged capability", "capability", capability)
+	}
 
 	// Log the capabilities that the execution client does not have.
 	for _, capability := range ethclient.BeaconKitSupportedCapabilities() {

--- a/execution/client/engine.go
+++ b/execution/client/engine.go
@@ -168,10 +168,12 @@ func (s *EngineClient) ExchangeCapabilities(
 	}
 
 	// Capture and log the capabilities that the execution client has.
+	s.capabilitiesMu.Lock()
 	for _, capability := range result {
 		s.logger.Info("Exchanged capability", "capability", capability)
 		s.capabilities[capability] = struct{}{}
 	}
+	s.capabilitiesMu.Unlock()
 
 	// Log the capabilities that the execution client does not have.
 	for _, capability := range ethclient.BeaconKitSupportedCapabilities() {


### PR DESCRIPTION
## Summary

- `EngineClient.capabilities` map had no mutex protecting it, while ExchangeCapabilities (write) and HasCapability (read) can be called concurrently from different goroutines
- The race window is most likely during execution client reconnects: the startup ticker calls `ExchangeCapabilities` repeatedly while ReportingService calls `HasCapability` every 5 minutes independently

