### PR TITLE
fix(log): cap oversized log lines with a truncation marker

### DIFF
--- a/log/phuslu/bound.go
+++ b/log/phuslu/bound.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package phuslu
+
+import (
+	"fmt"
+	"io"
+)
+
+// MaxLogLineBytes caps the size of one serialized log line, marker included, so a single oversized value cannot expand it into megabytes.
+// phuslu writes one entry per Write, so bounding each Write bounds each line.
+const MaxLogLineBytes = 64 * 1024
+
+// truncatingWriter caps every write at MaxLogLineBytes, reserving room to append a marker that names the original total size, and keeps
+// the log stream newline-terminated.
+type truncatingWriter struct {
+	out io.Writer
+}
+
+func (w truncatingWriter) Write(p []byte) (int, error) {
+	if len(p) <= MaxLogLineBytes {
+		return w.out.Write(p)
+	}
+	// Reserve room for the marker so the emitted line, marker included, never exceeds MaxLogLineBytes.
+	marker := fmt.Sprintf(" ...[truncated, total size %d bytes]\n", len(p))
+	keep := MaxLogLineBytes - len(marker)
+	if keep < 0 {
+		keep = 0
+	}
+	line := make([]byte, 0, keep+len(marker))
+	line = append(line, p[:keep]...)
+	line = append(line, marker...)
+	n, err := w.out.Write(line)
+	if err != nil {
+		return 0, err
+	}
+	if n < len(line) {
+		// A short write with a nil error violates the io.Writer contract; surface it rather than lose the line silently.
+		return 0, io.ErrShortWrite
+	}
+	// Report the full length as consumed so the logger does not treat the deliberate truncation as a short write.
+	return len(p), nil
+}

--- a/log/phuslu/bound_test.go
+++ b/log/phuslu/bound_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Copyright (C) 2025, Berachain Foundation. All rights reserved.
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file of this repository and at www.mariadb.com/bsl11.
+//
+// ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY
+// TERMINATE YOUR RIGHTS UNDER THIS LICENSE FOR THE CURRENT AND ALL OTHER
+// VERSIONS OF THE LICENSED WORK.
+//
+// THIS LICENSE DOES NOT GRANT YOU ANY RIGHT IN ANY TRADEMARK OR LOGO OF
+// LICENSOR OR ITS AFFILIATES (PROVIDED THAT YOU MAY USE A TRADEMARK OR LOGO OF
+// LICENSOR AS EXPRESSLY REQUIRED BY THIS LICENSE).
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+// AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+// EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+// TITLE.
+
+package phuslu_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/berachain/beacon-kit/log/phuslu"
+)
+
+// commitSig is a small element; a large slice of these stands in for an oversized logged value.
+type commitSig struct {
+	BlockIDFlag int
+	Address     []byte
+}
+
+// msgInfo nests a large slice so that logging the whole struct as a single field produces an oversized log line.
+type msgInfo struct {
+	Height     int
+	Round      int
+	Signatures []commitSig
+	PeerID     string
+}
+
+func newLoggerForStyle(out *bytes.Buffer, style string) *phuslu.Logger {
+	return phuslu.NewLogger(out, &phuslu.Config{TimeFormat: "RFC3339", LogLevel: "info", Style: style})
+}
+
+// TestLogLineIsBounded asserts that long log lines stay bounded and are marked as truncated in both output styles.
+func TestLogLineIsBounded(t *testing.T) {
+	t.Parallel()
+
+	attack := msgInfo{Signatures: make([]commitSig, 250_000), PeerID: "1cc8ac47fe215c7da976e41cf04ce1e8b6c8f33c"}
+
+	for _, style := range []string{phuslu.StyleJSON, phuslu.StylePretty} {
+		t.Run(style, func(t *testing.T) {
+			var out bytes.Buffer
+			newLoggerForStyle(&out, style).Error("Peer sent us invalid msg", "msg", attack)
+
+			b := out.Bytes()
+			if len(b) > phuslu.MaxLogLineBytes {
+				t.Fatalf("log line not bounded: %d bytes", len(b))
+			}
+			if !bytes.HasSuffix(b, []byte("\n")) {
+				t.Fatal("truncated line must remain newline-terminated")
+			}
+			if !bytes.Contains(b, []byte("truncated, total size")) {
+				t.Fatal("truncated line must carry a marker with the original total size")
+			}
+		})
+	}
+}

--- a/log/phuslu/logger.go
+++ b/log/phuslu/logger.go
@@ -172,14 +172,14 @@ func (l *Logger) withLogLevel(level string) {
 // useConsoleWriter sets the logger to use a console writer.
 func (l *Logger) useConsoleWriter() {
 	l.setWriter(&log.ConsoleWriter{
-		Writer:    l.out,
+		Writer:    truncatingWriter{out: l.out},
 		Formatter: l.formatter.Format,
 	})
 }
 
 // useJSONWriter sets the logger to use a IOWriter wrapper.
 func (l *Logger) useJSONWriter() {
-	l.setWriter(log.IOWriter{Writer: l.out})
+	l.setWriter(log.IOWriter{Writer: truncatingWriter{out: l.out}})
 }
 
 // setWriter sets the writer of the logger.


### PR DESCRIPTION
 This PR caps any single log line at `64KB` in the `phuslu` logger and replaces the dropped bytes with a `...[truncated, total size <N> bytes]` marker so one oversized value can't expand an entry into megabytes. It applies to both JSON and console styles and leaves normal logs untouched.

Note: truncation a JSON line will not be well-formed JSON. To address that properly we need to rely on go generics and bind each field value before serialization, way more complex but doable. Just not sure we need it as consumers of json would be able to handle a single ill-formed json line.