### PR TITLE
fix(ci): bump foundry-toolchain to v1.9.1 for Rust foundryup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,7 +96,7 @@ jobs:
           check-latest: true
           cache-dependency-path: "**/*.sum"
       - name: Install Foundry (cast drives the tx load)
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
       - run: make test-halt-swap-resume test-halt-swap-resume-time
         env:
           GOPATH: /home/runner/go

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -85,7 +85,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
           version: v1.3.1
         if: ${{ matrix.args == 'lint' || matrix.args == 'generate-check' || matrix.args == 'test-forge-cover' || matrix.args == 'test-forge-fuzz' }}


### PR DESCRIPTION
This PR bumps foundry-toolchain from v1.8.0 to v1.9.1 to fix CI failures after Foundry switched foundryup to a Rust binary [foundry#15498](https://github.com/foundry-rs/foundry/pull/15498), which broke v1.8.0's bash-based invocation.