### PR TITLE
fix(state-transition): emit evicted validator updates in deterministic order

### DIFF
--- a/state-transition/core/state_processor_validators.go
+++ b/state-transition/core/state_processor_validators.go
@@ -217,8 +217,20 @@ func validatorSetsDiffs(
 		delete(prevValsSet, key)
 	}
 
-	// prevValsSet now contains all evicted validators (and only those)
+	// prevValsSet now contains all evicted validators (and only those).
+	// Range order over a Go map is randomized per process, so collect the
+	// keys and sort them before appending. Without this, two nodes evicting
+	// the same set in the same epoch emit ValidatorUpdates in different
+	// orders. CometBFT sorts the change set before applying it, so this is
+	// not observable today, but relying on that is fragile for a value
+	// derived from the state transition.
+	evicted := make([]string, 0, len(prevValsSet))
 	for pkBytes := range prevValsSet {
+		evicted = append(evicted, pkBytes)
+	}
+	slices.Sort(evicted)
+
+	for _, pkBytes := range evicted {
 		//#nosec:G703 // bytes comes from a pk
 		pk, _ := bytes.ToBytes48([]byte(pkBytes))
 		res = append(res, &transition.ValidatorUpdate{


### PR DESCRIPTION
## Problem

`validatorSetsDiffs` builds the evicted-validator half of the `ValidatorUpdates` by ranging over `prevValsSet`, which is a Go map:

```go
// prevValsSet now contains all evicted validators (and only those)
for pkBytes := range prevValsSet {
    pk, _ := bytes.ToBytes48([]byte(pkBytes))
    res = append(res, &transition.ValidatorUpdate{
        Pubkey:           pk,
        EffectiveBalance: 0, // signal val eviction to consensus
    })
}
```

Go randomizes map range order per process, so two nodes evicting the same set in the same epoch emit the same updates in different orders. With the mainnet validator set cap this is reachable whenever 2+ validators are ejected in one epoch.

## Is this a live bug?

**No** — CometBFT calls `sort.Sort(ValidatorsByAddress(changes))` in `processChanges` before applying the change set, and `AppHash` comes from the beacon state root rather than the update list. So the resulting validator set is order-independent today.

I'm raising it because the ordering of a value derived from the state transition shouldn't depend on an implementation detail of the consumer, and the dependency is currently silent — nothing in this package documents or tests it. It's cheap to make explicit.

## Fix

Collect the keys and sort them before appending. Uses `slices.Sort`, which the file already imports. The active-validator branch above already emits in `currentValSet` order, so this makes the whole function deterministic.

`state-transition/...` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)