### PR TITLE
fix(ci): bump Go to 1.26.6 to clear nightly vulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/berachain/beacon-kit
 
-go 1.26.5
+go 1.26.6
 
 replace (
 	github.com/cometbft/cometbft => github.com/berachain/cometbft v1.0.1-0.20260529113827-ea326957ccc7

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -69,7 +69,7 @@ This directory is git-ignored. Logs from previous runs are overwritten.
 
 - **Docker** running locally
 - **Kurtosis CLI** installed ([instructions](https://docs.kurtosis.com/install)) with the engine started (`kurtosis engine start`)
-- **Go 1.26.2+**
+- **Go 1.26.6+**
 
 ## Running Tests
 


### PR DESCRIPTION
This PR fixes broken vulncheck, see https://github.com/berachain/beacon-kit/actions/runs/32009084262 as detected by nightly ci pipeline and reported via slack.
