### PR TITLE
ci(nightly): add missing pipeline permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,11 @@ jobs:
   pipeline:
     uses: ./.github/workflows/pipeline.yml
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
 
   # Run tests with locked and latest deps to catch breakage from both.
   test-deps:


### PR DESCRIPTION
The nightly run failed (https://github.com/berachain/beacon-kit/actions/runs/28158935993) due to missing permission from the calling workflow:

<img width="796" height="241" alt="image" src="https://github.com/user-attachments/assets/83c2e232-eef2-4262-becd-7332f63cd280" />

This PR fixes this by adding these permissons to the caller.

I looked first into splitting build-and-push-container into two jobs (build and push) since nightly never pushes it does not need those permissions, but that would result in building the docker image from scratch since it does not use caching. 
