### PR TITLE
fix(ci): pre-build the Go coverage tool to fix flaky coverage test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ROOT_DIR := $(shell pwd)
 .PHONY: clean format lint \
 	buf-install proto-clean \
 	test-unit test-unit-cover test-simulated test-forge-cover test-forge-fuzz \
+	covdata-prewarm \
 	forge-snapshot forge-snapshot-diff \
 	test-e2e test-e2e-no-build \
 	forge-lint-fix forge-lint golangci-install golangci golangci-fix \

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -246,6 +246,10 @@ define FILTER_COVERAGE
 	grep -Ev '(/testing/|/mock/|/mocks/|\.mock\.go)' $(1) > $(2)
 endef
 
+# Cache the covdata tool up front so the parallel coverage runs don't race to write-then-exec it ("text file busy").
+covdata-prewarm:
+	@go tool covdata >/dev/null 2>&1 || true
+
 test:
 	@$(MAKE) test-unit test-forge-fuzz
 
@@ -263,7 +267,7 @@ coverage-summary: test-unit test-simulated
 
 test-unit-cover: test-unit test-simulated test-unit-quick ## run golang unit tests with coverage
 
-test-unit:
+test-unit: covdata-prewarm
 	@echo "Running unit tests with coverage and race checks..."
 	@go list -f '{{.Dir}}/...' -m | xargs \
 		go test -race -covermode=atomic -coverpkg=github.com/berachain/beacon-kit/... -coverprofile=temp-test-unit-cover.txt -tags bls12381,test
@@ -276,7 +280,7 @@ test-unit-quick: ## run quick tests. We run these without coverage as covermode=
 	@go list -f '{{.Dir}}/testing/quick' -m | xargs \
 		go test -v -tags quick
 
-test-simulated: ## run simulation tests
+test-simulated: covdata-prewarm ## run simulation tests
 	@echo "Running simulation tests with coverage"
 	@go list -f '{{.Dir}}/testing/simulated' -m | xargs \
 		go test -cover -covermode=atomic -coverpkg=github.com/berachain/beacon-kit/... -coverprofile=temp-test-simulated.txt -tags simulated -v


### PR DESCRIPTION
Since we now have a nightly CI pipeline that reports error on slack I noticed a flaky failure this morning on CI when running `make test-unit-cover`, see https://github.com/berachain/beacon-kit/actions/runs/28702600175/job/85122973342

The issue seems to be that when collecting coverage, `go test` builds the Go coverage tool (`covdata`) into the build cache on demand, then runs it. In our parallel coverage runs it can get executed while still being written, failing with `text file busy` as we see in that run above.

This PR addresses this by building covdata once before the tests start, so the parallel runs reuse the cached binary instead of racing to build-and-run it.