### PR TITLE
fix(node-api): enforce DA period check in GetBlobSidecars

### DIFF
--- a/node-api/handlers/beacon/blob_test.go
+++ b/node-api/handlers/beacon/blob_test.go
@@ -168,7 +168,7 @@ func TestGetBlobSidecars(t *testing.T) {
 				require.Nil(t, res)
 				require.ErrorContains(t, err, "not within Data Availability Period")
 				require.ErrorContains(t, err, "212568")
-				backend.AssertNotCalled(t, "GetBlobSidecarsAtSlot")
+				backend.AssertNumberOfCalls(t, "GetBlobSidecarsAtSlot", 0)
 			},
 		},
 	}

--- a/node-api/handlers/beacon/blob_test.go
+++ b/node-api/handlers/beacon/blob_test.go
@@ -70,10 +70,10 @@ func TestGetBlobSidecars(t *testing.T) {
 		name                string
 		inputs              func() beacontypes.GetBlobSidecarsRequest
 		setMockExpectations func(*testing.T, *mocks.Backend)
-		check               func(t *testing.T, res any, err error)
+		check               func(t *testing.T, backend *mocks.Backend, res any, err error)
 	}{
 		{
-			name: "success",
+			name: "success - head",
 			inputs: func() beacontypes.GetBlobSidecarsRequest {
 				return beacontypes.GetBlobSidecarsRequest{
 					BlockIDRequest: handlertypes.BlockIDRequest{
@@ -88,7 +88,7 @@ func TestGetBlobSidecars(t *testing.T) {
 				b.EXPECT().GetSyncData().Return(int64(1234), int64(1234))
 				b.EXPECT().GetBlobSidecarsAtSlot(mock.Anything).Return(testSidecars, nil)
 			},
-			check: func(t *testing.T, res any, err error) {
+			check: func(t *testing.T, _ *mocks.Backend, res any, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
@@ -98,6 +98,77 @@ func TestGetBlobSidecars(t *testing.T) {
 
 				require.Len(t, sr.Data, 1)
 				require.Equal(t, beacontypes.SidecarFromConsensus(testSidecars[0]), sr.Data[0])
+			},
+		},
+		{
+			name: "success - head while syncing",
+			inputs: func() beacontypes.GetBlobSidecarsRequest {
+				return beacontypes.GetBlobSidecarsRequest{
+					BlockIDRequest: handlertypes.BlockIDRequest{
+						BlockID: utils.StateIDHead,
+					},
+					Indices: nil,
+				}
+			},
+			setMockExpectations: func(t *testing.T, b *mocks.Backend) {
+				t.Helper()
+
+				b.EXPECT().GetSyncData().Return(int64(1000), int64(800_000))
+				b.EXPECT().GetBlobSidecarsAtSlot(math.Slot(1000)).Return(testSidecars, nil)
+			},
+			check: func(t *testing.T, _ *mocks.Backend, res any, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, res)
+			},
+		},
+		{
+			name: "success - explicit slot within DA period",
+			inputs: func() beacontypes.GetBlobSidecarsRequest {
+				return beacontypes.GetBlobSidecarsRequest{
+					BlockIDRequest: handlertypes.BlockIDRequest{
+						BlockID: "999000",
+					},
+					Indices: nil,
+				}
+			},
+			setMockExpectations: func(t *testing.T, b *mocks.Backend) {
+				t.Helper()
+
+				b.EXPECT().GetSyncData().Return(int64(1_000_000), int64(1_000_000))
+				b.EXPECT().GetBlobSidecarsAtSlot(math.Slot(999_000)).Return(testSidecars, nil)
+			},
+			check: func(t *testing.T, _ *mocks.Backend, res any, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, res)
+			},
+		},
+		{
+			name: "reject - slot outside DA period",
+			inputs: func() beacontypes.GetBlobSidecarsRequest {
+				return beacontypes.GetBlobSidecarsRequest{
+					BlockIDRequest: handlertypes.BlockIDRequest{
+						BlockID: "212568",
+					},
+					Indices: nil,
+				}
+			},
+			setMockExpectations: func(t *testing.T, b *mocks.Backend) {
+				t.Helper()
+
+				b.EXPECT().GetSyncData().Return(int64(1_000_000), int64(1_000_000))
+			},
+			check: func(t *testing.T, backend *mocks.Backend, res any, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.Nil(t, res)
+				require.ErrorContains(t, err, "not within Data Availability Period")
+				require.ErrorContains(t, err, "212568")
+				backend.AssertNotCalled(t, "GetBlobSidecarsAtSlot")
 			},
 		},
 	}
@@ -130,7 +201,7 @@ func TestGetBlobSidecars(t *testing.T) {
 			res, err := h.GetBlobSidecars(c)
 
 			// finally do checks
-			tc.check(t, res, err)
+			tc.check(t, backend, res, err)
 		})
 	}
 }

