### PR TITLE
feat: osaka1 fork to floor the base fee and blob fee

### DIFF
--- a/gethlib/types/config.go
+++ b/gethlib/types/config.go
@@ -114,6 +114,9 @@ type BerachainConfig struct {
 
 	// Prague4 fork values.
 	Prague4 Prague4Config `json:"prague4,omitempty"`
+
+	// Osaka1 fork values.
+	Osaka1 Osaka1Config `json:"osaka1,omitempty"`
 }
 
 // Prague1Config is the config values for the Prague1 fork on Berachain.
@@ -152,6 +155,16 @@ type Prague3Config struct {
 type Prague4Config struct {
 	// Time is the time of the Prague4 fork.
 	Time *uint64 `json:"time,omitempty"` // Prague4 switch time (0 = already on prague4, nil = no fork)
+}
+
+// Osaka1Config is the config values for the Osaka1 fork on Berachain.
+type Osaka1Config struct {
+	// Time is the time of the Osaka1 fork.
+	Time *uint64 `json:"time,omitempty"` // Osaka1 switch time (0 = already on osaka1, nil = no fork)
+	// MinimumBaseFeeWei is the minimum base fee in wei.
+	MinimumBaseFeeWei *big.Int `json:"minimumBaseFeeWei,omitempty"`
+	// MinimumBlobBaseFeeWei is the minimum blob base fee in wei.
+	MinimumBlobBaseFeeWei *big.Int `json:"minimumBlobBaseFeeWei,omitempty"`
 }
 
 // IsLondon returns whether num is either equal to the London fork block or greater.

--- a/kurtosis/src/networks/kurtosis-devnet/network-configs/genesis.json.template
+++ b/kurtosis/src/networks/kurtosis-devnet/network-configs/genesis.json.template
@@ -52,6 +52,11 @@
       "prague2": {
         "time": 0,
         "minimumBaseFeeWei": 0
+      },
+      "osaka1": {
+        "time": 0,
+        "minimumBaseFeeWei": 10000000000,
+        "minimumBlobBaseFeeWei": 10000000000
       }
     }
   },

--- a/kurtosis/src/networks/kurtosis-devnet/network-configs/genesis.json.template
+++ b/kurtosis/src/networks/kurtosis-devnet/network-configs/genesis.json.template
@@ -55,8 +55,8 @@
       },
       "osaka1": {
         "time": 0,
-        "minimumBaseFeeWei": 10000000000,
-        "minimumBlobBaseFeeWei": 10000000000
+        "minimumBaseFeeWei": 1000000000,
+        "minimumBlobBaseFeeWei": 1000000000
       }
     }
   },

--- a/testing/e2e/standard/blob_test.go
+++ b/testing/e2e/standard/blob_test.go
@@ -69,8 +69,13 @@ func (s *BeaconKitE2ESuite) Test4844Live() {
 	s.Require().NoError(err)
 	gasFee, err := elClient.SuggestGasPrice(ctx)
 	s.Require().NoError(err)
+	blobBaseFee, err := elClient.BlobBaseFee(ctx)
+	s.Require().NoError(err)
 	nonce, err := elClient.NonceAt(ctx, sender.Address(), new(big.Int).SetUint64(blkNum))
 	s.Require().NoError(err)
+
+	// Cap at twice the current blob base fee to absorb fee movement
+	blobFeeCap := new(big.Int).Mul(blobBaseFee, big.NewInt(2))
 
 	// Craft and send each blob-carrying transaction.
 	blobTxs := make([]*coretypes.Transaction, 0, NumBlobsLoad)
@@ -89,7 +94,7 @@ func (s *BeaconKitE2ESuite) Test4844Live() {
 			nonce+i, nil, 1000000,
 			chainID, tip, gasFee, big.NewInt(0),
 			[]byte{0x01, 0x02, 0x03, 0x04},
-			big.NewInt(1), blobData,
+			blobFeeCap, blobData,
 			coretypes.AccessList{},
 		)
 

--- a/testing/e2e/standard/withdrawal_test.go
+++ b/testing/e2e/standard/withdrawal_test.go
@@ -215,14 +215,20 @@ func (s *BeaconKitE2ESuite) TestSubmitPartialWithdrawalTransaction() {
 	)
 	s.Require().NoError(err)
 
+	// Derive fee caps from the chain so the tx clears any configured base fee floor
+	tip, err := elClient.SuggestGasTipCap(ctx)
+	s.Require().NoError(err)
+	gasFee, err := elClient.SuggestGasPrice(ctx)
+	s.Require().NoError(err)
+
 	// Create and sign the transaction
 	tx := gethcore.MustSignNewTx(privateKey, signer, &gethcore.DynamicFeeTx{
 		ChainID:   chainID,
 		Nonce:     uint64(nonce),
 		To:        &params.WithdrawalQueueAddress,
 		Gas:       WithdrawalTxGasLimit,
-		GasFeeCap: big.NewInt(10000000000),
-		GasTipCap: big.NewInt(10000000000),
+		GasFeeCap: new(big.Int).Mul(gasFee, big.NewInt(2)),
+		GasTipCap: tip,
 		Value:     fee,
 		Data:      withdrawalTxData,
 	})

--- a/testing/files/eth-genesis.json
+++ b/testing/files/eth-genesis.json
@@ -52,6 +52,11 @@
       "prague2": {
         "time": 0,
         "minimumBaseFeeWei": 0
+      },
+      "osaka1": {
+        "time": 0,
+        "minimumBaseFeeWei": 10000000000,
+        "minimumBlobBaseFeeWei": 10000000000
       }
     }
   },

--- a/testing/files/eth-genesis.json
+++ b/testing/files/eth-genesis.json
@@ -55,8 +55,8 @@
       },
       "osaka1": {
         "time": 0,
-        "minimumBaseFeeWei": 10000000000,
-        "minimumBlobBaseFeeWei": 10000000000
+        "minimumBaseFeeWei": 1000000000,
+        "minimumBlobBaseFeeWei": 1000000000
       }
     }
   },

--- a/testing/networks/80069/eth-genesis.json
+++ b/testing/networks/80069/eth-genesis.json
@@ -112,6 +112,11 @@
       "prague2": {
         "time": 1758124800,
         "minimumBaseFeeWei": 0
+      },
+      "osaka1": {
+        "time": 9999999999,
+        "minimumBaseFeeWei": 10000000000,
+        "minimumBlobBaseFeeWei": 10000000000
       }
     }
   },

--- a/testing/networks/80069/eth-genesis.json
+++ b/testing/networks/80069/eth-genesis.json
@@ -114,9 +114,9 @@
         "minimumBaseFeeWei": 0
       },
       "osaka1": {
-        "time": 9999999999,
-        "minimumBaseFeeWei": 10000000000,
-        "minimumBlobBaseFeeWei": 10000000000
+        "time": 1784736000,
+        "minimumBaseFeeWei": 1000000000,
+        "minimumBlobBaseFeeWei": 1000000000
       }
     }
   },


### PR DESCRIPTION
Introduces the `osaka1` Berachain fork, which floors the base fee and the blob base fee. Enforcement lives in the EL (berachain/bera-reth#268), this PR adds the CL-side config and wires the fork into the genesis files.