### PR TITLE
fix(engine): classify EL HTTP 4xx as fatal via typed HTTPStatusError

### DIFF
--- a/execution/client/client.go
+++ b/execution/client/client.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	nethttp "net/http"
 	"sync"
 	"time"
 
@@ -32,7 +33,6 @@ import (
 	ethclientrpc "github.com/berachain/beacon-kit/execution/client/ethclient/rpc"
 	"github.com/berachain/beacon-kit/log"
 	"github.com/berachain/beacon-kit/primitives/math"
-	"github.com/berachain/beacon-kit/primitives/net/http"
 	"github.com/berachain/beacon-kit/primitives/net/jwt"
 )
 
@@ -193,8 +193,8 @@ func (s *EngineClient) verifyChainIDAndConnection(
 	// After the initial dial, check to make sure the chain ID is correct.
 	chainID, err = s.Client.ChainID(ctx)
 	if err != nil {
-		if errors.Is(err, http.ErrUnauthorized) {
-			// We always log this error as it is a critical error.
+		var httpErr *ethclientrpc.HTTPStatusError
+		if errors.As(err, &httpErr) && httpErr != nil && httpErr.StatusCode == nethttp.StatusUnauthorized {
 			s.logger.Error(UnauthenticatedConnectionErrorStr)
 		}
 		return err

--- a/execution/client/errors.go
+++ b/execution/client/errors.go
@@ -23,6 +23,7 @@ package client
 import (
 	engineerrors "github.com/berachain/beacon-kit/engine-primitives/errors"
 	"github.com/berachain/beacon-kit/errors"
+	"github.com/berachain/beacon-kit/execution/client/ethclient/rpc"
 	"github.com/berachain/beacon-kit/primitives/net/http"
 	jsonrpc "github.com/berachain/beacon-kit/primitives/net/json-rpc"
 )
@@ -42,6 +43,11 @@ var (
 	// ErrBadConnection indicates that the http.Client was unable to
 	// establish a connection.
 	ErrBadConnection = errors.New("connection error")
+
+	// ErrHTTPClientError indicates an HTTP 4xx response from the EL.
+	// The request itself is rejected (oversized body, bad request, etc.) and
+	// retrying with the same payload will never succeed. Classified as fatal.
+	ErrHTTPClientError = errors.New("http client error")
 )
 
 // Handles errors received from the RPC server according to the specification.
@@ -62,14 +68,19 @@ func (s *EngineClient) handleRPCError(
 		s.metrics.incrementHTTPTimeoutCounter()
 		return http.ErrTimeout
 	}
-	// Check for authorization errors
-	if errors.Is(err, http.ErrUnauthorized) {
-		return err
-	}
-	// Check for connection errors.
+
 	var e jsonrpc.Error
 	ok := errors.As(err, &e)
 	if !ok || e == nil {
+		// Not a JSON-RPC error, classify by transport-level signal.
+		var httpErr *rpc.HTTPStatusError
+		if errors.As(err, &httpErr) && httpErr != nil &&
+			httpErr.StatusCode >= 400 && httpErr.StatusCode < 500 {
+			// HTTP 4xx is a request-level rejection; retrying with the same payload will never
+			// succeed. Fatal so the proposer skips the slot instead of looping.
+			return errors.Join(ErrHTTPClientError, err)
+		}
+		// 5xx, other non-200, and plain transport failures fall through to ErrBadConnection.
 		return errors.Join(ErrBadConnection, err)
 	}
 
@@ -120,10 +131,16 @@ func (s *EngineClient) handleRPCError(
 	}
 }
 
-// IsFatalError defines errors that indicate a bad request or an otherwise
-// unusable client.
+// IsFatalError defines errors that indicate a bad request or an otherwise unusable client.
+// HTTP 4xx is fatal as the EL rejected the request itself (retrying with the same payload will fail).
 func IsFatalError(err error) bool {
-	return jsonrpc.IsPreDefinedError(err)
+	if jsonrpc.IsPreDefinedError(err) {
+		return true
+	}
+	if errors.Is(err, ErrHTTPClientError) {
+		return true
+	}
+	return false
 }
 
 // IsNonFatalError defines errors that should be ephemeral and can be

--- a/execution/client/errors_test.go
+++ b/execution/client/errors_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+//nolint:testpackage // we test the unexported handleRPCError method.
+package client
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	engineerrors "github.com/berachain/beacon-kit/engine-primitives/errors"
+	"github.com/berachain/beacon-kit/execution/client/ethclient/rpc"
+	"github.com/berachain/beacon-kit/log/phuslu"
+	beaconhttp "github.com/berachain/beacon-kit/primitives/net/http"
+	"github.com/stretchr/testify/require"
+)
+
+// noopSink implements TelemetrySink with no side effects.
+type noopSink struct{}
+
+func (noopSink) IncrementCounter(string, ...string)        {}
+func (noopSink) MeasureSince(string, time.Time, ...string) {}
+
+func newTestEngineClient() *EngineClient {
+	return &EngineClient{
+		logger:  phuslu.NewLogger(io.Discard, nil),
+		metrics: newClientMetrics(noopSink{}, phuslu.NewLogger(io.Discard, nil)),
+	}
+}
+
+func TestHandleRPCError_Classification(t *testing.T) {
+	t.Parallel()
+	s := newTestEngineClient()
+
+	tests := []struct {
+		name      string
+		in        error
+		wantIs    error // expected target for errors.Is (nil to skip)
+		wantFatal bool  // expected IsFatalError verdict
+		wantRetry bool  // expected IsNonFatalError verdict
+	}{
+		{
+			name:      "nil passes through",
+			in:        nil,
+			wantIs:    nil,
+			wantFatal: false,
+			wantRetry: false,
+		},
+		{
+			name:      "HTTP 413 (PoC) → ErrHTTPClientError (fatal)",
+			in:        &rpc.HTTPStatusError{StatusCode: 413, Body: `{"code":-32007,"message":"Request is too big"}`},
+			wantIs:    ErrHTTPClientError,
+			wantFatal: true,
+		},
+		{
+			name:      "HTTP 499 → ErrHTTPClientError (fatal)",
+			in:        &rpc.HTTPStatusError{StatusCode: 499, Body: ""},
+			wantIs:    ErrHTTPClientError,
+			wantFatal: true,
+		},
+		{
+			name:      "HTTP 401 → ErrHTTPClientError (fatal)",
+			in:        &rpc.HTTPStatusError{StatusCode: 401, Body: ""},
+			wantIs:    ErrHTTPClientError,
+			wantFatal: true,
+		},
+		{
+			name:      "HTTP 500 → ErrBadConnection (retryable, jsonrpsee body-stream blip)",
+			in:        &rpc.HTTPStatusError{StatusCode: 500, Body: `{"error":{"code":-32603}}`},
+			wantIs:    ErrBadConnection,
+			wantFatal: false,
+			wantRetry: true,
+		},
+		{
+			name:      "engine API timeout passes through (retryable)",
+			in:        engineerrors.ErrEngineAPITimeout,
+			wantIs:    engineerrors.ErrEngineAPITimeout,
+			wantFatal: false,
+			wantRetry: true,
+		},
+		{
+			name:      "plain transport error → ErrBadConnection (retryable, EL down)",
+			in:        errors.New("dial tcp: connection refused"),
+			wantIs:    ErrBadConnection,
+			wantFatal: false,
+			wantRetry: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := s.handleRPCError(tc.in)
+
+			if tc.wantIs == nil {
+				require.NoError(t, got)
+			} else {
+				require.Error(t, got)
+				require.ErrorIs(t, got, tc.wantIs)
+			}
+
+			require.Equal(t, tc.wantFatal, IsFatalError(got), "IsFatalError mismatch")
+			require.Equal(t, tc.wantRetry, IsNonFatalError(got), "IsNonFatalError mismatch")
+		})
+	}
+}
+
+// TestHandleRPCError_HTTPTimeout exercises the http.IsTimeoutError branch with
+// a real timeout produced by an unresponsive HTTP server.
+func TestHandleRPCError_HTTPTimeout(t *testing.T) {
+	t.Parallel()
+	s := newTestEngineClient()
+
+	// Server that never responds within the client's timeout.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	httpClient := &http.Client{Timeout: 50 * time.Millisecond}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	_, doErr := httpClient.Do(req)
+	require.Error(t, doErr)
+
+	got := s.handleRPCError(doErr)
+	require.ErrorIs(t, got, beaconhttp.ErrTimeout)
+	require.True(t, IsNonFatalError(got), "timeouts must be retryable")
+	require.False(t, IsFatalError(got))
+}

