### PR TITLE
chore(test): fix flaky run on proofs tests

### DIFF
--- a/testing/e2e/standard/proofs_test.go
+++ b/testing/e2e/standard/proofs_test.go
@@ -25,15 +25,31 @@ package standard_test
 import (
 	"math/big"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/berachain/beacon-kit/config/spec"
 	"github.com/berachain/beacon-kit/gethlib/ssztest"
 	"github.com/berachain/beacon-kit/node-api/handlers/proof/merkle"
+	ptypes "github.com/berachain/beacon-kit/node-api/handlers/proof/types"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	coretypes "github.com/ethereum/go-ethereum/core/types"
 )
+
+// errSlotNotIndexed is the transient server error returned while a queried node is still indexing the head.
+const errSlotNotIndexed = "slot not found at timestamp"
+
+// retryTimestampProof re-runs a t<timestamp> proof fetch while the queried node returns the errSlotNotIndexed.
+func retryTimestampProof[T any](fetch func() (*T, error)) (*T, error) {
+	resp, err := fetch()
+	for i := 0; i < 15 && err != nil && strings.Contains(err.Error(), errSlotNotIndexed); i++ {
+		time.Sleep(200 * time.Millisecond)
+		resp, err = fetch()
+	}
+	return resp, err
+}
 
 // TestBlockProposerProof tests the block proposer proof endpoint by fetching and verifying
 // the block proposer proofs against the SSZTest contract. Refer to
@@ -85,9 +101,9 @@ func (s *BeaconKitE2ESuite) TestBlockProposerProof() {
 	s.Require().NotNil(nextHeader)
 
 	// Get the block proposer proof for the next timestamp and enforce equality.
-	blockProposerResp2, err := s.ConsensusClients(0).BlockProposerProof(
-		s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10),
-	)
+	blockProposerResp2, err := retryTimestampProof(func() (*ptypes.BlockProposerResponse, error) {
+		return s.ConsensusClients(0).BlockProposerProof(s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10))
+	})
 	s.Require().NoError(err)
 	s.Require().NotNil(blockProposerResp2)
 	s.Require().NotNil(blockProposerResp2.BeaconBlockHeader)
