### PR TITLE
ci(pipeline): disable fail-fast on ci matrix

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -55,6 +55,7 @@ jobs:
 
   ci:
     strategy:
+      fail-fast: false
       matrix:
         args:
           - "build"


### PR DESCRIPTION
This PR disables `fail-fast` on ci matrix so if any ci job fails it does not cancel all the remaining ci jobs. This happens for example if vulncheck job fails (which is almost always unrelated to the PR) so it does not make sense to cancel other jobs.  