### PR TITLE
fix(da): guard against nil inner BeaconBlockHeader in BlobSidecar decode

### DIFF
--- a/da/types/sidecar.go
+++ b/da/types/sidecar.go
@@ -174,6 +174,9 @@ func (b *BlobSidecar) ValidateAfterDecodingSSZ() error {
 	if b.SignedBeaconBlockHeader == nil {
 		b.SignedBeaconBlockHeader = &ctypes.SignedBeaconBlockHeader{}
 	}
+	if b.SignedBeaconBlockHeader.Header == nil {
+		b.SignedBeaconBlockHeader.Header = &ctypes.BeaconBlockHeader{}
+	}
 	return nil
 }
 

--- a/da/types/sidecar_test.go
+++ b/da/types/sidecar_test.go
@@ -205,6 +205,60 @@ func Test_KZGRootIndex(t *testing.T) {
 	require.Equal(t, 2*kzgParentRootIndex, uint64(ctypes.KZGRootIndex))
 }
 
+func TestValidateAfterDecodingSSZ_NilHeaders(t *testing.T) {
+	t.Parallel()
+
+	inclusionProof := make([]common.Root, ctypes.KZGInclusionProofDepth)
+
+	tests := []struct {
+		name    string
+		sidecar *types.BlobSidecar
+	}{
+		{
+			name: "nil SignedBeaconBlockHeader",
+			sidecar: &types.BlobSidecar{
+				Index:                   1,
+				Blob:                    eip4844.Blob{},
+				KzgCommitment:           eip4844.KZGCommitment{},
+				KzgProof:                eip4844.KZGProof{},
+				SignedBeaconBlockHeader: nil,
+				InclusionProof:          inclusionProof,
+			},
+		},
+		{
+			name: "nil inner Header",
+			sidecar: &types.BlobSidecar{
+				Index:         1,
+				Blob:          eip4844.Blob{},
+				KzgCommitment: eip4844.KZGCommitment{},
+				KzgProof:      eip4844.KZGProof{},
+				SignedBeaconBlockHeader: &ctypes.SignedBeaconBlockHeader{
+					Header:    nil,
+					Signature: crypto.BLSSignature{},
+				},
+				InclusionProof: inclusionProof,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sc := tt.sidecar
+
+			require.NoError(t, sc.ValidateAfterDecodingSSZ())
+			require.NotNil(t, sc.SignedBeaconBlockHeader)
+			require.NotNil(t, sc.SignedBeaconBlockHeader.Header)
+			require.NotNil(t, sc.GetBeaconBlockHeader())
+
+			require.NotPanics(t, func() {
+				slot := sc.GetBeaconBlockHeader().GetSlot()
+				require.Equal(t, math.Slot(0), slot)
+			})
+		})
+	}
+}
+
 func TestHashTreeRoot(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Karalabe SSZ permits the inner Header pointer of a SignedBeaconBlockHeader to decode to nil when the wire payload encodes that field as zero-length. The existing nil-fill in ValidateAfterDecodingSSZ only initialized the outer SignedBeaconBlockHeader, leaving the inner Header pointer nil and allowing a crafted gossiped sidecar to panic any node that reaches da/store.Persist (GetBeaconBlockHeader().GetSlot()).

Extend the same zero-fill mitigation one level deeper so downstream accessors are nil-safe. Adds a regression test covering both the outer and inner nil shapes.