--- a/execution/client/ethclient/rpc/client.go
+++ b/execution/client/ethclient/rpc/client.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/berachain/beacon-kit/log"
 	"github.com/berachain/beacon-kit/primitives/encoding/json"
-	beaconhttp "github.com/berachain/beacon-kit/primitives/net/http"
 	"github.com/berachain/beacon-kit/primitives/net/jwt"
 )
 
@@ -186,6 +185,9 @@ func (rpc *client) callRaw(
 
 	response, err := rpc.client.Do(req) //#nosec:G704 // URL is operator-configured RPC endpoint.
 	if err != nil {
+		// handle error as a transport level failure (connection refused, DNS, TLS, body EOF, ctx cancellation, etc)
+		// and return it as-is and let upstream handleRPCError classify it (timeouts become http.ErrTimeout and
+		// everything else falls through to ErrBadConnection).
 		return nil, err
 	}
 	if response == nil {
@@ -198,14 +200,8 @@ func (rpc *client) callRaw(
 		return nil, err
 	}
 
-	switch response.StatusCode {
-	case http.StatusOK:
-		// OK: just proceed (no return)
-	case http.StatusUnauthorized:
-		return nil, beaconhttp.ErrUnauthorized
-	default:
-		// Return a default error
-		return nil, fmt.Errorf("unexpected status code %d: %s", response.StatusCode, string(data))
+	if response.StatusCode != http.StatusOK {
+		return nil, &HTTPStatusError{StatusCode: response.StatusCode, Body: string(data)}
 	}
 
 	resp := new(Response)

--- a/execution/client/ethclient/rpc/errors.go
+++ b/execution/client/ethclient/rpc/errors.go
@@ -20,6 +20,21 @@
 
 package rpc
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var ErrNilResponse = errors.New("nil response")
+
+// HTTPStatusError is returned by callRaw when the EL responds with a non-200
+// status. It carries the HTTP status code so upstream classifiers can decide
+// retry policy via errors.As without string-matching the error message.
+type HTTPStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("unexpected status code %d: %s", e.StatusCode, e.Body)
+}

--- a/primitives/net/http/errors.go
+++ b/primitives/net/http/errors.go
@@ -24,13 +24,8 @@ import (
 	"errors"
 )
 
-var (
-	// ErrTimeout indicates a timeout error from http.Client.
-	ErrTimeout = errors.New("timeout from HTTP client")
-
-	// ErrUnauthorized indicates an unauthorized error from http.Client.
-	ErrUnauthorized = errors.New("401 unauthorized request")
-)
+// ErrTimeout indicates a timeout error from http.Client.
+var ErrTimeout = errors.New("timeout from HTTP client")
 
 // TimeoutError defines an interface for timeout errors.
 // It includes methods for error message retrieval and timeout status checking.


### PR DESCRIPTION
This PR Introduces a typed `rpc.HTTPStatusError` so the EL's HTTP status code propagates through to `handleRPCError`. Previously, `callRaw` collapsed every non-200 response into `fmt.Errorf("unexpected status code %d: ...")`, which didn't satisfy the `jsonrpc.Error` interface and so fell into the catch-all `ErrBadConnection` (retryable) bucket.

With the typed error in place, `handleRPCError` now classifies HTTP 4xx as fatal (`ErrHTTPClientError`) and leaves 5xx and other transport failures retryable (`ErrBadConnection`), so  the engine no longer retries forever on rejections the EL won't accept on a second try.

Will likely made a follow-up PR which will split the engine retry policy between `ProcessProposal` (bounded retry where a failing proposal should be rejected so consensus can move on) and `FinalizeBlock` (unbounded retry where the block is already agreed, must be applied).