@@ -234,9 +250,11 @@ func (s *BeaconKitE2ESuite) TestValidatorBalanceProof() {
 	s.Require().NotNil(nextHeader)
 
 	// Get the block proposer proof for the next timestamp and enforce equality.
-	balanceResp2, err := s.ConsensusClients(0).ValidatorBalanceProof(
-		s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
-	)
+	balanceResp2, err := retryTimestampProof(func() (*ptypes.ValidatorBalanceResponse, error) {
+		return s.ConsensusClients(0).ValidatorBalanceProof(
+			s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
+		)
+	})
 	s.Require().NoError(err)
 	s.Require().NotNil(balanceResp2)
 	s.Require().NotNil(balanceResp2.BeaconBlockHeader)
@@ -343,9 +361,11 @@ func (s *BeaconKitE2ESuite) TestValidatorCredentialsProof() {
 	s.Require().NotNil(nextHeader)
 
 	// Get the block proposer proof for the next timestamp and enforce equality.
-	credsResp1, err := s.ConsensusClients(0).ValidatorCredentialsProof(
-		s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
-	)
+	credsResp1, err := retryTimestampProof(func() (*ptypes.ValidatorWithdrawalCredentialsResponse, error) {
+		return s.ConsensusClients(0).ValidatorCredentialsProof(
+			s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
+		)
+	})
 	s.Require().NoError(err)
 	s.Require().NotNil(credsResp1)
 	s.Require().NotNil(credsResp1.BeaconBlockHeader)
@@ -475,9 +495,11 @@ func (s *BeaconKitE2ESuite) TestValidatorPubkeyProof() {
 	s.Require().NotNil(nextHeader)
 
 	// Get the pubkey proof for the next timestamp and enforce equality.
-	pubkeyResp2, err := s.ConsensusClients(0).ValidatorPubkeyProof(
-		s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
-	)
+	pubkeyResp2, err := retryTimestampProof(func() (*ptypes.ValidatorPubkeyResponse, error) {
+		return s.ConsensusClients(0).ValidatorPubkeyProof(
+			s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
+		)
+	})
 	s.Require().NoError(err)
 	s.Require().NotNil(pubkeyResp2)
 	s.Require().NotNil(pubkeyResp2.BeaconBlockHeader)

--- a/testing/e2e/standard/proofs_test.go
+++ b/testing/e2e/standard/proofs_test.go
@@ -25,31 +25,15 @@ package standard_test
 import (
 	"math/big"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/berachain/beacon-kit/config/spec"
 	"github.com/berachain/beacon-kit/gethlib/ssztest"
 	"github.com/berachain/beacon-kit/node-api/handlers/proof/merkle"
-	ptypes "github.com/berachain/beacon-kit/node-api/handlers/proof/types"
 	"github.com/berachain/beacon-kit/primitives/common"
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	coretypes "github.com/ethereum/go-ethereum/core/types"
 )
-
-// errSlotNotIndexed is the transient server error returned while a queried node is still indexing the head.
-const errSlotNotIndexed = "slot not found at timestamp"
-
-// retryTimestampProof re-runs a t<timestamp> proof fetch while the queried node returns the errSlotNotIndexed.
-func retryTimestampProof[T any](fetch func() (*T, error)) (*T, error) {
-	resp, err := fetch()
-	for i := 0; i < 15 && err != nil && strings.Contains(err.Error(), errSlotNotIndexed); i++ {
-		time.Sleep(200 * time.Millisecond)
-		resp, err = fetch()
-	}
-	return resp, err
-}
 
 // TestBlockProposerProof tests the block proposer proof endpoint by fetching and verifying
 // the block proposer proofs against the SSZTest contract. Refer to
@@ -101,9 +85,7 @@ func (s *BeaconKitE2ESuite) TestBlockProposerProof() {
 	s.Require().NotNil(nextHeader)
 
 	// Get the block proposer proof for the next timestamp and enforce equality.
-	blockProposerResp2, err := retryTimestampProof(func() (*ptypes.BlockProposerResponse, error) {
-		return s.ConsensusClients(0).BlockProposerProof(s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10))
-	})
+	blockProposerResp2, err := s.ConsensusClients(0).BlockProposerProof(s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10))
 	s.Require().NoError(err)
 	s.Require().NotNil(blockProposerResp2)
 	s.Require().NotNil(blockProposerResp2.BeaconBlockHeader)
@@ -250,11 +232,9 @@ func (s *BeaconKitE2ESuite) TestValidatorBalanceProof() {
 	s.Require().NotNil(nextHeader)
 
 	// Get the block proposer proof for the next timestamp and enforce equality.
-	balanceResp2, err := retryTimestampProof(func() (*ptypes.ValidatorBalanceResponse, error) {
-		return s.ConsensusClients(0).ValidatorBalanceProof(
-			s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
-		)
-	})
+	balanceResp2, err := s.ConsensusClients(0).ValidatorBalanceProof(
+		s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
+	)
 	s.Require().NoError(err)
 	s.Require().NotNil(balanceResp2)
 	s.Require().NotNil(balanceResp2.BeaconBlockHeader)
@@ -361,11 +341,9 @@ func (s *BeaconKitE2ESuite) TestValidatorCredentialsProof() {
 	s.Require().NotNil(nextHeader)
 
 	// Get the block proposer proof for the next timestamp and enforce equality.
-	credsResp1, err := retryTimestampProof(func() (*ptypes.ValidatorWithdrawalCredentialsResponse, error) {
-		return s.ConsensusClients(0).ValidatorCredentialsProof(
-			s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
-		)
-	})
+	credsResp1, err := s.ConsensusClients(0).ValidatorCredentialsProof(
+		s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
+	)
 	s.Require().NoError(err)
 	s.Require().NotNil(credsResp1)
 	s.Require().NotNil(credsResp1.BeaconBlockHeader)
@@ -495,11 +473,9 @@ func (s *BeaconKitE2ESuite) TestValidatorPubkeyProof() {
 	s.Require().NotNil(nextHeader)
 
 	// Get the pubkey proof for the next timestamp and enforce equality.
-	pubkeyResp2, err := retryTimestampProof(func() (*ptypes.ValidatorPubkeyResponse, error) {
-		return s.ConsensusClients(0).ValidatorPubkeyProof(
-			s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
-		)
-	})
+	pubkeyResp2, err := s.ConsensusClients(0).ValidatorPubkeyProof(
+		s.Ctx(), "t"+strconv.FormatUint(nextHeader.Time, 10), strconv.FormatUint(validatorIndex, 10),
+	)
 	s.Require().NoError(err)
 	s.Require().NotNil(pubkeyResp2)
 	s.Require().NotNil(pubkeyResp2.BeaconBlockHeader)

--- a/testing/e2e/suite/types/beacon_client.go
+++ b/testing/e2e/suite/types/beacon_client.go
@@ -235,15 +235,22 @@ func (c *customBeaconClient) Validators(
 	}, nil
 }
 
-// errSlotNotIndexed is the transient server error returned while a queried node is still indexing the head.
-// Defined in GetParentSlotByTimestamp (storage/block/store.go:128)
-const errSlotNotIndexed = "slot not found at timestamp"
+const (
+	// errSlotNotIndexed is the transient server error returned while a queried node is still
+	// indexing the head. Defined in GetParentSlotByTimestamp (storage/block/store.go:128).
+	errSlotNotIndexed = "slot not found at timestamp"
+
+	// proofRetryAttempts and proofRetryInterval bound the wait for the node to index the head,
+	// within a total 3s, above the ~2s target block time.
+	proofRetryAttempts = 15
+	proofRetryInterval = 200 * time.Millisecond
+)
 
 // doProofRequestUntilIndexed re-runs fetch while the node reports it has not yet indexed the queried timestamp.
 func doProofRequestUntilIndexed[T any](ctx context.Context, c *customBeaconClient, url string) (*T, error) {
 	resp, err := doProofRequest[T](ctx, c, url)
-	for i := 0; i < 15 && err != nil && strings.Contains(err.Error(), errSlotNotIndexed); i++ {
-		time.Sleep(200 * time.Millisecond)
+	for i := 0; i < proofRetryAttempts && err != nil && strings.Contains(err.Error(), errSlotNotIndexed); i++ {
+		time.Sleep(proofRetryInterval)
 		resp, err = doProofRequest[T](ctx, c, url)
 	}
 	return resp, err

--- a/testing/e2e/suite/types/beacon_client.go
+++ b/testing/e2e/suite/types/beacon_client.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -253,6 +254,10 @@ func (c *customBeaconClient) BlockProposerProof(
 		return nil, errors.New("received nil response")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("received non-OK response %s: %s", resp.Status, string(body))
+	}
 
 	var result ptypes.BlockProposerResponse
 	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -282,6 +287,10 @@ func (c *customBeaconClient) ValidatorBalanceProof(
 		return nil, errors.New("received nil response")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("received non-OK response %s: %s", resp.Status, string(body))
+	}
 
 	var result ptypes.ValidatorBalanceResponse
 	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -311,6 +320,10 @@ func (c *customBeaconClient) ValidatorCredentialsProof(
 		return nil, errors.New("received nil response")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("received non-OK response %s: %s", resp.Status, string(body))
+	}
 
 	var result ptypes.ValidatorWithdrawalCredentialsResponse
 	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -340,6 +353,10 @@ func (c *customBeaconClient) ValidatorPubkeyProof(
 		return nil, errors.New("received nil response")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("received non-OK response %s: %s", resp.Status, string(body))
+	}
 
 	var result ptypes.ValidatorPubkeyResponse
 	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {

--- a/testing/e2e/suite/types/beacon_client.go
+++ b/testing/e2e/suite/types/beacon_client.go
@@ -234,13 +234,8 @@ func (c *customBeaconClient) Validators(
 	}, nil
 }
 
-// BlockProposerProof calls `bkit/v1/proof/block_proposer/:timestamp_id` endpoint to get
-// the merkle proofs that can be used to verify the block proposer for a given timestamp id.
-func (c *customBeaconClient) BlockProposerProof(
-	ctx context.Context, timestampID string,
-) (*ptypes.BlockProposerResponse, error) {
-	url := fmt.Sprintf("%s/bkit/v1/proof/block_proposer/%s", c.address, timestampID)
-
+// doProofRequest issues a GET to a proof endpoint and decodes the JSON body into *T.
+func doProofRequest[T any](ctx context.Context, c *customBeaconClient, url string) (*T, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -259,12 +254,21 @@ func (c *customBeaconClient) BlockProposerProof(
 		return nil, fmt.Errorf("received non-OK response %s: %s", resp.Status, string(body))
 	}
 
-	var result ptypes.BlockProposerResponse
+	var result T
 	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
 	return &result, nil
+}
+
+// BlockProposerProof calls `bkit/v1/proof/block_proposer/:timestamp_id` endpoint to get
+// the merkle proofs that can be used to verify the block proposer for a given timestamp id.
+func (c *customBeaconClient) BlockProposerProof(
+	ctx context.Context, timestampID string,
+) (*ptypes.BlockProposerResponse, error) {
+	url := fmt.Sprintf("%s/bkit/v1/proof/block_proposer/%s", c.address, timestampID)
+	return doProofRequest[ptypes.BlockProposerResponse](ctx, c, url)
 }
 
 // ValidatorBalanceProof calls `bkit/v1/proof/validator_balance/:timestamp_id/:validator_index` endpoint to get
@@ -273,31 +277,7 @@ func (c *customBeaconClient) ValidatorBalanceProof(
 	ctx context.Context, timestampID string, validatorIndex string,
 ) (*ptypes.ValidatorBalanceResponse, error) {
 	url := fmt.Sprintf("%s/bkit/v1/proof/validator_balance/%s/%s", c.address, timestampID, validatorIndex)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := c.client.Do(req) //#nosec:G704 // URL is from trusted test infrastructure.
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	if resp == nil {
-		return nil, errors.New("received nil response")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("received non-OK response %s: %s", resp.Status, string(body))
-	}
-
-	var result ptypes.ValidatorBalanceResponse
-	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return &result, nil
+	return doProofRequest[ptypes.ValidatorBalanceResponse](ctx, c, url)
 }
 
 // ValidatorCredentialsProof calls `bkit/v1/proof/validator_credentials/:timestamp_id/:validator_index` endpoint to get
@@ -306,31 +286,7 @@ func (c *customBeaconClient) ValidatorCredentialsProof(
 	ctx context.Context, timestampID string, validatorIndex string,
 ) (*ptypes.ValidatorWithdrawalCredentialsResponse, error) {
 	url := fmt.Sprintf("%s/bkit/v1/proof/validator_credentials/%s/%s", c.address, timestampID, validatorIndex)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := c.client.Do(req) //#nosec:G704 // URL is from trusted test infrastructure.
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	if resp == nil {
-		return nil, errors.New("received nil response")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("received non-OK response %s: %s", resp.Status, string(body))
-	}
-
-	var result ptypes.ValidatorWithdrawalCredentialsResponse
-	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return &result, nil
+	return doProofRequest[ptypes.ValidatorWithdrawalCredentialsResponse](ctx, c, url)
 }
 
 // ValidatorPubkeyProof calls `bkit/v1/proof/validator_pubkey/:timestamp_id/:validator_index` endpoint to get
@@ -339,29 +295,5 @@ func (c *customBeaconClient) ValidatorPubkeyProof(
 	ctx context.Context, timestampID string, validatorIndex string,
 ) (*ptypes.ValidatorPubkeyResponse, error) {
 	url := fmt.Sprintf("%s/bkit/v1/proof/validator_pubkey/%s/%s", c.address, timestampID, validatorIndex)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := c.client.Do(req) //#nosec:G704 // URL is from trusted test infrastructure.
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	if resp == nil {
-		return nil, errors.New("received nil response")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("received non-OK response %s: %s", resp.Status, string(body))
-	}
-
-	var result ptypes.ValidatorPubkeyResponse
-	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return &result, nil
+	return doProofRequest[ptypes.ValidatorPubkeyResponse](ctx, c, url)
 }

--- a/testing/e2e/suite/types/beacon_client.go
+++ b/testing/e2e/suite/types/beacon_client.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	client "github.com/attestantio/go-eth2-client"
 	beaconapi "github.com/attestantio/go-eth2-client/api"
@@ -234,6 +235,20 @@ func (c *customBeaconClient) Validators(
 	}, nil
 }
 
+// errSlotNotIndexed is the transient server error returned while a queried node is still indexing the head.
+// Defined in GetParentSlotByTimestamp (storage/block/store.go:128)
+const errSlotNotIndexed = "slot not found at timestamp"
+
+// doProofRequestUntilIndexed re-runs fetch while the node reports it has not yet indexed the queried timestamp.
+func doProofRequestUntilIndexed[T any](ctx context.Context, c *customBeaconClient, url string) (*T, error) {
+	resp, err := doProofRequest[T](ctx, c, url)
+	for i := 0; i < 15 && err != nil && strings.Contains(err.Error(), errSlotNotIndexed); i++ {
+		time.Sleep(200 * time.Millisecond)
+		resp, err = doProofRequest[T](ctx, c, url)
+	}
+	return resp, err
+}
+
 // doProofRequest issues a GET to a proof endpoint and decodes the JSON body into *T.
 func doProofRequest[T any](ctx context.Context, c *customBeaconClient, url string) (*T, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -268,7 +283,7 @@ func (c *customBeaconClient) BlockProposerProof(
 	ctx context.Context, timestampID string,
 ) (*ptypes.BlockProposerResponse, error) {
 	url := fmt.Sprintf("%s/bkit/v1/proof/block_proposer/%s", c.address, timestampID)
-	return doProofRequest[ptypes.BlockProposerResponse](ctx, c, url)
+	return doProofRequestUntilIndexed[ptypes.BlockProposerResponse](ctx, c, url)
 }
 
 // ValidatorBalanceProof calls `bkit/v1/proof/validator_balance/:timestamp_id/:validator_index` endpoint to get
@@ -277,7 +292,7 @@ func (c *customBeaconClient) ValidatorBalanceProof(
 	ctx context.Context, timestampID string, validatorIndex string,
 ) (*ptypes.ValidatorBalanceResponse, error) {
 	url := fmt.Sprintf("%s/bkit/v1/proof/validator_balance/%s/%s", c.address, timestampID, validatorIndex)
-	return doProofRequest[ptypes.ValidatorBalanceResponse](ctx, c, url)
+	return doProofRequestUntilIndexed[ptypes.ValidatorBalanceResponse](ctx, c, url)
 }
 
 // ValidatorCredentialsProof calls `bkit/v1/proof/validator_credentials/:timestamp_id/:validator_index` endpoint to get
@@ -286,7 +301,7 @@ func (c *customBeaconClient) ValidatorCredentialsProof(
 	ctx context.Context, timestampID string, validatorIndex string,
 ) (*ptypes.ValidatorWithdrawalCredentialsResponse, error) {
 	url := fmt.Sprintf("%s/bkit/v1/proof/validator_credentials/%s/%s", c.address, timestampID, validatorIndex)
-	return doProofRequest[ptypes.ValidatorWithdrawalCredentialsResponse](ctx, c, url)
+	return doProofRequestUntilIndexed[ptypes.ValidatorWithdrawalCredentialsResponse](ctx, c, url)
 }
 
 // ValidatorPubkeyProof calls `bkit/v1/proof/validator_pubkey/:timestamp_id/:validator_index` endpoint to get
@@ -295,5 +310,5 @@ func (c *customBeaconClient) ValidatorPubkeyProof(
 	ctx context.Context, timestampID string, validatorIndex string,
 ) (*ptypes.ValidatorPubkeyResponse, error) {
 	url := fmt.Sprintf("%s/bkit/v1/proof/validator_pubkey/%s/%s", c.address, timestampID, validatorIndex)
-	return doProofRequest[ptypes.ValidatorPubkeyResponse](ctx, c, url)
+	return doProofRequestUntilIndexed[ptypes.ValidatorPubkeyResponse](ctx, c, url)
 }


### PR DESCRIPTION
Flaky run: https://github.com/berachain/beacon-kit/actions/runs/29086626434/job/86341770240

Simply refactors the requests into a single function, adding check on http response status (which was not checked).
Catches the http error and retries request.
Fix extended to all tests even though just `TestValidatorPubkeyProof` was recorded to fail.