### PR TITLE
perf(beacondb): add validator set cache to  avoid full scan in GetValidators

### DIFF
--- a/consensus-types/types/deposits.go
+++ b/consensus-types/types/deposits.go
@@ -18,7 +18,6 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-//nolint:dupl // False positive detected.
 package types
 
 import (

--- a/consensus-types/types/validators.go
+++ b/consensus-types/types/validators.go
@@ -18,7 +18,6 @@
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 // TITLE.
 
-//nolint:dupl // False positive detected.
 package types
 
 import (
@@ -29,6 +28,16 @@ import (
 
 // Validators is a type alias for a SSZ list of Validator containers.
 type Validators []*Validator
+
+// Copy returns a deep copy of the Validators slice.
+func (vs Validators) Copy() Validators {
+	cpy := make(Validators, len(vs))
+	for i, v := range vs {
+		val := *v
+		cpy[i] = &val
+	}
+	return cpy
+}
 
 // SizeSSZ returns the SSZ encoded size in bytes for the Validators.
 func (vs Validators) SizeSSZ(siz *ssz.Sizer, _ bool) uint32 {

--- a/storage/beacondb/kvstore.go
+++ b/storage/beacondb/kvstore.go
@@ -97,6 +97,9 @@ type KVStore struct {
 	// We must use `*ctypes.PendingPartialWithdrawals` instead of `ctypes.PendingPartialWithdrawals` as marshalling
 	// methods require a pointer receiver.
 	pendingPartialWithdrawals sdkcollections.Item[*ctypes.PendingPartialWithdrawals]
+	// validatorsCache caches the full validator set to avoid repeated DB reads
+	// within the same block. Invalidated on any validator write.
+	validatorsCache ctypes.Validators
 }
 
 // New creates a new instance of Store.
@@ -276,5 +279,9 @@ func (kv *KVStore) Context() context.Context {
 func (kv *KVStore) WithContext(ctx context.Context) *KVStore {
 	cpy := *kv
 	cpy.ctx = ctx
+	// Reset cache: epoch processing updates validators on a copy and commits to disk,
+	// but the parent KVStore's cache still holds pre-epoch data. Without this,
+	// subsequent blocks would silently use stale effective balances and activation statuses.
+	cpy.validatorsCache = nil
 	return &cpy
 }

--- a/storage/beacondb/registry.go
+++ b/storage/beacondb/registry.go
@@ -41,6 +41,7 @@ func (kv *KVStore) AddValidator(val *ctypes.Validator) error {
 		return err
 	}
 
+	kv.validatorsCache = nil
 	return kv.balances.Set(kv.ctx, idx, 0)
 }
 
@@ -49,6 +50,7 @@ func (kv *KVStore) UpdateValidatorAtIndex(
 	index math.ValidatorIndex,
 	val *ctypes.Validator,
 ) error {
+	kv.validatorsCache = nil
 	return kv.validators.Set(kv.ctx, index.Unwrap(), val)
 }
 
@@ -96,6 +98,11 @@ func (kv *KVStore) ValidatorByIndex(
 func (kv *KVStore) GetValidators() (
 	ctypes.Validators, error,
 ) {
+	if kv.validatorsCache != nil {
+		// Return a deep copy so callers that mutate validators dont corrupt the cache.
+		return kv.validatorsCache.Copy(), nil
+	}
+
 	registrySize, err := kv.validatorIndex.Peek(kv.ctx)
 	if err != nil {
 		return nil, err
@@ -122,16 +129,17 @@ func (kv *KVStore) GetValidators() (
 		vals = append(vals, val)
 	}
 
-	return vals, err
+	kv.validatorsCache = vals
+	return kv.validatorsCache.Copy(), err
 }
 
 // GetTotalValidators returns the total number of validators.
 func (kv *KVStore) GetTotalValidators() (math.U64, error) {
-	validators, err := kv.GetValidators()
+	count, err := kv.validatorIndex.Peek(kv.ctx)
 	if err != nil {
 		return 0, err
 	}
-	return math.U64(len(validators)), nil
+	return math.U64(count), nil
 }
 
 // GetBalance returns the balance of a validator.

--- a/storage/beacondb/registry.go
+++ b/storage/beacondb/registry.go
@@ -95,11 +95,9 @@ func (kv *KVStore) ValidatorByIndex(
 }
 
 // GetValidators retrieves all validators from the beacon state.
-func (kv *KVStore) GetValidators() (
-	ctypes.Validators, error,
-) {
+func (kv *KVStore) GetValidators() (_ ctypes.Validators, err error) {
 	if kv.validatorsCache != nil {
-		// Return a deep copy so callers that mutate validators dont corrupt the cache.
+		// Return a deep copy so callers that mutate validators don't corrupt the cache.
 		return kv.validatorsCache.Copy(), nil
 	}
 
@@ -108,10 +106,7 @@ func (kv *KVStore) GetValidators() (
 		return nil, err
 	}
 
-	var (
-		vals = make([]*ctypes.Validator, 0, registrySize)
-		val  *ctypes.Validator
-	)
+	vals := make([]*ctypes.Validator, 0, registrySize)
 
 	iter, err := kv.validators.Iterate(kv.ctx, nil)
 	if err != nil {
@@ -122,15 +117,15 @@ func (kv *KVStore) GetValidators() (
 	}()
 
 	for ; iter.Valid(); iter.Next() {
-		val, err = iter.Value()
-		if err != nil {
-			return nil, err
+		val, iterErr := iter.Value()
+		if iterErr != nil {
+			return nil, iterErr
 		}
 		vals = append(vals, val)
 	}
 
 	kv.validatorsCache = vals
-	return kv.validatorsCache.Copy(), err
+	return kv.validatorsCache.Copy(), nil
 }
 
 // GetTotalValidators returns the total number of validators.

--- a/storage/beacondb/registry_test.go
+++ b/storage/beacondb/registry_test.go
@@ -291,6 +291,42 @@ func TestPendingPartialWithdrawals_Update(t *testing.T) {
 	require.Equal(t, updatedWithdrawals, ppw)
 }
 
+func TestValidatorsCache(t *testing.T) {
+	t.Parallel()
+	store, err := initTestStore()
+	require.NoError(t, err)
+
+	val1 := &types.Validator{Pubkey: bytes.B48{0x01}, EffectiveBalance: 32e9}
+	require.NoError(t, store.AddValidator(val1))
+
+	// First call populates cache; second call should return identical result.
+	a, err := store.GetValidators()
+	require.NoError(t, err)
+	b, err := store.GetValidators()
+	require.NoError(t, err)
+	require.Equal(t, a, b)
+
+	// Mutating a returned validator must not corrupt the cache.
+	a[0].SetEffectiveBalance(0)
+	c, err := store.GetValidators()
+	require.NoError(t, err)
+	require.Equal(t, math.Gwei(32e9), c[0].GetEffectiveBalance())
+
+	// Adding a validator invalidates the cache.
+	val2 := &types.Validator{Pubkey: bytes.B48{0x02}, EffectiveBalance: 32e9}
+	require.NoError(t, store.AddValidator(val2))
+	d, err := store.GetValidators()
+	require.NoError(t, err)
+	require.Len(t, d, 2)
+
+	// Updating a validator invalidates the cache.
+	updated := &types.Validator{Pubkey: bytes.B48{0x01}, EffectiveBalance: 0}
+	require.NoError(t, store.UpdateValidatorAtIndex(0, updated))
+	e, err := store.GetValidators()
+	require.NoError(t, err)
+	require.Equal(t, updated, e[0])
+}
+
 func initTestStore() (*beacondb.KVStore, error) {
 	db, err := db.OpenDB("", dbm.MemDBBackend)
 	if err != nil {

--- a/storage/beacondb/registry_test.go
+++ b/storage/beacondb/registry_test.go
@@ -327,6 +327,36 @@ func TestValidatorsCache(t *testing.T) {
 	require.Equal(t, updated, e[0])
 }
 
+// TestValidatorsCache_WithContextResets pins the invariant that a fresh
+// per-block view (WithContext) never serves another instance's stale validator
+// cache. This is what keeps a syncing node correct across blocks that add or
+// update validators: each block reads committed state, not pre-block cache.
+func TestValidatorsCache_WithContextResets(t *testing.T) {
+	t.Parallel()
+	store, err := initTestStore()
+	require.NoError(t, err)
+
+	require.NoError(t, store.AddValidator(
+		&types.Validator{Pubkey: bytes.B48{0x01}, EffectiveBalance: 32e9}))
+
+	// Populate store's cache with the 1-validator set.
+	vals, err := store.GetValidators()
+	require.NoError(t, err)
+	require.Len(t, vals, 1)
+
+	// Commit a new validator on a separate copy without touching store's cache
+	// (mirrors epoch updates committed on a copy during block processing).
+	require.NoError(t, store.WithContext(t.Context()).AddValidator(
+		&types.Validator{Pubkey: bytes.B48{0x02}, EffectiveBalance: 32e9}))
+
+	// A fresh per-block view must read committed state (2), not inherit store's
+	// stale 1-validator cache. Fails if WithContext stops resetting the cache.
+	fresh := store.WithContext(t.Context())
+	got, err := fresh.GetValidators()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+}
+
 func initTestStore() (*beacondb.KVStore, error) {
 	db, err := db.OpenDB("", dbm.MemDBBackend)
 	if err != nil {


### PR DESCRIPTION
I noticed `devnet-core` blocktimes degraded from 2s to ~14s after running for ~6 days. CPU profiling (`go tool pprof`) showed almost 50% of CPU was spent in `GetValidators()`. This method  iterates all validators from PebbleDB on every call, and is called multiple times per block.

 This PR makes three fixes:
 - `GetTotalValidators()` now reads the sequence counter instead of loading all validators just to count them. This is called every block from `processWithdrawals()`.
- `GetValidators()` results are cached in `KVStore`, invalidated on writes (`AddValidator`, `UpdateValidatorAtIndex`) and on `WithContext()` (since epoch validator updates commit to disk but don't update the parent's cache). Each block pays the DB cost at most once instead of 5-10 times.
- `GetValidators()` now also properly propagates `iter.Close()` errors via named return values.

If further optimization is needed, the cache could be made to persist across blocks by propagating the copy's updated cache back to the parent singleton after block commit (reducing the full Pebble scan from once-per-block to once-per-epoch or every 32 blocks).