### PR TITLE
fix(primitives): validate length in NewExecutionAddressFromHex

### DIFF
--- a/primitives/common/execution.go
+++ b/primitives/common/execution.go
@@ -98,16 +98,29 @@ func (h *ExecutionHash) UnmarshalJSON(input []byte) error {
 /*                              ExecutionAddress                              */
 /* -------------------------------------------------------------------------- */
 
+// ExecutionAddressSize is the length of an ExecutionAddress in bytes.
+const ExecutionAddressSize = 20
+
 // ExecutionAddress represents a 20-byte Ethereum address.
 // We use this type to represent addresses that come from the execution layer.
 // It is EIP-55 checksummed and compliant.
-type ExecutionAddress [20]byte
+type ExecutionAddress [ExecutionAddressSize]byte
 
 // NewExecutionAddressFromHex creates a new address from a hex string.
+//
+// Errors if:
+// - input is not prefixed with "0x".
+// - input is not valid hex of 20 bytes.
 func NewExecutionAddressFromHex(input string) (ExecutionAddress, error) {
 	bz, err := hex.ToBytes(input)
 	if err != nil {
 		return ExecutionAddress{}, err
+	}
+	// The slice-to-array conversion below panics when bz is shorter than
+	// ExecutionAddressSize and silently drops the trailing bytes when it is
+	// longer, so the length must be checked first.
+	if len(bz) != ExecutionAddressSize {
+		return ExecutionAddress{}, bytes.ErrIncorrectLength
 	}
 	return ExecutionAddress(bz), nil
 }

--- a/primitives/common/execution_test.go
+++ b/primitives/common/execution_test.go
@@ -126,3 +126,51 @@ func TestExecutionAddressUnmarshalJSON_Short(t *testing.T) {
 		})
 	}
 }
+
+func TestNewExecutionAddressFromHex_Length(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:  "exactly 20 bytes",
+			input: "0x0000000000000000000000000000000000000001",
+		},
+		{
+			// Previously panicked: converting a short slice to [20]byte is a
+			// run-time panic.
+			name:    "19 bytes",
+			input:   "0x00000000000000000000000000000000000001",
+			wantErr: true,
+		},
+		{
+			// Previously truncated silently: converting a longer slice keeps
+			// only the leading 20 bytes.
+			name:    "25 bytes",
+			input:   "0x0000000000000000000000000000000000000001deadbeef0a",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   "0x",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.NotPanics(t, func() {
+				addr, err := common.NewExecutionAddressFromHex(tt.input)
+				if tt.wantErr {
+					require.Error(t, err)
+					require.Equal(t, common.ExecutionAddress{}, addr)
+					return
+				}
+				require.NoError(t, err)
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`NewExecutionAddressFromHex` converts the decoded bytes straight to `ExecutionAddress` (`[20]byte`) with no length check:

```go
func NewExecutionAddressFromHex(input string) (ExecutionAddress, error) {
	bz, err := hex.ToBytes(input)
	if err != nil {
		return ExecutionAddress{}, err
	}
	return ExecutionAddress(bz), nil   // no length check
}
```

Go's slice-to-array conversion has two distinct failure modes here:

| input | behaviour |
|---|---|
| < 20 bytes | **panics** — `cannot convert slice with length 19 to array or pointer to array with length 20` |
| > 20 bytes | **silently truncated** — keeps only the leading 20 bytes |

## Why it matters

`StringToExecutionAddressFunc` is registered as a decode hook in two places:

- `config/config.go:133` — app.toml (e.g. `SuggestedFeeRecipient`)
- `config/spec/creator.go:103` — custom chain-spec TOML via `--beacon-kit.chain-spec-file`

So a malformed address in either file panics the node at startup with an opaque runtime error, or — in the over-length case — resolves to a *different address than the operator wrote*. For `EVMInflationAddress` or `DepositContractAddress` that produces a node which silently disagrees with its peers rather than failing loudly at config load.

Note this is operator-supplied input, not network-reachable — it's a robustness/correctness issue, not a remotely triggerable one.

## Fix

Check the length and return `bytes.ErrIncorrectLength`. This matches `NewRootFromHex` in the same package, which already validates:

```go
if len(val) != RootSize {
    return Root{}, bytes.ErrIncorrectLength
}
```

Also introduces `ExecutionAddressSize` so the array length and the check can't drift apart.

## Tests

`TestNewExecutionAddressFromHex_Length` covers 20 / 19 / 25 / empty. Confirmed on `main` the 19-byte case panics and the 25-byte case is silently accepted; both pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)