### PR TITLE
fix(node-api): return 404 for unknown state_id roots

### DIFF
--- a/node-api/handlers/utils/mappings.go
+++ b/node-api/handlers/utils/mappings.go
@@ -26,12 +26,13 @@ import (
 	"strings"
 
 	"github.com/berachain/beacon-kit/errors"
+	handlertypes "github.com/berachain/beacon-kit/node-api/handlers/types"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
+	"github.com/berachain/beacon-kit/storage/block"
 )
 
 var (
-	ErrNoSlotForStateRoot         = errors.New("slot not found at state root")
 	ErrFailedMappingHeightTooHigh = errors.New("failed mapping height too high")
 )
 
@@ -57,7 +58,10 @@ func StateIDToHeight[StorageBackendT interface {
 	}
 	slot, err := storage.GetSlotByStateRoot(root)
 	if err != nil {
-		return 0, ErrNoSlotForStateRoot
+		if errors.Is(err, block.ErrBlockStoreNotEnabled) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("%w: %w", handlertypes.ErrNotFound, err)
 	}
 	if slot > stdmath.MaxInt64 { // appease linters
 		return 0, fmt.Errorf("%w: slot %d", ErrFailedMappingHeightTooHigh, slot)

--- a/node-api/handlers/utils/mappings_test.go
+++ b/node-api/handlers/utils/mappings_test.go
@@ -105,6 +105,9 @@ func TestStateIDToHeight(t *testing.T) {
 			for _, target := range tc.errNot {
 				require.NotErrorIs(t, err, target)
 			}
+			if tc.storage.err != nil {
+				require.ErrorIs(t, err, tc.storage.err)
+			}
 		})
 	}
 }

--- a/node-api/handlers/utils/mappings_test.go
+++ b/node-api/handlers/utils/mappings_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package utils_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/berachain/beacon-kit/node-api/handlers/types"
+	"github.com/berachain/beacon-kit/node-api/handlers/utils"
+	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/math"
+	"github.com/berachain/beacon-kit/storage/block"
+	"github.com/stretchr/testify/require"
+)
+
+type stateRootStorage struct {
+	slot math.Slot
+	err  error
+}
+
+func (s stateRootStorage) GetSlotByStateRoot(_ common.Root) (math.Slot, error) {
+	return s.slot, s.err
+}
+
+func TestStateIDToHeight(t *testing.T) {
+	t.Parallel()
+
+	unknownRoot := "0x" + strings.Repeat("01", 32)
+
+	tests := []struct {
+		name    string
+		stateID string
+		storage stateRootStorage
+		want    int64
+		errIs   []error
+		errNot  []error
+	}{
+		{
+			name:    "head",
+			stateID: utils.StateIDHead,
+			want:    utils.Head,
+		},
+		{
+			name:    "slot",
+			stateID: "42",
+			want:    42,
+		},
+		{
+			name:    "known state root",
+			stateID: unknownRoot,
+			storage: stateRootStorage{slot: math.Slot(7)},
+			want:    7,
+		},
+		{
+			name:    "unknown state root",
+			stateID: unknownRoot,
+			storage: stateRootStorage{err: errors.New("slot not found at state root")},
+			errIs:   []error{types.ErrNotFound},
+		},
+		{
+			name:    "block store not enabled",
+			stateID: unknownRoot,
+			storage: stateRootStorage{err: block.ErrBlockStoreNotEnabled},
+			errIs:   []error{block.ErrBlockStoreNotEnabled},
+			errNot:  []error{types.ErrNotFound},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := utils.StateIDToHeight(tc.stateID, tc.storage)
+			if len(tc.errIs) == 0 {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+				return
+			}
+
+			require.Error(t, err)
+			require.Zero(t, got)
+			for _, target := range tc.errIs {
+				require.ErrorIs(t, err, target)
+			}
+			for _, target := range tc.errNot {
+				require.NotErrorIs(t, err, target)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a client queries a Beacon API endpoint with a valid hex `state_id` that is not indexed on the node (e.g. `GET /eth/v1/beacon/states/0x<unknown-root>/validators`), `StateIDToHeight` returned an error that was not wrapped with `types.ErrNotFound`. Middleware therefore mapped the response to HTTP 500 instead of the spec-defined HTTP 404 ("State not found").

This change wraps state root lookup failures with `types.ErrNotFound` at the mapping layer, fixing all `/states/{state_id}/*` endpoints in one place. The underlying storage error (including the state root) is preserved in the error chain, consistent with how `GetBlockHeaders` handles unknown parent block roots.

`block.ErrBlockStoreNotEnabled` is passed through unchanged, since that indicates a server configuration issue rather than a missing state.

## Changes

- `node-api/handlers/utils/mappings.go`: wrap `GetSlotByStateRoot` failures with `types.ErrNotFound`; exclude `ErrBlockStoreNotEnabled`
- `node-api/handlers/utils/mappings_test.go`: unit tests for unknown state root, block store disabled, and existing resolution paths

## Test plan

- [x] `go test ./node-api/handlers/utils/... -count=1`

## Follow-up

`BlockIDToHeight` has the same class of issue for unknown `block_id` roots (`GetBlockHeaderByID`, `GetBlobSidecars`). Happy to follow up in a separate PR if this direction looks good.