### PR TITLE
ci(nightly): run full pipeline and deps tests nightly against main

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-name: deps
+name: nightly
 
 on:
   schedule:
@@ -32,32 +32,21 @@ on:
 
 # Cancel any in-progress run if a new one starts on the same branch.
 concurrency:
-  group: vuln-and-dep-check-${{ github.ref }}
+  group: nightly-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
-  # Catch newly published vulnerabilities in dependencies via symbol-level analysis.
-  govulncheck:
-    runs-on:
-      labels: ubuntu-24.04-beacon-kit
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: recursive
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
-          cache-dependency-path: "**/*.sum"
-      - run: make vulncheck
+  # Run the full CI pipeline against main (build, lint, unit, forge, e2e, vulncheck, ...).
+  pipeline:
+    uses: ./.github/workflows/pipeline.yml
+    secrets: inherit
 
   # Run tests with locked and latest deps to catch breakage from both.
   test-deps:
     runs-on:
       labels: ubuntu-24.04-beacon-kit
+    permissions:
+      contents: read
     strategy:
       fail-fast: false # Always run both variants so one failure doesn't hide the other.
       matrix:
@@ -83,17 +72,19 @@ jobs:
         env:
           GOPATH: /home/runner/go
 
-  # Post to Slack if any job above fails
+  # Post to Slack only when the nightly run fails.
   notify-slack:
-    needs: [govulncheck, test-deps]
+    needs: [pipeline, test-deps]
     if: failure()
     runs-on:
       labels: ubuntu-24.04-beacon-kit
+    permissions:
+      contents: read
     steps:
       - name: Post failure to Slack
         env:
           CORE_SLACK_WEBHOOK_URL: ${{ secrets.CORE_SLACK_WEBHOOK_URL }}
-          TEXT: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} ${{ github.workflow }} workflow failed
+          TEXT: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} nightly CI failed (pipeline=${{ needs.pipeline.result }}, test-deps=${{ needs.test-deps.result }})
         run: |
           if [ -z "$CORE_SLACK_WEBHOOK_URL" ]; then
             echo "CORE_SLACK_WEBHOOK_URL not set; skipping Slack notification."

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,6 +34,7 @@ on:
       - "v*"
   pull_request:
   merge_group:
+  workflow_call:
 
 concurrency:
   group: ci-${{ github.ref }}-tests


### PR DESCRIPTION
Right now nothing watches main between merges. Full CI only runs on PRs, so a bad interaction between two separately-green branches, a drifting dependency or flaky tests can sit broken on main until the next PR catches it. Our nightly job, meanwhile, only checked vulncheck and the dependency tests.

This PR points the nightly at the entire CI pipeline against `main` every night, so we catch regressions across build, lint, unit, forge, e2e, and vulncheck rather than just dependency issues.

The old `vuln-and-dep-check.yml` is renamed to `nightly.yml` and now calls the existing `pipeline.yml` as a reusable workflow. The dependency tests and the Slack-on-failure notification are kept.