--- a/node-api/handlers/beacon/blobs.go
+++ b/node-api/handlers/beacon/blobs.go
@@ -48,14 +48,16 @@ func (h *Handler) GetBlobSidecars(c handlers.Context) (any, error) {
 		return nil, err
 	}
 
+	headHeight, _ := h.backend.GetSyncData()
+	if headHeight < 0 {
+		return nil, errors.New("invalid negative block height")
+	}
+
 	var slot math.Slot
-	if slotID == utils.Head {
-		latestHeight, _ := h.backend.GetSyncData()
-		if latestHeight < 0 {
-			return nil, errors.New("invalid negative block height")
-		}
-		slot = math.Slot(latestHeight)
-	} else {
+	switch slotID {
+	case utils.Head:
+		slot = math.Slot(headHeight)
+	default:
 		slot = math.Slot(slotID) //#nosec: G115 // practically safe
 	}
 
@@ -71,10 +73,11 @@ func (h *Handler) GetBlobSidecars(c handlers.Context) (any, error) {
 	}
 
 	// Validate the requested slot is within the Data Availability Period.
-	if !h.cs.WithinDAPeriod(slot, slot) {
+	// Compare against local head; same retention window as availability pruning.
+	if !h.cs.WithinDAPeriod(slot, math.Slot(headHeight)) {
 		return nil, fmt.Errorf(
 			"requested slot (%d) is not within Data Availability Period (previous %d epochs)",
-			slotID, h.cs.MinEpochsForBlobsSidecarsRequest(),
+			slot.Unwrap(), h.cs.MinEpochsForBlobsSidecarsRequest(),
 		)
 	}
 

--- a/node-api/handlers/beacon/blobs.go
+++ b/node-api/handlers/beacon/blobs.go
@@ -72,8 +72,8 @@ func (h *Handler) GetBlobSidecars(c handlers.Context) (any, error) {
 		indices[i] = idx.Unwrap()
 	}
 
-	// Validate the requested slot is within the Data Availability Period.
-	// Compare against local head; same retention window as availability pruning.
+	// Validate the requested slot is within the DA period (epoch-based WithinDAPeriod,
+	// same check as FinalizeSidecars). Reference local head, not sync target.
 	if !h.cs.WithinDAPeriod(slot, math.Slot(headHeight)) {
 		return nil, fmt.Errorf(
 			"requested slot (%d) is not within Data Availability Period (previous %d epochs)",


### PR DESCRIPTION
Fixes #3127 

## Summary

`GetBlobSidecars` was calling `WithinDAPeriod(slot, slot)`, which always evaluates to true, so the DA retention guard never ran.

This change compares the requested slot against **local head** from `GetSyncData()`, using the same retention window as availability pruning. The error message now prints the resolved slot instead of `slotID` (which is `-1` for `head`).

**Before:** `WithinDAPeriod(slot, slot)` → always passes  
**After:** `WithinDAPeriod(slot, headHeight)` → rejects slots outside `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`

Local head is used (not sync target) so `/blob_sidecars/head` still works while the node is syncing.

## Test plan

- [x] `go test -tags=test ./node-api/handlers/beacon/... -run TestGetBlobSidecars`
- [x] `go test -tags=test ./node-api/handlers/beacon/...`
- [x] Head request succeeds (`head` block id)
- [x] Head request succeeds while syncing (`headHeight=1000`, `syncToHeight=800_000`)
- [x] Explicit in-window slot accepted (999000 with head at 1_000_000)
- [x] Out-of-window slot rejected (212568 with head at 1_000_000)
- [x] Store not queried when DA check fails (`AssertNotCalled` on `GetBlobSidecarsAtSlot`)