### PR TITLE
fix(node-api): correct invalid `,string` tag on CommitteeData.Validators

### DIFF
--- a/node-api/handlers/beacon/types/response.go
+++ b/node-api/handlers/beacon/types/response.go
@@ -114,11 +114,13 @@ type Validator struct {
 	WithdrawableEpoch          string `json:"withdrawable_epoch"`
 }
 
-//nolint:staticcheck // todo: figure this out.
 type CommitteeData struct {
-	Index      uint64   `json:"index,string"`
-	Slot       uint64   `json:"slot,string"`
-	Validators []uint64 `json:"validators,string"`
+	Index uint64 `json:"index,string"`
+	Slot  uint64 `json:"slot,string"`
+	// The `,string` option has no effect on a slice, so `[]uint64` encoded as
+	// raw numbers rather than the quoted strings the Beacon API specifies for
+	// this field. Hold the indices as strings so they marshal correctly.
+	Validators []string `json:"validators"`
 }
 
 type BlockRewardsData struct {


### PR DESCRIPTION
## Problem

`CommitteeData` carries a `//nolint:staticcheck // todo: figure this out.`:

```go
//nolint:staticcheck // todo: figure this out.
type CommitteeData struct {
	Index      uint64   `json:"index,string"`
	Slot       uint64   `json:"slot,string"`
	Validators []uint64 `json:"validators,string"`
}
```

The suppressed diagnostic is SA5008. The `,string` option is only honoured for numeric, bool and string fields — on a slice `encoding/json` silently ignores it:

```
actual  : {"index":"1","slot":"2","validators":[3,4]}
spec    : {"index":"1","slot":"2","validators":["3","4"]}
```

The Beacon API quotes all numeric values, including the entries of `validators`, so the current type would emit non-conformant JSON.

## Fix

Hold the indices as `[]string` so they marshal as quoted strings, and drop the nolint — `staticcheck ./node-api/handlers/beacon/types/` is clean afterwards.

## Scope

`CommitteeData` isn't constructed anywhere yet — `/eth/v1/beacon/states/:state_id/committees` is still routed to `h.NotImplemented` — so this is latent rather than a live response bug. That also means changing the type now is free, before a handler is written against it.

Happy to instead add a `MarshalJSON` that quotes a `[]uint64` if you'd rather the struct keep numeric types for the future handler's benefit — just say which you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)