### PR TITLE
feat(preconf): harden HTTP server limits

### DIFF
--- a/beacon/preconf/client.go
+++ b/beacon/preconf/client.go
@@ -55,11 +55,12 @@ var (
 
 // Client is an HTTP client for fetching payloads from the sequencer.
 type Client struct {
-	logger       log.Logger
-	httpClient   *http.Client
-	sequencerURL string
-	jwtSecret    *jwt.Secret
-	timeout      time.Duration
+	logger          log.Logger
+	httpClient      *http.Client
+	sequencerURL    string
+	jwtSecret       *jwt.Secret
+	timeout         time.Duration
+	maxResponseSize int64
 
 	// mu protects the JWT token cache
 	mu          sync.RWMutex
@@ -69,13 +70,18 @@ type Client struct {
 
 // NewClient creates a new preconf client for fetching payloads from the sequencer.
 // If caCertPool is non-nil, only the provided CA is trusted for TLS verification.
+// A maxResponseSize <= 0 falls back to DefaultMaxResponseSize.
 func NewClient(
 	logger log.Logger,
 	sequencerURL string,
 	jwtSecret *jwt.Secret,
 	timeout time.Duration,
 	caCertPool *x509.CertPool,
+	maxResponseSize int64,
 ) *Client {
+	if maxResponseSize <= 0 {
+		maxResponseSize = DefaultMaxResponseSize
+	}
 	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
 		defaultTransport = &http.Transport{}
@@ -86,10 +92,11 @@ func NewClient(
 		RootCAs:    caCertPool, // nil = system trust store
 	}
 	return &Client{
-		logger:       logger,
-		sequencerURL: sequencerURL,
-		jwtSecret:    jwtSecret,
-		timeout:      timeout,
+		logger:          logger,
+		sequencerURL:    sequencerURL,
+		jwtSecret:       jwtSecret,
+		timeout:         timeout,
+		maxResponseSize: maxResponseSize,
 		httpClient: &http.Client{
 			Timeout:   timeout,
 			Transport: transport,
@@ -140,10 +147,14 @@ func (c *Client) GetPayloadBySlot(
 	}
 	defer resp.Body.Close()
 
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
+	// Read response body, capped to bound memory. Read one extra byte so a
+	// response exactly at the limit is distinguishable from an oversized one.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, c.maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if int64(len(body)) > c.maxResponseSize {
+		return nil, fmt.Errorf("sequencer response exceeds %d byte limit", c.maxResponseSize)
 	}
 
 	// Handle error responses

--- a/beacon/preconf/client.go
+++ b/beacon/preconf/client.go
@@ -43,6 +43,9 @@ import (
 const (
 	// tokenCacheExpiry is how long to cache JWT tokens before regenerating.
 	tokenCacheExpiry = 30 * time.Second
+
+	// maxResponseHeaderBytes caps the sequencer's response headers, which are standard headers only (<1KB), stdlib default is 10MB.
+	maxResponseHeaderBytes = 64 * 1024
 )
 
 var (
@@ -91,6 +94,7 @@ func NewClient(
 		MinVersion: tls.VersionTLS12,
 		RootCAs:    caCertPool, // nil = system trust store
 	}
+	transport.MaxResponseHeaderBytes = maxResponseHeaderBytes
 	return &Client{
 		logger:          logger,
 		sequencerURL:    sequencerURL,
@@ -147,8 +151,7 @@ func (c *Client) GetPayloadBySlot(
 	}
 	defer resp.Body.Close()
 
-	// Read response body, capped to bound memory. Read one extra byte so a
-	// response exactly at the limit is distinguishable from an oversized one.
+	// Read response body, capped to bound memory. Read one extra byte so a response at the limit is distinguishable from an oversized one.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, c.maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)

--- a/beacon/preconf/client_test.go
+++ b/beacon/preconf/client_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package preconf_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/berachain/beacon-kit/beacon/preconf"
+	"github.com/berachain/beacon-kit/log/noop"
+	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/net/jwt"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClient_RejectsOversizedResponse verifies the client caps the sequencer
+// response body so a malicious/compromised sequencer cannot OOM the validator.
+func TestClient_RejectsOversizedResponse(t *testing.T) {
+	t.Parallel()
+
+	// Cap the client at 1MiB and return a 2MiB response, over the cap.
+	const maxSize = 1024 * 1024
+	huge := make([]byte, 2*maxSize)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		//nolint:errcheck // test handler
+		w.Write(huge)
+	}))
+	defer srv.Close()
+
+	secret, err := jwt.NewFromHex(secretAHex)
+	require.NoError(t, err)
+
+	client := preconf.NewClient(noop.NewLogger[any](), srv.URL, secret, 5*time.Second, nil, maxSize)
+
+	_, err = client.GetPayloadBySlot(t.Context(), 100, common.Root{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds")
+}

--- a/beacon/preconf/client_test.go
+++ b/beacon/preconf/client_test.go
@@ -33,8 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestClient_RejectsOversizedResponse verifies the client caps the sequencer
-// response body so a malicious/compromised sequencer cannot OOM the validator.
+// TestClient_RejectsOversizedResponse verifies the client caps the response body so a malicious sequencer cannot OOM the validator.
 func TestClient_RejectsOversizedResponse(t *testing.T) {
 	t.Parallel()
 

--- a/beacon/preconf/config.go
+++ b/beacon/preconf/config.go
@@ -37,9 +37,8 @@ const (
 	// DefaultHealthCheckInterval is how often the client probes the sequencer when it is unavailable.
 	DefaultHealthCheckInterval = 10 * time.Second
 
-	// DefaultMaxResponseSize caps the sequencer response body on the validator's client to bound memory.
-	// 16MiB comfortably holds a worst-case valid block (30M-gas calldata ~6MiB hex + 6 blobs ~1.5MiB hex +
-	// overhead) with ~2x headroom, while preventing OOM from a malicious or compromised sequencer.
+	// DefaultMaxResponseSize caps the sequencer response body on the validator's client to prevent OOM from a malicious sequencer.
+	// 16MiB holds a worst-case valid block (30M-gas calldata ~6MiB hex + 6 blobs ~1.5MiB hex + overhead) with ~2x headroom.
 	DefaultMaxResponseSize = 16 * 1024 * 1024
 )
 
@@ -97,8 +96,7 @@ type Config struct {
 	// HealthCheckInterval is how often to probe the sequencer health endpoint when it becomes unavailable.
 	HealthCheckInterval time.Duration `mapstructure:"health-check-interval"`
 
-	// MaxResponseSize caps the sequencer response body (in bytes) read by the client.
-	// Must exceed the maximum valid block size.Defaults to DefaultMaxResponseSize.
+	// MaxResponseSize caps the sequencer response body in bytes. Must exceed the max valid block size, defaults to DefaultMaxResponseSize.
 	MaxResponseSize int64 `mapstructure:"max-response-size"`
 }
 

--- a/beacon/preconf/config.go
+++ b/beacon/preconf/config.go
@@ -36,6 +36,11 @@ const (
 
 	// DefaultHealthCheckInterval is how often the client probes the sequencer when it is unavailable.
 	DefaultHealthCheckInterval = 10 * time.Second
+
+	// DefaultMaxResponseSize caps the sequencer response body on the validator's client to bound memory.
+	// 16MiB comfortably holds a worst-case valid block (30M-gas calldata ~6MiB hex + 6 blobs ~1.5MiB hex +
+	// overhead) with ~2x headroom, while preventing OOM from a malicious or compromised sequencer.
+	DefaultMaxResponseSize = 16 * 1024 * 1024
 )
 
 // Config holds preconfirmation configuration.
@@ -91,6 +96,10 @@ type Config struct {
 
 	// HealthCheckInterval is how often to probe the sequencer health endpoint when it becomes unavailable.
 	HealthCheckInterval time.Duration `mapstructure:"health-check-interval"`
+
+	// MaxResponseSize caps the sequencer response body (in bytes) read by the client.
+	// Must exceed the maximum valid block size.Defaults to DefaultMaxResponseSize.
+	MaxResponseSize int64 `mapstructure:"max-response-size"`
 }
 
 // DefaultConfig returns the default preconfirmation configuration.
@@ -99,6 +108,7 @@ func DefaultConfig() Config {
 		APIPort:             DefaultAPIPort,
 		FetchTimeout:        DefaultFetchTimeout,
 		HealthCheckInterval: DefaultHealthCheckInterval,
+		MaxResponseSize:     DefaultMaxResponseSize,
 	}
 }
 
@@ -121,6 +131,9 @@ func (c *Config) TLSEnabled() bool {
 func (c *Config) Validate() error {
 	if (c.TLSCertPath != "") != (c.TLSKeyPath != "") {
 		return errors.New("tls-cert-path and tls-key-path must both be set or both be empty")
+	}
+	if c.MaxResponseSize < 0 {
+		return errors.New("max-response-size must not be negative")
 	}
 	if c.SequencerCACertPath != "" {
 		if c.SequencerURL == "" {

--- a/beacon/preconf/server.go
+++ b/beacon/preconf/server.go
@@ -55,31 +55,29 @@ const (
 	// serverReadHeaderTimeout is the timeout for reading request headers.
 	serverReadHeaderTimeout = 10 * time.Second
 
-	// serverReadTimeout bounds the total time to read a request (headers + body).
-	// Must be >= serverReadHeaderTimeout. Defends against a Slowloris attack: a
-	// client sends headers fast enough to pass serverReadHeaderTimeout, then
-	// trickles the body one byte at a time to hold the connection (and its
-	// goroutine) open indefinitely. Capping total read time disconnects it.
+	// serverReadTimeout bounds the total time to read a request (headers + body). Must be >= serverReadHeaderTimeout. Defends against a
+	// Slowloris attack: a client sends headers fast enough to pass serverReadHeaderTimeout, then trickles the body one byte at a time to
+	// hold the connection (and its goroutine) open indefinitely. Capping total read time disconnects it.
 	serverReadTimeout = 15 * time.Second
 
-	// serverWriteTimeout bounds the time to write a response. Defends against a
-	// reverse Slowloris attack: a client makes a valid request but then reads the
-	// response one byte at a time (or stops reading entirely), blocking the
-	// server goroutine in Encode forever. Capping write time disconnects it.
+	// serverWriteTimeout bounds the time to write a response. Defends against a reverse Slowloris attack: a client makes a valid request
+	// but then reads the response one byte at a time (or stops reading entirely), blocking the server goroutine in Encode forever.
+	// Capping write time disconnects it.
 	serverWriteTimeout = 30 * time.Second
 
 	// serverIdleTimeout bounds how long an idle keep-alive connection stays open.
 	serverIdleTimeout = 60 * time.Second
 
-	// maxConcurrentConnections caps simultaneous connections so a connection
-	// flood cannot exhaust file descriptors. Sized for ~100 validators plus
-	// headroom and monitoring.
+	// maxConcurrentConnections caps simultaneous connections so a connection flood cannot exhaust file descriptors. Sized for ~100
+	// validators plus headroom and monitoring.
 	maxConcurrentConnections = 256
 
-	// maxRequestBodySize caps the GetPayload request body. The request is ~100
-	// bytes (slot + parent block root); 2KB gives 20x headroom while guarding
-	// against OOM from an oversized body.
+	// maxRequestBodySize caps the GetPayload request body. The request is ~100 bytes (slot + parent block root),
+	// so 2KB gives 20x headroom while guarding against OOM from an oversized body.
 	maxRequestBodySize = 2048
+
+	// maxRequestHeaderBytes caps request headers. Requests carry only a bearer JWT plus standard headers (<1KB), stdlib default is 1MB.
+	maxRequestHeaderBytes = 16 * 1024
 
 	// authHeaderParts is the expected number of parts in the Authorization header.
 	authHeaderParts = 2
@@ -186,6 +184,7 @@ func (s *Server) Start(_ context.Context) error {
 		ReadTimeout:       serverReadTimeout,
 		WriteTimeout:      serverWriteTimeout,
 		IdleTimeout:       serverIdleTimeout,
+		MaxHeaderBytes:    maxRequestHeaderBytes,
 	}
 
 	tlsEnabled := s.tlsPaths.Enabled()
@@ -212,8 +211,7 @@ func (s *Server) Start(_ context.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to bind preconf API server to %s", addr)
 	}
-	// Cap concurrent connections so a connection flood cannot exhaust file
-	// descriptors and lock out legitimate validators.
+	// Cap concurrent connections so a connection flood cannot exhaust file descriptors and lock out legitimate validators.
 	ln = netutil.LimitListener(ln, maxConcurrentConnections)
 
 	s.mu.Lock()

--- a/beacon/preconf/server.go
+++ b/beacon/preconf/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/net/jwt"
 	gjwt "github.com/golang-jwt/jwt/v5"
+	"golang.org/x/net/netutil"
 )
 
 const (
@@ -53,6 +54,32 @@ const (
 
 	// serverReadHeaderTimeout is the timeout for reading request headers.
 	serverReadHeaderTimeout = 10 * time.Second
+
+	// serverReadTimeout bounds the total time to read a request (headers + body).
+	// Must be >= serverReadHeaderTimeout. Defends against a Slowloris attack: a
+	// client sends headers fast enough to pass serverReadHeaderTimeout, then
+	// trickles the body one byte at a time to hold the connection (and its
+	// goroutine) open indefinitely. Capping total read time disconnects it.
+	serverReadTimeout = 15 * time.Second
+
+	// serverWriteTimeout bounds the time to write a response. Defends against a
+	// reverse Slowloris attack: a client makes a valid request but then reads the
+	// response one byte at a time (or stops reading entirely), blocking the
+	// server goroutine in Encode forever. Capping write time disconnects it.
+	serverWriteTimeout = 30 * time.Second
+
+	// serverIdleTimeout bounds how long an idle keep-alive connection stays open.
+	serverIdleTimeout = 60 * time.Second
+
+	// maxConcurrentConnections caps simultaneous connections so a connection
+	// flood cannot exhaust file descriptors. Sized for ~100 validators plus
+	// headroom and monitoring.
+	maxConcurrentConnections = 256
+
+	// maxRequestBodySize caps the GetPayload request body. The request is ~100
+	// bytes (slot + parent block root); 2KB gives 20x headroom while guarding
+	// against OOM from an oversized body.
+	maxRequestBodySize = 2048
 
 	// authHeaderParts is the expected number of parts in the Authorization header.
 	authHeaderParts = 2
@@ -156,6 +183,9 @@ func (s *Server) Start(_ context.Context) error {
 		Addr:              addr,
 		Handler:           mux,
 		ReadHeaderTimeout: serverReadHeaderTimeout,
+		ReadTimeout:       serverReadTimeout,
+		WriteTimeout:      serverWriteTimeout,
+		IdleTimeout:       serverIdleTimeout,
 	}
 
 	tlsEnabled := s.tlsPaths.Enabled()
@@ -182,6 +212,9 @@ func (s *Server) Start(_ context.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to bind preconf API server to %s", addr)
 	}
+	// Cap concurrent connections so a connection flood cannot exhaust file
+	// descriptors and lock out legitimate validators.
+	ln = netutil.LimitListener(ln, maxConcurrentConnections)
 
 	s.mu.Lock()
 	s.httpServer = server
@@ -334,9 +367,16 @@ func (s *Server) handleGetPayload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse request body
+	// Parse request body, capped to guard against OOM from an oversized body.
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
 	var req GetPayloadRequest
 	if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			result = ServerResultRequestTooLarge
+			s.writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		result = ServerResultBadRequest
 		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return

--- a/beacon/preconf/server_metrics.go
+++ b/beacon/preconf/server_metrics.go
@@ -36,6 +36,7 @@ const (
 	ServerResultResponseWriteError ServerResult = "response_write_error"
 	ServerResultMethodNotAllowed   ServerResult = "method_not_allowed"
 	ServerResultBadRequest         ServerResult = "bad_request"
+	ServerResultRequestTooLarge    ServerResult = "request_too_large"
 )
 
 // TelemetrySink is a minimal sink interface used by the preconf server for

--- a/beacon/preconf/server_test.go
+++ b/beacon/preconf/server_test.go
@@ -251,14 +251,15 @@ func TestServer_RejectsOversizedRequestBody(t *testing.T) {
 		newTestWhitelist(t, pubkeyAHex),
 		preconf.NewProposerTracker(),
 		&mockPayloadProvider{hasPayload: true},
+		&mockSyncChecker{ready: true},
+		&mockELChecker{connected: true},
 		0,
 		preconf.TLSPaths{},
 		metrics.NewNoOpTelemetrySink(),
 	)
 
-	// A valid-JSON body well over the 2KB cap: a long string value forces the
-	// decoder to read past the limit, where MaxBytesReader trips. Authenticated
-	// and whitelisted so the request reaches body parsing.
+	// A valid-JSON body well over the 2KB cap: a long string value forces the decoder to read past the limit, where MaxBytesReader trips.
+	// Authenticated and whitelisted so the request reaches body parsing.
 	body := append([]byte(`{"slot":1,"pad":"`), bytes.Repeat([]byte("a"), 4096)...)
 	body = append(body, '"', '}')
 	req := httptest.NewRequest(http.MethodPost, preconf.PayloadEndpoint, bytes.NewReader(body))

--- a/beacon/preconf/server_test.go
+++ b/beacon/preconf/server_test.go
@@ -239,6 +239,39 @@ func TestServer_ProposerCheck(t *testing.T) {
 	}
 }
 
+func TestServer_RejectsOversizedRequestBody(t *testing.T) {
+	t.Parallel()
+
+	validatorA, _ := parser.ConvertPubkey(pubkeyAHex)
+	secretA, _ := jwt.NewFromHex(secretAHex)
+
+	server := preconf.NewServer(
+		noop.NewLogger[any](),
+		preconf.ValidatorJWTs{validatorA: secretA},
+		newTestWhitelist(t, pubkeyAHex),
+		preconf.NewProposerTracker(),
+		&mockPayloadProvider{hasPayload: true},
+		0,
+		preconf.TLSPaths{},
+		metrics.NewNoOpTelemetrySink(),
+	)
+
+	// A valid-JSON body well over the 2KB cap: a long string value forces the
+	// decoder to read past the limit, where MaxBytesReader trips. Authenticated
+	// and whitelisted so the request reaches body parsing.
+	body := append([]byte(`{"slot":1,"pad":"`), bytes.Repeat([]byte("a"), 4096)...)
+	body = append(body, '"', '}')
+	req := httptest.NewRequest(http.MethodPost, preconf.PayloadEndpoint, bytes.NewReader(body))
+	token, _ := secretA.BuildSignedToken()
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	require.Contains(t, rec.Body.String(), "request body too large")
+}
+
 func TestServer_RejectsNonPostMethods(t *testing.T) {
 	t.Parallel()
 
@@ -747,7 +780,7 @@ func TestServer_TLS_ClientPinning(t *testing.T) {
 	// succeeds once the listener is accepting (retried to absorb startup).
 	pinnedPool, err := preconf.LoadCACert(certPath)
 	require.NoError(t, err)
-	pinnedClient := preconf.NewClient(noop.NewLogger[any](), url, secret, 2*time.Second, pinnedPool)
+	pinnedClient := preconf.NewClient(noop.NewLogger[any](), url, secret, 2*time.Second, pinnedPool, 0)
 	require.Eventually(t, func() bool {
 		return pinnedClient.CheckHealth(t.Context()) == nil
 	}, 2*time.Second, 20*time.Millisecond, "pinned client should trust the server's cert")
@@ -758,7 +791,7 @@ func TestServer_TLS_ClientPinning(t *testing.T) {
 	otherCertPath, _ := generateSelfSignedCert(t)
 	otherPool, err := preconf.LoadCACert(otherCertPath)
 	require.NoError(t, err)
-	otherClient := preconf.NewClient(noop.NewLogger[any](), url, secret, 2*time.Second, otherPool)
+	otherClient := preconf.NewClient(noop.NewLogger[any](), url, secret, 2*time.Second, otherPool, 0)
 	err = otherClient.CheckHealth(t.Context())
 	require.ErrorContains(t, err, "certificate signed by unknown authority")
 }

--- a/config/template/template.go
+++ b/config/template/template.go
@@ -162,7 +162,6 @@ fetch-timeout = "{{ .BeaconKit.Preconf.FetchTimeout }}"
 # How often to probe sequencer health endpoint when it becomes unavailable.
 health-check-interval = "{{ .BeaconKit.Preconf.HealthCheckInterval }}"
 
-# Max sequencer response size (bytes) accepted by the client. Must exceed the
-# maximum valid block size; raise it only if the chain runs a higher gas limit.
+# Max sequencer response size (bytes) accepted by the client. Must exceed the max valid block size, raise it only for a higher gas limit.
 max-response-size = {{ .BeaconKit.Preconf.MaxResponseSize }}
 `

--- a/config/template/template.go
+++ b/config/template/template.go
@@ -161,4 +161,8 @@ fetch-timeout = "{{ .BeaconKit.Preconf.FetchTimeout }}"
 
 # How often to probe sequencer health endpoint when it becomes unavailable.
 health-check-interval = "{{ .BeaconKit.Preconf.HealthCheckInterval }}"
+
+# Max sequencer response size (bytes) accepted by the client. Must exceed the
+# maximum valid block size; raise it only if the chain runs a higher gas limit.
+max-response-size = {{ .BeaconKit.Preconf.MaxResponseSize }}
 `

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/umbracle/fastrlp v0.1.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/crypto v0.50.0
+	golang.org/x/net v0.53.0
 	golang.org/x/sync v0.20.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -252,7 +253,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.17.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
-	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/node-core/components/preconf_client.go
+++ b/node-core/components/preconf_client.go
@@ -95,12 +95,5 @@ func ProvidePreconfClient(in PreconfClientInput) (*preconf.Client, error) {
 		"fetch_timeout", cfg.FetchTimeout,
 	)
 
-	return preconf.NewClient(
-		logger,
-		cfg.SequencerURL,
-		jwtSecret,
-		cfg.FetchTimeout,
-		caCertPool,
-		cfg.MaxResponseSize,
-	), nil
+	return preconf.NewClient(logger, cfg.SequencerURL, jwtSecret, cfg.FetchTimeout, caCertPool, cfg.MaxResponseSize), nil
 }

--- a/node-core/components/preconf_client.go
+++ b/node-core/components/preconf_client.go
@@ -101,5 +101,6 @@ func ProvidePreconfClient(in PreconfClientInput) (*preconf.Client, error) {
 		jwtSecret,
 		cfg.FetchTimeout,
 		caCertPool,
+		cfg.MaxResponseSize,
 	), nil
 }


### PR DESCRIPTION
This PR hardens the preconf HTTP server and validator client against DoS and OOM, The sequencer is internet-facing, so it previously accepted unbounded request bodies, had no read/write/idle timeouts, and no cap on concurrent connections, leaving it open to OOM, Slowloris, and connection-exhaustion attacks.

More specifically, the main changes are:

- Request body cap (server): `MaxBytesReader` (2 KB) -> `413` on oversized bodies.
- Read/Write/Idle timeouts (server): 15s / 30s / 60s, closes Slowloris and idle keep-alive vectors.
- Max concurrent connections (server): `netutil.LimitListener(256)`.
- Response body cap (client): default 16 MiB, configurable via `max-response-size`, to prevent a malicious sequencer OOMing a validator. Picked 16 MiB which should cover the worst-case valid block, full hex-encoded transactions (~6 MiB) + 6 blobs (~1.5 MiB) with ~2× headroom. 